### PR TITLE
Try to bring generic and non generic together in 2 different classes

### DIFF
--- a/src/NumSharp.Core/Interfaces/IStorage.cs
+++ b/src/NumSharp.Core/Interfaces/IStorage.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections;
+
+namespace NumSharp.Core
+{
+    public interface IStorage : IEnumerable, IEnumerator
+    {
+        Type dtype {get;set;}
+        Array GetData();
+        T[] GetData<T>(); 
+        T GetData<T>(params int[] indexer);
+        void SetData(Array value);
+        void SetData<T>(T[] value);
+        void SetData<T>(T value, params int[] indexer);
+    }
+}

--- a/src/NumSharp.Core/NDArrayGeneric.cs
+++ b/src/NumSharp.Core/NDArrayGeneric.cs
@@ -24,6 +24,38 @@ using System.Text;
 using System.Globalization;
 using System.Collections;
 
+namespace NumSharp.Generic
+{
+    public class NDArray<T> : NumSharp.Core.NDArray where T : struct
+    {
+        public NDArray()
+        {
+            this.dtype = typeof(T);
+            Shape = new NumSharp.Core.Shape(new int[] { 0 });
+            Storage = new NumSharp.Core.NDStorage(dtype);
+        }
+        public T this[params int[] select]
+        {
+            get
+            {
+                return (T)Storage[Shape.GetIndexInShape(select)];
+            }
+            set
+            {
+                if (select.Length == NDim)
+                {
+                    Storage[Shape.GetIndexInShape(select)] = value;
+                }
+                else
+                {
+
+                }
+            }
+        }
+    }
+}
+ 
+
 namespace NumSharp.Core
 {
     /// <summary>

--- a/src/NumSharp.Core/NdArray.cs
+++ b/src/NumSharp.Core/NdArray.cs
@@ -54,7 +54,10 @@ namespace NumSharp.Core
         /// Total of elements
         /// </summary>
         public int Size => Shape.Size;
+        public NDArray()
+        {
 
+        }
         public NDArray(Type dtype)
         {
             this.dtype = dtype;

--- a/test/NumSharp.UnitTest/Creation/NdArray.Array.Test.cs
+++ b/test/NumSharp.UnitTest/Creation/NdArray.Array.Test.cs
@@ -14,6 +14,27 @@ namespace NumSharp.UnitTest.Extensions
         NumPy np = new NumPy();
 
         [TestMethod]
+        public void TestGeneric()
+        {
+            double start = 0;
+            double stop = 10;
+            double step = 1;
+            
+            int length = (int)Math.Ceiling((stop - start + 0.0) / step);
+            int index = 0;
+
+            var np1 = new NumSharp.Generic.NDArray<double>();
+            np1.Shape = new Shape(length);
+
+            np1.Storage.Allocate(length);
+            for (double i = start; i < stop; i += step)
+                np1.Data<double>()[index++] = i;
+
+            var value = np1[2];
+            
+        }
+
+        [TestMethod]
         public void Array1Dim()
         {
             var list = new int[] { 1, 2, 3 };


### PR DESCRIPTION
- The NDArray is now extrem dynamic and flexible 
- The only thing I find annoyingful at moment --> indexing
- I mean **true** indexing like np1[1,2,3] and not via Data method
- we can not indexing in a gentle way since the output is always different (int, double,...)
- This i think is extrem nice with our generic old class (but I dont want to go back to old class…)
- my idea : NumSharp.Generic.NDArray which is 100% a child of NumSharp.Core.NDArray 
- check the code we can use 100% of the Core methods but the indexing here looks gentle. 
- every user shall decide by theirselves which is better for their project 
- for Pandas.NET sure we go with NumSharp.Core.NDArray 