### PR TITLE
 Fix: Avoid IndexOutOfRangeException in arange method

### DIFF
--- a/src/NumSharp.Core/Creation/np.arange.cs
+++ b/src/NumSharp.Core/Creation/np.arange.cs
@@ -22,14 +22,16 @@ namespace NumSharp.Core
             }
 
             int length = (int)Math.Ceiling((stop - start + 0.0) / step);
-            int index = 0;
 
-            var nd = new NDArray(typeof(double), new Shape(length) );
+            var nd = new NDArray(typeof(double), new Shape(length));
 
             double[] puffer = nd.Storage.GetData() as double[];
 
-            for (double i = start; i < stop; i += step)
-                puffer[index++] = i;
+            for (int index = 0; index < length; index++)
+            {
+                double value = start + index * step;
+                puffer[index] = value;
+            }
 
             return nd;
         }

--- a/test/NumSharp.UnitTest/Creation/np.arange.Test.cs
+++ b/test/NumSharp.UnitTest/Creation/np.arange.Test.cs
@@ -25,6 +25,16 @@ namespace NumSharp.UnitTest.Creation
 
             n = np.arange(0, 11, 3);
             Assert.IsTrue(Enumerable.SequenceEqual(n.Storage.GetData<int>(), new int[] { 0, 3, 6, 9 }));
+
+            // Test increments < 1
+            var startd = 0.0;
+            var stopd = 12.0;
+            var incrementd = 0.1;
+            n = np.arange(startd, stopd, incrementd);
+            var r = n.Storage.GetData<double>();
+            var t = Enumerable.Repeat(0, (int)((stopd - startd) / incrementd)).Select((tr, ti) => tr + incrementd * ti);
+            Assert.IsTrue(r.Length == 120);
+            Assert.IsTrue(Enumerable.SequenceEqual(r, t));
         }
     }
 }

--- a/test/NumSharp.UnitTest/Selection/NDArray.AMax.Test.cs
+++ b/test/NumSharp.UnitTest/Selection/NDArray.AMax.Test.cs
@@ -15,7 +15,7 @@ namespace NumSharp.UnitTest.Selection
         {
             //default type
             var n = np.arange(0, 12, 0.1);
-            var d1 = n.amax();
+            var d1 = np.amax(n);
             Assert.IsTrue(d1[0].Equals(11.9));
 
             //no axis

--- a/test/NumSharp.UnitTest/Selection/NDArray.AMax.Test.cs
+++ b/test/NumSharp.UnitTest/Selection/NDArray.AMax.Test.cs
@@ -13,8 +13,13 @@ namespace NumSharp.UnitTest.Selection
         [TestMethod]
         public void amax()
         {
+            //default type
+            var n = np.arange(0, 12, 0.1);
+            var d1 = n.amax();
+            Assert.IsTrue(d1[0].Equals(11.9));
+
             //no axis
-            var n = np.arange(4).reshape(2, 2);
+            n = np.arange(4).reshape(2, 2);
             var n1 = np.amax(n).MakeGeneric<double>();
             Assert.IsTrue(n1[0] == 3);
 


### PR DESCRIPTION
Using doubles could cause IndexOutOfRangeException. Unit tests added to test it no long happens.