### PR TITLE
Make save method compatible with numpy's npy

### DIFF
--- a/src/NumSharp.Core/APIs/np.save.cs
+++ b/src/NumSharp.Core/APIs/np.save.cs
@@ -167,6 +167,8 @@ namespace NumSharp
       writer.Write((byte)0); // minor;
 
       string tuple = String.Join(", ", shape.Select(i => i.ToString()).ToArray());
+      if (shape.Length == 1)
+        tuple += ","; // 1-dim array's shape is (R,)
       string header = "{{'descr': '{0}', 'fortran_order': False, 'shape': ({1}), }}";
       header = String.Format(header, dtype, tuple);
       int preamble = 10; // magic string (6) + 4

--- a/test/NumSharp.UnitTest/np.save_load.Test.cs
+++ b/test/NumSharp.UnitTest/np.save_load.Test.cs
@@ -19,5 +19,15 @@ namespace NumSharp.UnitTest
       np.Load<int[]>(@"test.npy");
       np.Load_Npz<int[]>(@"test1.npz");
     }
+
+    [TestMethod]
+    public void SaveAndLoadMultiDimArray()
+    {
+      int[,] x =  { {1,2}, {3,4} };
+      np.Save(x, @"test_SaveAndLoadMultiDimArray.npy");
+      np.Save_Npz(x, @"test_SaveAndLoadMultiDimArray.npz");
+      np.Load<int[,]>(@"test_SaveAndLoadMultiDimArray.npy");
+      np.Load_Npz<int[,]>(@"test_SaveAndLoadMultiDimArray.npz");
+    }
   }
 }


### PR DESCRIPTION
Python numpy cannot load a npy file that generated by NumSharp.np.Save method.
Because shape shows `(R)` not `(R,)`.

So I changed save with shape `(R,)`.