### PR TITLE
ViewStorage: implemented 1-d slicing with step (nested views)

### DIFF
--- a/src/NumSharp.Core/Backends/TypedArrayStorage.cs
+++ b/src/NumSharp.Core/Backends/TypedArrayStorage.cs
@@ -141,6 +141,13 @@ namespace NumSharp.Backends
             _arrayDouble = values;
         }
 
+        public TypedArrayStorage(int[] values)
+        {
+            _DType = typeof(int);
+            _Shape = new Shape(values.Length);
+            _arrayInt32 = values;
+        }
+
         public TypedArrayStorage(object[] values)
         {
             _DType = values.GetType().GetElementType();

--- a/src/NumSharp.Core/NumSharp.Core.csproj
+++ b/src/NumSharp.Core/NumSharp.Core.csproj
@@ -77,13 +77,6 @@
   </Target>
 
   <ItemGroup>
-		<!--<Content CopyToOutputDirectory="PreserveNewest" Include="./runtimes/win-x64/native/lapack.dll" Link="lapack.dll" Pack="true" PackagePath="runtimes/win-x64/native/lapack.dll" />
-    <Content CopyToOutputDirectory="PreserveNewest" Include="./runtimes/win-x64/native/blas_win64_MT.dll" Link="blas_win64_MT.dll" Pack="true" PackagePath="runtimes/win-x64/native/blas_win64_MT.dll" />
-    <Content CopyToOutputDirectory="PreserveNewest" Include="./runtimes/linux-x64/native/blas.so" Link="blas.so" Pack="true" PackagePath="runtimes/linux-x64/native/blas.so" />
-    <Content CopyToOutputDirectory="PreserveNewest" Include="./runtimes/linux-x64/native/lapack.so" Link="lapack.so" Pack="true" PackagePath="runtimes/linux-x64/native/lapack.so" />-->
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="ArrayFire" Version="0.0.2" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/src/NumSharp.Core/NumSharp.Core.csproj.DotSettings
+++ b/src/NumSharp.Core/NumSharp.Core.csproj.DotSettings
@@ -8,4 +8,5 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=operations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=operations_005Celementwise/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=sorting_005Fsearching_005Fcounting/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=statistics/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=statistics/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=view/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/NumSharp.Core/Shape.cs
+++ b/src/NumSharp.Core/Shape.cs
@@ -171,6 +171,15 @@ namespace NumSharp
             }
         }
 
+        #region Slicing support
+
+        public Shape Slice(Slice[] slices)
+        {
+            return new Shape(Dimensions.Select((dim, i) => slices[i].GetSize(dim)).ToArray());
+        }
+
+        #endregion
+
         public static implicit operator int[] (Shape shape) => shape.dimensions;
         public static implicit operator Shape(int[] dims) => new Shape(dims);
 

--- a/src/NumSharp.Core/Slice.cs
+++ b/src/NumSharp.Core/Slice.cs
@@ -188,5 +188,12 @@ namespace NumSharp
             return $"{(Start == 0 ? "" : Start.ToString())}:{(Stop == null ? "" : Stop.ToString())}{optional_step}";
         }
 
+        // return the size of the slice, given the data dimension on this axiy
+        public int GetSize(int dim)
+        {
+            var start = Math.Max(0, Start ?? 0);
+            var stop = Math.Min(dim,  Stop ?? dim);
+            return (int)Math.Ceiling((stop - start) / (double)Math.Abs(Step));
+        }
     }
 }

--- a/src/NumSharp.Core/View/ViewStorage.cs
+++ b/src/NumSharp.Core/View/ViewStorage.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NumSharp
+{
+    public class ViewStorage : IStorage
+    {
+
+        public ViewStorage(IStorage dataStorage, string slice_notation) : this(dataStorage, Slice.ParseSlices(slice_notation))
+        {
+        }
+
+        public ViewStorage(IStorage dataStorage, params Slice[] slices)
+        {
+            if (dataStorage==null)
+                throw  new ArgumentException("dataStorage must not be null");
+            if (slices == null)
+                throw new ArgumentException("slices must not be null");
+            if (slices.Length == 0)
+                throw new ArgumentException("slices must contain at least one slice");
+            _data = dataStorage;
+            _slices = slices;
+            EnsureSliceStartStop();
+        }
+
+        private IStorage _data = null;
+        private Slice[] _slices =  null;
+
+        private void EnsureSliceStartStop()
+        {
+            if (_slices.Length == 1)
+            {
+                _slices[0].Start = Math.Max(0, _slices[0].Start ?? 0);
+                var size = _data.Shape.Size;
+                _slices[0].Stop = Math.Min(size, _slices[0].Stop ?? size);                    
+            }
+            else
+            {
+                throw new NotImplementedException("Multi-Dim slicing");
+            }
+        }
+
+        public object Clone()
+        {
+            return new ViewStorage(_data, _slices);
+        }
+
+        public Type DType => _data.DType;
+        public int DTypeSize => _data.DTypeSize;
+        public Slice Slice { get; set; } // <--- this is not doing anything in View! 
+        public Shape Shape { get { return _data.Shape.Slice(_slices); } }
+
+        public void Allocate(Shape shape, Type dtype = null)
+        {
+            // not sure if View should be allowed to Allocate
+            throw new NotImplementedException();
+        }
+
+        public void Allocate(Array values)
+        {
+            // not sure if View should be allowed to Allocate
+            throw new NotImplementedException();
+        }
+
+        public Array GetData()
+        {
+            // since the view is a subset of the data we have to copy here
+            if (_slices.Length == 1)
+            {
+                var slice = _slices[0];
+                int size = Shape.Size; 
+                var data = AllocateArray(size, _data.DType);
+                for (var i = 0; i < size; i++)
+                    data.SetValue(GetValue(i), i);
+                return data;
+            }
+            else
+            {
+                throw new NotImplementedException("Multi-Dim slicing");
+            }
+        }
+
+        private object GetValue(int idx)
+        {
+            switch (DType.Name)
+            {
+                //case "Byte":
+                //    return GetByte(idx);
+                case "Boolean":
+                    return GetBoolean(idx);
+                case "Int16":
+                    return GetInt16(idx);
+                case "Int32":
+                    return GetInt32(idx);
+                case "Int64":
+                    return GetInt64(idx);
+                //case "UInt32":
+                //    return GetUInt32(idx);
+                case "Single":
+                    return GetSingle(idx);
+                case "Double":
+                    return GetDouble(idx);
+                case "Decimal":
+                    return GetDecimal(idx);
+                case "String":
+                    return GetString(idx);
+                //case "Object":
+                //    return GetObject(idx);
+                case "NDArray":
+                    return GetNDArray(idx);
+                default:
+                    throw new NotImplementedException($"GetValue {DType.Name}");
+            }
+        }
+
+
+        private Array AllocateArray(int size, Type dataDType)
+        {
+            switch (dataDType.Name)
+            {
+                case "Byte":
+                    return new byte[size];
+                case "Boolean":
+                    return new bool[size];
+                case "Int16":
+                    return new short[size];
+                case "Int32":
+                    return new int[size];
+                case "Int64":
+                    return new long[size];
+                case "UInt32":
+                    return new uint[size];
+                case "Single":
+                    return new float[size];
+                case "Double":
+                    return new double[size];
+                case "Decimal":
+                    return new decimal[size];
+                case "String":
+                    return new string[size];
+                case "Object":
+                    return new object[size];
+                case "NDArray":
+                    return new NDArray[size];
+                default:
+                    throw new NotImplementedException($"AllocateArray {dataDType.Name}");
+            }
+        }
+
+        public Array CloneData()
+        {
+            throw  new NotImplementedException("Cloning the data is not supported in view");            
+        }
+
+        public T[] GetData<T>()
+        {
+            return GetData() as T[];
+        }
+
+        public T GetData<T>(params int[] indices)
+        {
+            return _data.GetData<T>(TransformIndices(indices, _slices));
+        }
+
+        // todo move to Shape when implementing of multi-dim slicing
+        private int[] TransformIndices(int[] indices, Slice[] slices)
+        {
+            // transform in-place, for performance reasons
+            for (int i = 0; i < indices.Length; i++)
+            {
+                var idx = indices[i];
+                indices[i] = TransformIndex(idx, slices);
+            }
+            return indices;
+        }
+
+        // todo move to Shape when implementing of multi-dim slicing
+        private int TransformIndex(int idx, Slice[] slices)
+        {
+            if (slices.Length == 1)
+            {
+                var slice = slices[0];
+                var start = slice.Step > 0 ? slice.Start.Value : Math.Max(0,  slice.Stop.Value-1);
+                //var stop = slice.Step > 0 ? slice.Stop.Value : Math.Max(0, slice.Start.Value - 1);
+                return start + idx * slice.Step;
+            }
+            else 
+                throw new NotImplementedException("Multi-Dim slicing");
+        }
+
+        public Span<T> GetSpanData<T>(params int[] indices)
+        {
+            throw new NotImplementedException("span of a view is not supported as it typically is not contiguous memory");
+        }
+
+        public bool GetBoolean(params int[] indices)
+        {
+            return _data.GetBoolean(TransformIndices(indices, _slices));
+        }
+
+        public short GetInt16(params int[] indices)
+        {
+            return _data.GetInt16(TransformIndices(indices, _slices));
+        }
+
+        public int GetInt32(params int[] indices)
+        {
+            return _data.GetInt32(TransformIndices(indices, _slices));
+        }
+
+        public long GetInt64(params int[] indices)
+        {
+            return _data.GetInt64(TransformIndices(indices, _slices));
+        }
+
+        public float GetSingle(params int[] indices)
+        {
+            return _data.GetSingle(TransformIndices(indices, _slices));
+        }
+
+        public double GetDouble(params int[] indices)
+        {
+            return _data.GetDouble(TransformIndices(indices, _slices));
+        }
+
+        public decimal GetDecimal(params int[] indices)
+        {
+            return _data.GetDecimal(TransformIndices(indices, _slices));
+        }
+
+        public string GetString(params int[] indices)
+        {
+            return _data.GetString(TransformIndices(indices, _slices));
+        }
+
+        public NDArray GetNDArray(params int[] indices)
+        {
+            return _data.GetNDArray(TransformIndices(indices, _slices));
+        }
+
+        public void SetData(Array values)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetData<T>(Array values)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetData<T>(T value, params int[] indexes)
+        {
+            _data.SetData<T>(value, TransformIndices(indexes, _slices));
+        }
+
+        public void SetData(Array values, Type dtype)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Reshape(params int[] dimensions)
+        {
+            //Shape = new Shape(dimensions);
+            //TODO: how to reshape a view?
+        }
+
+        public Span<T> View<T>(Slice slice = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/NumSharp.UnitTest/View/ViewStorage.Test.cs
+++ b/test/NumSharp.UnitTest/View/ViewStorage.Test.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NumSharp.Backends;
+
+namespace NumSharp.UnitTest.View
+{
+    [TestClass]
+    public class ViewStorageTest : TestClass
+    {
+        [TestMethod]
+        public void GetData_1D()
+        {
+            var data = new TypedArrayStorage(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+            Assert.AreEqual(new Shape(10), data.Shape );
+            // return identical view
+            var view = new ViewStorage(data, ":");
+            Assert.AreEqual(new Shape(10), view.Shape);
+            AssertAreEqual(data.GetData(), view.GetData());
+            view = new ViewStorage(data, "-77:77");
+            Assert.AreEqual(new Shape(10), view.Shape);
+            AssertAreEqual(data.GetData(), view.GetData());
+            // return reduced view
+            view = new ViewStorage(data, "7:");
+            Assert.AreEqual(new Shape(3), view.Shape);
+            AssertAreEqual(new int[] { 7, 8, 9 }, view.GetData());
+            view = new ViewStorage(data, ":5");
+            Assert.AreEqual(new Shape(5), view.Shape);
+            AssertAreEqual(new int[] { 0, 1, 2, 3, 4 }, view.GetData());
+            view = new ViewStorage(data, "2:3");
+            Assert.AreEqual(new Shape(1), view.Shape);
+            AssertAreEqual(new int[] { 2 }, view.GetData());
+            // return stepped view
+            view = new ViewStorage(data, "::2");
+            Assert.AreEqual(new Shape(5), view.Shape);
+            AssertAreEqual(new int[] { 0, 2, 4, 6, 8 }, view.GetData());
+            view = new ViewStorage(data, "::3");
+            Assert.AreEqual(new Shape(4), view.Shape);
+            AssertAreEqual(new int[] { 0, 3, 6, 9 }, view.GetData());
+            view = new ViewStorage(data, "-77:77:77");
+            Assert.AreEqual(new Shape(1), view.Shape);
+            AssertAreEqual(new []{0}, view.GetData());
+            // negative step!
+            view = new ViewStorage(data, "::-1");
+            Assert.AreEqual(new Shape(10), view.Shape);
+            AssertAreEqual(data.GetData().OfType<int>().Reverse().ToArray(), view.GetData());
+            view = new ViewStorage(data, "::-2");
+            Assert.AreEqual(new Shape(5), view.Shape);
+            AssertAreEqual(new int[] { 9, 7, 5, 3, 1 }, view.GetData());
+            view = new ViewStorage(data, "::-3");
+            Assert.AreEqual(new Shape(4), view.Shape);
+            AssertAreEqual(new int[] { 9, 6, 3, 0 }, view.GetData());
+            view = new ViewStorage(data, "-77:77:-77");
+            Assert.AreEqual(new Shape(1), view.Shape);
+            AssertAreEqual(new[] { 9 }, view.GetData());
+        }
+
+        [TestMethod]
+        public void Indexing_1D()
+        {
+            var data = new TypedArrayStorage(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+            // return identical view
+            var view = new ViewStorage(data, ":");
+            AssertAreEqual(new[]{0,5,9}, view.GetData<int>(0,5,9));
+            view = new ViewStorage(data, "-77:77");
+            AssertAreEqual(new[] { 0, 5, 9 }, view.GetData<int>(0, 5, 9));
+            // return reduced view
+            view = new ViewStorage(data, "7:");
+            AssertAreEqual(new int[] { 7, 8, 9 }, view.GetData<int>(0,1,2));
+            view = new ViewStorage(data, ":5");
+            AssertAreEqual(new int[] { 0, 1, 2, 3, 4 }, view.GetData<int>(0, 1, 2, 3, 4));
+            view = new ViewStorage(data, "2:3");
+            AssertAreEqual(new int[] { 2 }, view.GetData<int>(0));
+            // return stepped view
+            view = new ViewStorage(data, "::2");
+            AssertAreEqual(new int[] { 0, 2, 4, 6, 8 }, view.GetData<int>(0,1,2,3,4));
+            view = new ViewStorage(data, "::3");
+            AssertAreEqual(new int[] { 0, 3, 6, 9 }, view.GetData<int>(0,1,2,3));
+            view = new ViewStorage(data, "-77:77:77");
+            AssertAreEqual(new[] { 0 }, view.GetData<int>(0));
+            // negative step!
+            view = new ViewStorage(data, "::-1");
+            AssertAreEqual(new[] { 9, 5, 0 }, view.GetData<int>(0, 5, 9));
+            view = new ViewStorage(data, "::-2");
+            AssertAreEqual(new int[] { 9, 7, 5, 3, 1 }, view.GetData<int>(0, 1, 2, 3, 4));
+            view = new ViewStorage(data, "::-3");
+            AssertAreEqual(new int[] { 9, 6, 3, 0 }, view.GetData<int>(0, 1, 2, 3));
+            view = new ViewStorage(data, "-77:77:-77");
+            AssertAreEqual(new[] { 9 }, view.GetData<int>(0));
+        }
+
+        [TestMethod]
+        public void NestedView_1D()
+        {
+            var data = new TypedArrayStorage(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+            // return identical view
+            var identical = new ViewStorage(data, ":");
+            Assert.AreEqual(new Shape(10), identical.Shape);
+            var view1 = new ViewStorage(identical, "1:9");
+            Assert.AreEqual(new Shape(8), view1.Shape);
+            AssertAreEqual(new int[] { 1, 2, 3, 4, 5, 6, 7, 8, }, view1.GetData());
+            var view2 = new ViewStorage(view1, "::-2");
+            Assert.AreEqual(new Shape(4), view2.Shape);
+            AssertAreEqual(new int[] { 8, 6, 4, 2, }, view2.GetData());
+            var view3 = new ViewStorage(view2, "::-3");
+            Assert.AreEqual(new Shape(2), view3.Shape);
+            AssertAreEqual(new int[] { 2, 8 }, view3.GetData());
+            // all must see the same modifications, no matter if original or any view is modified
+            // modify original
+            data.SetData(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, -8, -9 });
+            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, -8, }, view1.GetData());
+            AssertAreEqual(new int[] { -8, -6, -4, -2, }, view2.GetData());
+            AssertAreEqual(new int[] { -2, -8 }, view3.GetData());
+            // modify views
+            view1.SetData(88, 7);
+            AssertAreEqual(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, 88, -9 }, data.GetData());
+            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, 88, }, view1.GetData());
+            AssertAreEqual(new int[] { 88, -6, -4, -2, }, view2.GetData());
+            AssertAreEqual(new int[] { -2, 88 }, view3.GetData());
+        }
+    }
+}

--- a/test/NumSharp.UnitTest/View/ViewStorage.Test.cs
+++ b/test/NumSharp.UnitTest/View/ViewStorage.Test.cs
@@ -63,32 +63,58 @@ namespace NumSharp.UnitTest.View
             var data = new TypedArrayStorage(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
             // return identical view
             var view = new ViewStorage(data, ":");
-            AssertAreEqual(new[]{0,5,9}, view.GetData<int>(0,5,9));
+            Assert.AreEqual(0,view.GetData<int>(0));
+            Assert.AreEqual(5, view.GetData<int>(5));
+            Assert.AreEqual(9, view.GetData<int>(9));
             view = new ViewStorage(data, "-77:77");
-            AssertAreEqual(new[] { 0, 5, 9 }, view.GetData<int>(0, 5, 9));
+            Assert.AreEqual(0, view.GetData<int>(0));
+            Assert.AreEqual(5, view.GetData<int>(5));
+            Assert.AreEqual(9, view.GetData<int>(9));
             // return reduced view
             view = new ViewStorage(data, "7:");
-            AssertAreEqual(new int[] { 7, 8, 9 }, view.GetData<int>(0,1,2));
+            Assert.AreEqual(7, view.GetData<int>(0));
+            Assert.AreEqual(8, view.GetData<int>(1));
+            Assert.AreEqual(9, view.GetData<int>(2));
             view = new ViewStorage(data, ":5");
-            AssertAreEqual(new int[] { 0, 1, 2, 3, 4 }, view.GetData<int>(0, 1, 2, 3, 4));
+            Assert.AreEqual(0, view.GetData<int>(0));
+            Assert.AreEqual(1, view.GetData<int>(1));
+            Assert.AreEqual(2, view.GetData<int>(2));
+            Assert.AreEqual(3, view.GetData<int>(3));
+            Assert.AreEqual(4, view.GetData<int>(4));
             view = new ViewStorage(data, "2:3");
-            AssertAreEqual(new int[] { 2 }, view.GetData<int>(0));
+            Assert.AreEqual(2, view.GetData<int>(0));
             // return stepped view
             view = new ViewStorage(data, "::2");
-            AssertAreEqual(new int[] { 0, 2, 4, 6, 8 }, view.GetData<int>(0,1,2,3,4));
+            Assert.AreEqual(0, view.GetData<int>(0));
+            Assert.AreEqual(2, view.GetData<int>(1));
+            Assert.AreEqual(4, view.GetData<int>(2));
+            Assert.AreEqual(6, view.GetData<int>(3));
+            Assert.AreEqual(8, view.GetData<int>(4));
             view = new ViewStorage(data, "::3");
-            AssertAreEqual(new int[] { 0, 3, 6, 9 }, view.GetData<int>(0,1,2,3));
+            Assert.AreEqual(0, view.GetData<int>(0));
+            Assert.AreEqual(3, view.GetData<int>(1));
+            Assert.AreEqual(6, view.GetData<int>(2));
+            Assert.AreEqual(9, view.GetData<int>(3));
             view = new ViewStorage(data, "-77:77:77");
-            AssertAreEqual(new[] { 0 }, view.GetData<int>(0));
+            Assert.AreEqual(0, view.GetData<int>(0));
             // negative step!
             view = new ViewStorage(data, "::-1");
-            AssertAreEqual(new[] { 9, 5, 0 }, view.GetData<int>(0, 5, 9));
+            Assert.AreEqual(9, view.GetData<int>(0));
+            Assert.AreEqual(4, view.GetData<int>(5));
+            Assert.AreEqual(0, view.GetData<int>(9));
             view = new ViewStorage(data, "::-2");
-            AssertAreEqual(new int[] { 9, 7, 5, 3, 1 }, view.GetData<int>(0, 1, 2, 3, 4));
+            Assert.AreEqual(9, view.GetData<int>(0));
+            Assert.AreEqual(7, view.GetData<int>(1));
+            Assert.AreEqual(5, view.GetData<int>(2));
+            Assert.AreEqual(3, view.GetData<int>(3));
+            Assert.AreEqual(1, view.GetData<int>(4));
             view = new ViewStorage(data, "::-3");
-            AssertAreEqual(new int[] { 9, 6, 3, 0 }, view.GetData<int>(0, 1, 2, 3));
+            Assert.AreEqual(9, view.GetData<int>(0));
+            Assert.AreEqual(6, view.GetData<int>(1));
+            Assert.AreEqual(3, view.GetData<int>(2));
+            Assert.AreEqual(0, view.GetData<int>(3));
             view = new ViewStorage(data, "-77:77:-77");
-            AssertAreEqual(new[] { 9 }, view.GetData<int>(0));
+            Assert.AreEqual(9, view.GetData<int>(0));
         }
 
         [TestMethod]

--- a/test/NumSharp.UnitTest/View/ViewStorage.Test.cs
+++ b/test/NumSharp.UnitTest/View/ViewStorage.Test.cs
@@ -145,6 +145,11 @@ namespace NumSharp.UnitTest.View
             AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, 88, }, view1.GetData());
             AssertAreEqual(new int[] { 88, -6, -4, -2, }, view2.GetData());
             AssertAreEqual(new int[] { -2, 88 }, view3.GetData());
+            view3.SetData(22, 0);
+            AssertAreEqual(new int[] { 0, -1, 22, -3, -4, -5, -6, -7, 88, -9 }, data.GetData());
+            AssertAreEqual(new int[] { -1, 22, -3, -4, -5, -6, -7, 88, }, view1.GetData());
+            AssertAreEqual(new int[] { 88, -6, -4, 22, }, view2.GetData());
+            AssertAreEqual(new int[] { 22, 88 }, view3.GetData());
         }
     }
 }


### PR DESCRIPTION
I think the test speaks volumes: 

        [TestMethod]
        public void NestedView_1D()
        {
            var data = new TypedArrayStorage(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
            // return identical view
            var identical = new ViewStorage(data, ":");
            Assert.AreEqual(new Shape(10), identical.Shape);
            var view1 = new ViewStorage(identical, "1:9");
            Assert.AreEqual(new Shape(8), view1.Shape);
            AssertAreEqual(new int[] { 1, 2, 3, 4, 5, 6, 7, 8, }, view1.GetData());
            var view2 = new ViewStorage(view1, "::-2");
            Assert.AreEqual(new Shape(4), view2.Shape);
            AssertAreEqual(new int[] { 8, 6, 4, 2, }, view2.GetData());
            var view3 = new ViewStorage(view2, "::-3");
            Assert.AreEqual(new Shape(2), view3.Shape);
            AssertAreEqual(new int[] { 2, 8 }, view3.GetData());
            // all must see the same modifications, no matter if original or any view is modified
            // modify original
            data.SetData(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, -8, -9 });
            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, -8, }, view1.GetData());
            AssertAreEqual(new int[] { -8, -6, -4, -2, }, view2.GetData());
            AssertAreEqual(new int[] { -2, -8 }, view3.GetData());
            // modify views
            view1.SetData(88, 7);
            AssertAreEqual(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, 88, -9 }, data.GetData());
            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, 88, }, view1.GetData());
            AssertAreEqual(new int[] { 88, -6, -4, -2, }, view2.GetData());
            AssertAreEqual(new int[] { -2, 88 }, view3.GetData());
        }