### PR TITLE
Slice assign for generic NDArray<T> added

### DIFF
--- a/src/NumSharp.Core/Creation/NdArray.MakeGeneric.cs
+++ b/src/NumSharp.Core/Creation/NdArray.MakeGeneric.cs
@@ -12,11 +12,17 @@ namespace NumSharp
     {
         public NDArray<T> MakeGeneric<T>() where T : struct
         {
-            var genericArray = new NDArray<T>(Storage.Shape);
-
-            genericArray.Array = Storage.GetData<T>();
-
-            return genericArray;
+            if (typeof(T) == dtype)
+            {
+                var genericArray = new NDArray<T>(Storage);
+                return genericArray;
+            }
+            else
+            {
+                var genericArray = new NDArray<T>(Storage.Shape);
+                genericArray.Array = Storage.GetData<T>();
+                return genericArray;
+            }
         }
     }
 }

--- a/src/NumSharp.Core/Generics/NDArrayGeneric.cs
+++ b/src/NumSharp.Core/Generics/NDArrayGeneric.cs
@@ -58,5 +58,40 @@ namespace NumSharp.Generic
                 Storage.SetData(value, select);
             }
         }
+
+        /// <summary>
+        /// slicing of generic - overridden on purpose
+        /// </summary>
+        /// <value></value>
+        new public NDArray<T> this[string slice]
+        {
+            get
+            {
+                return base[slice].MakeGeneric<T>();
+            }
+
+            set
+            {
+                base[slice] = value;
+            }
+        }
+
+        /// <summary>
+        /// slicing of generic - overridden on purpose
+        /// </summary>
+        /// <value></value>
+        new public NDArray<T> this[Slice[] slices]
+        {
+            get
+            {
+                return base[slices].MakeGeneric<T>();
+            }
+
+            set
+            {
+                base[slices] = value;
+            }
+        }
+
     }
 }

--- a/src/NumSharp.Core/Generics/NDArrayGeneric.cs
+++ b/src/NumSharp.Core/Generics/NDArrayGeneric.cs
@@ -33,6 +33,14 @@ namespace NumSharp.Generic
         {
         }
 
+        public NDArray(IStorage storage) : base(storage)
+        {
+            if (typeof(T) != storage.DType)
+            {
+                throw new ArgumentException($"Storage type must be the same as T. {storage.DType.Name} != {typeof(T).Name}", nameof(storage));
+            }
+        }
+
         public NDArray(Shape shape) : base(typeof(T))
         {
             Storage.Allocate(shape);
@@ -41,6 +49,23 @@ namespace NumSharp.Generic
         public NDArray(Array array, Shape shape) : this(shape)
         {
             Storage.SetData(array);
+        }
+
+        /// <summary>
+        /// Array access to storage data - overridden on purpose
+        /// </summary>
+        /// <value></value>
+        new public T[] Array
+        {
+            get
+            {
+                return Storage.GetData<T>();
+            }
+
+            set
+            {
+                Storage.SetData<T>(value);
+            }
         }
         /// <summary>
         /// indexing of generic - overridden on purpose
@@ -55,7 +80,7 @@ namespace NumSharp.Generic
 
             set
             {
-                Storage.SetData(value, select);
+                Storage.SetData<T>(value, select);
             }
         }
 
@@ -72,7 +97,7 @@ namespace NumSharp.Generic
 
             set
             {
-                base[slice] = value;
+                Array = value.Data<T>();
             }
         }
 
@@ -80,7 +105,7 @@ namespace NumSharp.Generic
         /// slicing of generic - overridden on purpose
         /// </summary>
         /// <value></value>
-        new public NDArray<T> this[Slice[] slices]
+        new public NDArray<T> this[params Slice[] slices]
         {
             get
             {
@@ -89,9 +114,23 @@ namespace NumSharp.Generic
 
             set
             {
-                base[slices] = value;
+                Array = value.Data<T>();
             }
         }
 
+        public static implicit operator T[] (NDArray<T> nd)
+        {
+            return nd.Array;
+        }
+        /*
+        public static implicit operator NDArray<T>(T[] tArray)
+        {
+            var genericArray = new NDArray<T>();
+            genericArray.Array = tArray;
+            return genericArray;
+        }
+        */
+
     }
+
 }

--- a/src/NumSharp.Core/Selection/NDArray.Indexing.cs
+++ b/src/NumSharp.Core/Selection/NDArray.Indexing.cs
@@ -80,7 +80,7 @@ namespace NumSharp
 
             set
             {
-                throw new NotImplementedException("slice data set is not implemented.");
+                throw new NotImplementedException("slice data set is not implemented for types less NDArray's.");
             }
         }
 

--- a/src/NumSharp.Core/Slice.cs
+++ b/src/NumSharp.Core/Slice.cs
@@ -204,9 +204,30 @@ namespace NumSharp
         // return the size of the slice, given the data dimension on this axiy
         public int GetSize(int dim)
         {
-            var start = Math.Max(0, Start ?? 0);
-            var stop = Math.Min(dim,  Stop ?? dim);
-            return (int)Math.Ceiling((stop - start) / (double)Math.Abs(Step));
+            var absStart = GetAbsStart(dim);
+            var absStop = GetAbsStop(dim);
+            var absStep = GetAbsStep();
+            return ((absStop - absStart)+(absStep-1)) / absStep;
+        }
+
+        public int GetAbsStep()
+        {
+            return Math.Abs(Step);
+        }
+        public int GetAbsStart(int dim)
+        {
+            // Note: No handling of out of range
+            var absStartN = Start < 0 ? dim + Start : Start;
+            var absStart = Step < 0 ? (absStartN ?? dim) : (absStartN ?? 0);
+            return absStart;
+        }
+
+        public int GetAbsStop(int dim)
+        {
+            // Note: No handling of out of range
+            var absStopN = Stop < 0 ? dim + Stop : Stop;
+            var absStop = Step < 0 ? (absStopN ?? 0) : (absStopN ?? dim);
+            return absStop;
         }
 
     }

--- a/src/NumSharp.Core/View/ViewStorage.cs
+++ b/src/NumSharp.Core/View/ViewStorage.cs
@@ -288,8 +288,49 @@ namespace NumSharp
             throw new NotImplementedException();
         }
 
+        private void IncrementIndexes(int [] storageIndexes, int[] storageStartIdxs, int []storageStopIdxs, int[] storageSteps)
+        {
+            var dims = storageIndexes.Length;
+            for (var dimIdx = dims-1; dimIdx >= 0; dimIdx--)
+            {
+                storageIndexes[dimIdx] += storageSteps[dimIdx];
+                if (storageIndexes[dimIdx] > storageStopIdxs[dimIdx])
+                {
+                    storageIndexes[dimIdx] = storageStartIdxs[dimIdx];
+                } else
+                {
+                    break;
+                }
+            }
+        }
+
         public void SetData<T>(Array values)
         {
+            if (values is T[] tArray)
+            {
+                var sliceDims = new int[_slices.Length];
+                var sliceStartIdxs = new int[_slices.Length];
+                var sliceStopIdxs = new int[_slices.Length];
+                var sliceSteps = new int[_slices.Length];
+                for (var dimIdx = 0; dimIdx < _slices.Length; dimIdx++)
+                {
+                    sliceDims[dimIdx] = Shape.Dimensions[dimIdx];
+                    sliceStartIdxs[dimIdx] = 0;
+                    sliceStopIdxs[dimIdx] = sliceDims[dimIdx] - 1;
+                    sliceSteps[dimIdx] = _slices[dimIdx].GetAbsStep();
+                }
+                var storageStartIdxs = TransformIndices(sliceStartIdxs, _slices);
+                var storageStopIdxs = TransformIndices(sliceStopIdxs, _slices);
+                var storageSteps = sliceSteps;
+                var storageIndexes = storageStartIdxs;
+                var tLength = tArray.Length;
+                for (var tIdx = 0; tIdx < tLength; tIdx++)
+                {
+                    _data.SetData<T>(tArray[tIdx], storageIndexes);
+                    IncrementIndexes(storageIndexes, storageStartIdxs, storageStopIdxs, storageSteps);
+                }
+                return;
+            }
             throw new NotImplementedException();
         }
 

--- a/test/NumSharp.Benchmark/NDArraySliceAndSpanTester.cs
+++ b/test/NumSharp.Benchmark/NDArraySliceAndSpanTester.cs
@@ -1,0 +1,250 @@
+﻿
+using System;
+using System.Numerics;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Running;
+using NumSharp;
+using NumSharp.Generic;
+
+namespace NumSharp.Benchmark
+{
+    //[RPlotExporter, RankColumn]
+    [SimpleJob(RunStrategy.ColdStart, targetCount: 20)]
+    [MinColumn, MaxColumn, MeanColumn, MedianColumn]
+    [HtmlExporter]
+    public class NDArraySliceAndSpanTester
+    {
+
+        public double[] A1;
+        public Memory<double> M1;
+        public Memory<double> M2;
+        public NDArray N1;
+        public NDArray<double> ND1;
+        public NDArray NS1;
+        public NDArray<double> NDS1;
+        public NDArray NS2;
+        public NDArray<double> NDS2;
+
+        private Span<double> GetFullA1Span()
+        {
+            return new Span<double>(A1);
+        }
+        private Span<double> GetPartialA1Span()
+        {
+            return new Span<double>(A1, 1, A1.Length-2);
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var arraySize = 100000;
+            A1 = new double[arraySize].Select((x, idx) => x + idx).ToArray();
+            M1 = new Memory<double>(A1);
+            M2 = new Memory<double>(A1, 2, A1.Length - 2);
+            N1 = new NDArray(new double[arraySize].Select((x, idx) => x + idx).ToArray());
+            ND1 = new NDArray(new double[arraySize].Select((x, idx) => x + idx).ToArray()).MakeGeneric<double>();
+            NS1 = N1["1:" + (N1.size-2)];
+            NDS1 = ND1["1:" + (ND1.size - 2)];
+            NS2 = N1["1:" + (N1.size - 2) + ":2"];
+            NDS2 = ND1["1:" + (ND1.size - 2) + ":2"];
+        }
+        [Benchmark(Description = "C# double[] initialized in a for loop")]
+        public void Array1InitInForLoop()
+        {
+            //unchecked
+            {
+                var aLength = A1.Length;
+                for (int idx = 0; idx < aLength; idx++)
+                    A1[idx] = 1.0;
+            }
+        }
+        [Benchmark(Description = "C# double[] initialized in a fixed for loop")]
+        public unsafe void Array1InitInFixedForLoop()
+        {
+            fixed (double *pA1 = A1)
+            {
+                var aLength = A1.Length;
+                for (int idx = 0; idx < aLength; idx++)
+                    pA1[idx] = 1.0;
+            }
+        }
+
+        [Benchmark(Description = "C# Memory<double> initialized in a for loop")]
+        public void Memory1InitInForLoop()
+        {
+            var MS1 = M1.Span;
+            //unchecked
+            {
+                for (int idx = 0; idx < M1.Length; idx++)
+                    MS1[idx] = 1.0;
+            }
+        }
+        [Benchmark(Description = "C# Memory<double>(1:-1).Span initialized in a for loop")]
+        public void Memory2InitInForLoop()
+        {
+            var MS2 = M2.Span;
+            //unchecked
+            {
+                for (int idx = 0; idx < M2.Length; idx++)
+                    MS2[idx] = 1.0;
+            }
+        }
+
+        [Benchmark(Description = "C# Span<double> initialized in a for loop")]
+        public void Span1InitInForLoop()
+        {
+            var S1 = GetFullA1Span();
+            //unchecked
+            {
+                for (int idx = 0; idx < S1.Length; idx++)
+                    S1[idx] = 1.0;
+            }
+        }
+        [Benchmark(Description = "C# Span<double>(1:-1) initialized in a for loop")]
+        public void Span2InitInForLoop()
+        {
+            var S2 = GetPartialA1Span();
+            //unchecked
+            {
+                for (int idx = 0; idx < S2.Length; idx++)
+                    S2[idx] = 1.0;
+            }
+        }
+
+        [Benchmark(Description = "C# Span<double>(1:-1) initialized in a fixed for loop")]
+        public unsafe void Span2InitInFixedForLoop()
+        {
+            var S2 = GetPartialA1Span();
+            fixed (double *pS2 = S2)
+            {
+                var aLength = S2.Length;
+                for (int idx = 0; idx < aLength; idx++)
+                    pS2[idx] = 1.0;
+            }
+        }
+
+
+
+        [Benchmark(Description = "C# Span<double> initialized in a for loop via array copy")]
+        public void Span1AsArrayInitInForLoop()
+        {
+            var S1 = GetFullA1Span();
+            var S1Copy = S1.ToArray();
+            //unchecked
+            {
+                for (int idx = 0; idx < S1Copy.Length; idx++)
+                    S1Copy[idx] = 1.0;
+                for (int idx = 0; idx < S1Copy.Length; idx++)
+                    S1[idx] = S1Copy[idx];
+            }
+        }
+        [Benchmark(Description = "C# Span<double>(1:-1) initialized in a for loop via array copy")]
+        public void Span2AsArrayInitInForLoop()
+        {
+            var S2 = GetPartialA1Span();
+            var S2Copy = S2.ToArray();
+            //unchecked
+            {
+                for (int idx = 0; idx < S2Copy.Length; idx++)
+                    S2Copy[idx] = 1.0;
+                for (int idx = 0; idx < S2Copy.Length; idx++)
+                    S2[idx] = S2Copy[idx];
+            }
+        }
+        [Benchmark(Description = "NDArray initialized in a for loop")]
+        public void NDArray1InitInForLoop()
+        {
+            //var A1 = N1.Array;
+            //unchecked
+            {
+                for (int idx = 0; idx < N1.size; idx++)
+                    N1[idx] = 1.0;
+            }
+        }
+        [Benchmark(Description = "NDArray<double> initialized in a for loop")]
+        public void NDArrayDouble1InitInForLoop()
+        {
+            //var A1 = N1.Array;
+            //unchecked
+            {
+                for (int idx = 0; idx < ND1.size; idx++)
+                    ND1[idx] = 1.0;
+            }
+        }
+        [Benchmark(Description = "NDArray[1:-1] initialized in a for loop")]
+        public void NDArraySlice1InitInForLoop()
+        {
+            //var A1 = N1.Array;
+            //unchecked
+            {
+                for (int idx = 0; idx < NS1.size; idx++)
+                    NS1[idx] = 1.0;
+            }
+        }
+
+
+        [Benchmark(Description = "NDArray<double>[1:-1] initialized in a for loop")]
+        public void NDArrayDoubleSlice1InitInForLoop()
+        {
+            //var A1 = N1.Array;
+            //unchecked
+            {
+                for (int idx = 0; idx < NDS1.size; idx++)
+                    NDS1[idx] = 1.0;
+            }
+        }
+
+        [Benchmark(Description = "NDArray[1:-1:2] initialized in a for loop")]
+        public void NDArraySlice2InitInForLoop()
+        {
+            //var A1 = N1.Array;
+            //unchecked
+            {
+                for (int idx = 0; idx < NS2.size; idx++)
+                    NS2[idx] = 1.0;
+            }
+        }
+
+
+        [Benchmark(Description = "NDArray<double>[1:-1:2] initialized in a for loop")]
+        public void NDArrayDoubleSlice2InitInForLoop()
+        {
+            //var A1 = N1.Array;
+            //unchecked
+            {
+                for (int idx = 0; idx < NDS2.size; idx++)
+                    NDS2[idx] = 1.0;
+            }
+        }
+
+        [Benchmark(Description = "NDArray[1:-1].ToArray() and assign index 0")]
+        public void NDArraySlice1ToArray()
+        {
+            var A1 = NS1.Array;
+            A1.SetValue(1.1, 0);
+        }
+        [Benchmark(Description = "NDArray<double>[1:-1].ToArray() and assign index 0")]
+        public void NDArrayDoubleSlice1ToArray()
+        {
+            var A1 = NDS1.Array;
+            A1.SetValue(1.1, 0);
+        }
+
+        [Benchmark(Description = "NDArray[1:-1:2].ToArray() and assign index 0")]
+        public void NDArraySlice2ToArray()
+        {
+            var A2 = NS2.Array;
+            A2.SetValue(1.1, 0);
+        }
+        [Benchmark(Description = "NDArray<double>[1:-1:2].ToArray() and assign index 0")]
+        public void NDArrayDoubleSlice2ToArray()
+        {
+            var A2 = NDS2.Array;
+            A2.SetValue(1.1, 0);
+        }
+
+
+    }
+}

--- a/test/NumSharp.Benchmark/NumSharp.Benchmark.csproj
+++ b/test/NumSharp.Benchmark/NumSharp.Benchmark.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">
@@ -20,6 +21,10 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">

--- a/test/NumSharp.Benchmark/NumSharp.Benchmark.csproj
+++ b/test/NumSharp.Benchmark/NumSharp.Benchmark.csproj
@@ -21,6 +21,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/NumSharp.Benchmark/Program.cs
+++ b/test/NumSharp.Benchmark/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace NumSharp.Benchmark
@@ -24,7 +25,12 @@ namespace NumSharp.Benchmark
             }
             else
             {
-                BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run();
+#if DEBUG
+                IConfig config = new DebugInProcessConfig();
+#else
+                IConfig config = null;
+#endif
+                BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, config);
             }
 
             Console.ReadLine();

--- a/test/NumSharp.UnitTest/Selection/NDArray.Indexing.Test.cs
+++ b/test/NumSharp.UnitTest/Selection/NDArray.Indexing.Test.cs
@@ -458,6 +458,55 @@ namespace NumSharp.UnitTest.Selection
         }
 
         [TestMethod]
+        public void AssignGeneric1DSlice1()
+        {
+            var x = np.arange(5).MakeGeneric<int>();
+            var y1 = np.arange(5, 8).MakeGeneric<int>();
+            var y2 = np.arange(10, 13).MakeGeneric<int>();
+
+            AssertAreEqual(new int[] { 0, 1, 2, 3, 4 }, x.Data<int>());
+
+            var xS1 = x["1:4"];
+            xS1[0] = y1[0];
+            xS1[1] = y1[1];
+            xS1[2] = y1[2];
+
+            AssertAreEqual(new int[] { 5, 6, 7 }, xS1.Data<int>());
+            AssertAreEqual(new int[] { 0, 5, 6, 7, 4 }, x.Data<int>());
+
+            var xS2 = x[new Slice(1, -1)];
+            xS2[":"] = y2;
+
+            AssertAreEqual(new int[] { 10, 11, 12 }, xS2.Data<int>());
+            AssertAreEqual(new int[] { 0, 10, 11, 12, 4 }, x.Data<int>());
+        }
+
+        [TestMethod]
+        public void AssignGeneric2DSlice1()
+        {
+            var x = np.arange(9).reshape(3,3).MakeGeneric<int>();
+            var y1 = np.arange(6, 9).MakeGeneric<int>();
+            var y2 = np.arange(12, 15).MakeGeneric<int>();
+
+            AssertAreEqual(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 }, x.Data<int>());
+
+            var xS1 = x["1"];
+            xS1[0] = y1[0];
+            xS1[1] = y1[1];
+            xS1[2] = y1[2];
+
+            AssertAreEqual(new int[] { 6, 7, 8 }, xS1.Data<int>());
+            AssertAreEqual(new int[] { 0, 1, 2, 6, 7, 8, 6, 7, 8 }, x.Data<int>());
+
+            var xS2 = x[new Slice(1, -1)];
+            xS2[":"] = y2;
+
+            AssertAreEqual(new int[] { 12, 13, 14 }, xS2.Data<int>());
+            AssertAreEqual(new int[] { 0, 1, 2, 12, 13, 14, 6, 7, 8 }, x.Data<int>());
+        }
+
+
+        [TestMethod]
         public void SliceNotation()
         {
             // items start through stop-1


### PR DESCRIPTION
Slice assign for generic NDArray<T> added (very primitiv implementation, limited tested and does not support untyped NDArray)
Slice(1, -1) support added (limited test added)
Slice inteface added to generic NDArray<T>.
Slice benchmark tests added and debug of benchmark made easier