### PR TITLE
Support for dotnet pack --version-suffix

### DIFF
--- a/src/NumSharp.Core/NumSharp.Core.csproj
+++ b/src/NumSharp.Core/NumSharp.Core.csproj
@@ -22,7 +22,6 @@
     <FileVersion>0.10.1.0</FileVersion>
     <RepositoryType>git</RepositoryType>
     <PackageTags>NumPy, NumSharp, MachineLearning, Math, Scientific, Numeric</PackageTags>
-    <Version>0.10.1</Version>
     <PackageLicenseUrl></PackageLicenseUrl>
     <LangVersion>latest</LangVersion>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/44989469?s=200&amp;v=4</PackageIconUrl>
@@ -30,6 +29,8 @@
     <Product>NumSharp</Product>
     <Company>SciSharp STACK</Company>
     <RootNamespace>NumSharp</RootNamespace>
+    <Version>0.10.1</Version>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(Version)-$(VersionSuffix)</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^net\d'))">


### PR DESCRIPTION
Support for creating ci build and prerelease versions via
   dotnet pack --version-suffix "ci-x"
while keeping the ability to edit the package inforamtion via Visual Studio GUI