### PR TITLE
 uint16 support for tofile and fromfile and uint16 divide

### DIFF
--- a/src/NumSharp.Core/APIs/np.fromfile.cs
+++ b/src/NumSharp.Core/APIs/np.fromfile.cs
@@ -17,13 +17,26 @@ namespace NumSharp
                     {
                         var fileSize = new System.IO.FileInfo(fileName).Length;
                         var arraySize = fileSize / Marshal.SizeOf(dtype);
-                        var nd = new NDArray(dtype);
+                        byte[] dataArray;
                         using (BinaryReader reader = new BinaryReader(File.Open(fileName, FileMode.Open)))
                         {
-                            var dataArray = reader.ReadBytes((int)arraySize);
-                            nd.SetData(dataArray);
+                            dataArray = reader.ReadBytes((int)arraySize);
                         }
-                        return nd;
+                        return new NDArray(dataArray);
+                    }
+                case TypeCode.UInt16:
+                    {
+                        var fileSize = new System.IO.FileInfo(fileName).Length;
+                        var arraySize = fileSize / Marshal.SizeOf(dtype);
+                        var dataArray = new ushort[arraySize];
+                        using (BinaryReader reader = new BinaryReader(File.Open(fileName, FileMode.Open)))
+                        {
+                            for (var i = 0; i < (int)arraySize; i++)
+                            {
+                                dataArray[i] = reader.ReadUInt16();
+                            }
+                        }
+                        return new NDArray(dataArray);
                     }
             }
             throw new NotImplementedException($"fromfile dtype={dtype} not implemented yet");

--- a/src/NumSharp.Core/APIs/np.tofile.cs
+++ b/src/NumSharp.Core/APIs/np.tofile.cs
@@ -21,6 +21,18 @@ namespace NumSharp
                         }
                     }
                     break;
+                case TypeCode.UInt16:
+                    {
+                        var arr = Array as UInt16[];
+                        using (BinaryWriter writer = new BinaryWriter(File.Open(fileName, FileMode.Create)))
+                        {
+                            for (var i = 0; i < arr.Length; i++)
+                            {
+                                writer.Write(arr[i]);
+                            }
+                        }
+                    }
+                    break;
                 default:
                     throw new NotImplementedException($"tofile dtype={dtype} not implemented yet");
             }            

--- a/src/NumSharp.Core/Backends/Default/Math/Default.Divide.cs
+++ b/src/NumSharp.Core/Backends/Default/Math/Default.Divide.cs
@@ -67,6 +67,56 @@ namespace NumSharp.Backends
             switch (np3SysArr)
             {
 
+                case System.Byte[] resArr:
+                    {
+                        System.Byte[] np1Array = np1SysArr as System.Byte[];
+                        System.Byte[] np2Array = np2SysArr as System.Byte[];
+                        np1Array = (np1Array == null) ? x.CloneData<System.Byte>() : np1Array;
+                        np2Array = (np2Array == null) ? y.CloneData<System.Byte>() : np2Array;
+
+                        if (scalarNo == 0)
+                            for (int idx = 0; idx < np3SysArr.Length; idx++)
+                                resArr[idx] = (byte)(np1Array[idx] / np2Array[idx]);
+                        else if (scalarNo == 1)
+                        {
+                            System.Int32 scalar = x.CloneData<System.Int32>()[0];
+                            for (int idx = 0; idx < np3SysArr.Length; idx++)
+                                resArr[idx] = (byte)(scalar / np2Array[idx]);
+                        }
+                        else if (scalarNo == 2)
+                        {
+                            System.Int32 scalar = y.CloneData<System.Int32>()[0];
+                            for (int idx = 0; idx < np3SysArr.Length; idx++)
+                                resArr[idx] = (byte)(np1Array[idx] / scalar);
+                        }
+                        break;
+                    }
+
+                case System.UInt16[] resArr:
+                    {
+                        System.UInt16[] np1Array = np1SysArr as System.UInt16[];
+                        System.UInt16[] np2Array = np2SysArr as System.UInt16[];
+                        np1Array = (np1Array == null) ? x.CloneData<System.UInt16>() : np1Array;
+                        np2Array = (np2Array == null) ? y.CloneData<System.UInt16>() : np2Array;
+
+                        if (scalarNo == 0)
+                            for (int idx = 0; idx < np3SysArr.Length; idx++)
+                                resArr[idx] = (UInt16)(np1Array[idx] / np2Array[idx]);
+                        else if (scalarNo == 1)
+                        {
+                            System.Int32 scalar = x.CloneData<System.Int32>()[0];
+                            for (int idx = 0; idx < np3SysArr.Length; idx++)
+                                resArr[idx] = (UInt16)(scalar / np2Array[idx]);
+                        }
+                        else if (scalarNo == 2)
+                        {
+                            System.Int32 scalar = y.CloneData<System.Int32>()[0];
+                            for (int idx = 0; idx < np3SysArr.Length; idx++)
+                                resArr[idx] = (UInt16)(np1Array[idx] / scalar);
+                        }
+                        break;
+                    }
+
                 case System.Int32[] resArr:
                     {
                         System.Int32[] np1Array = np1SysArr as System.Int32[];

--- a/src/NumSharp.Core/Backends/TypedArrayStorage.cs
+++ b/src/NumSharp.Core/Backends/TypedArrayStorage.cs
@@ -545,10 +545,21 @@ namespace NumSharp.Backends
                     _arrayInt16[idx] = val;
                     break;
                 case short[] values:
-                    if (indice.Length == 0)
-                        _arrayInt16 = values;
+                    if (value.GetType() == typeof(ushort[]))
+                    {
+                        if (indice.Length == 0)
+                            _arrayUInt16 = value as ushort[];
+                        else
+                            _arrayUInt16.SetValue(values, idx);
+                        break;
+                    }
                     else
-                        _arrayInt16.SetValue(values, idx);
+                    {
+                        if (indice.Length == 0)
+                            _arrayInt16 = values;
+                        else
+                            _arrayInt16.SetValue(values, idx);
+                    }
                     break;
                 case ushort val:
                     _arrayUInt16[idx] = val;

--- a/test/NumSharp.UnitTest/APIs/np.math.Test.cs
+++ b/test/NumSharp.UnitTest/APIs/np.math.Test.cs
@@ -10,7 +10,7 @@ namespace NumSharp.UnitTest.APIs
     public class ApiMathTest
     {
         [TestMethod]
-        public void add()
+        public void AddInt32()
         {
             var x = np.arange(3);
             var y = np.arange(3);
@@ -22,9 +22,23 @@ namespace NumSharp.UnitTest.APIs
             z = np.add(x, y);
             Assert.IsTrue(Enumerable.SequenceEqual(z.Data<int>(), new int[] { 0, 2, 4, 6, 8, 10, 12, 14, 16 }));
         }
+        
+        [TestMethod]
+        public void DivideInt32()
+        {
+            var x = np.arange(1, 4);
+            var y = np.arange(1, 4);
+            var z = np.divide(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<int>(), new int[] { 1, 1, 1 }));
+
+            x = np.arange(1, 10);
+            y = np.arange(1, 10);
+            z = np.divide(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<int>(), new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1 }));
+        }
 
         [TestMethod]
-        public void sum2x2()
+        public void Sum2x2Int32()
         {
             var data = new int[,] { { 0, 1 }, { 0, 5 } };
 
@@ -45,7 +59,7 @@ namespace NumSharp.UnitTest.APIs
         }
 
         [TestMethod]
-         public void sum2x3x2()
+         public void Sum2x3x2Int32()
         {
             var data = np.arange(12).reshape(2, 3, 2);
 
@@ -68,5 +82,62 @@ namespace NumSharp.UnitTest.APIs
             Assert.IsTrue(Enumerable.SequenceEqual(s2.shape, new int[] { 2, 3 }));
             Assert.IsTrue(Enumerable.SequenceEqual(s2.Data<int>(), new int[] { 1, 5, 9, 13, 17, 21 }));
         }
+
+        [TestMethod]
+        public void AddUInt8()
+        {
+            var x = np.arange(3).astype(np.uint8);
+            var y = np.arange(3).astype(np.uint8);
+            var z = np.add(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<Byte>(), new Byte[] { 0, 2, 4 }));
+
+            x = np.arange(9).astype(np.uint8);
+            y = np.arange(9).astype(np.uint8);
+            z = np.add(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<Byte>(), new Byte[] { 0, 2, 4, 6, 8, 10, 12, 14, 16 }));
+        }
+
+        [TestMethod]
+        public void DivideUInt8()
+        {
+            var x = np.arange(1, 4).astype(np.uint8);
+            var y = np.arange(1, 4).astype(np.uint8);
+            var z = np.divide(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<Byte>(), new Byte[] { 1, 1, 1 }));
+
+            x = np.arange(1, 10).astype(np.uint8);
+            y = np.arange(1, 10).astype(np.uint8);
+            z = np.divide(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<Byte>(), new Byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1 }));
+        }
+
+        [TestMethod]
+        public void AddUInt16()
+        {
+            var x = np.arange(3).astype(np.uint16);
+            var y = np.arange(3).astype(np.uint16);
+            var z = np.add(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<UInt16>(), new UInt16[] { 0, 2, 4 }));
+
+            x = np.arange(9).astype(np.uint16);
+            y = np.arange(9).astype(np.uint16);
+            z = np.add(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<UInt16>(), new UInt16[] { 0, 2, 4, 6, 8, 10, 12, 14, 16 }));
+        }
+
+        [TestMethod]
+        public void DivideUInt16()
+        {
+            var x = np.arange(1, 4).astype(np.uint16);
+            var y = np.arange(1, 4).astype(np.uint16);
+            var z = np.divide(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<UInt16>(), new UInt16[] { 1, 1, 1 }));
+
+            x = np.arange(1, 10).astype(np.uint16);
+            y = np.arange(1, 10).astype(np.uint16);
+            z = np.divide(x, y);
+            Assert.IsTrue(Enumerable.SequenceEqual(z.Data<UInt16>(), new UInt16[] { 1, 1, 1, 1, 1, 1, 1, 1, 1 }));
+        }
+
     }
 }

--- a/test/NumSharp.UnitTest/APIs/np.tofromfile.Test.cs
+++ b/test/NumSharp.UnitTest/APIs/np.tofromfile.Test.cs
@@ -8,22 +8,43 @@ using System.Linq;
 namespace NumSharp.UnitTest.APIs
 {
     [TestClass]
-    public class NumpyToFromFileTest
+    public class NumpyToFromFileTest : TestClass
     {
         [TestMethod]
-        public void NumpyToFromFileTest1()
+        public void NumpyToFromFileTestByte1()
         {
             var testString = "Hallo World!";
-            byte[] bytes = Encoding.ASCII.GetBytes(testString);
+            byte[] rawData = Encoding.ASCII.GetBytes(testString);
 
-            NDArray byteArray = np.frombuffer(bytes, np.uint8);
 
-            var testFileName = @"test." + nameof(NumpyToFromFileTest1);
-            byteArray.tofile(testFileName);
+            NDArray ndArray = new NDArray(rawData);
+
+            var testFileName = @"test." + nameof(NumpyToFromFileTestByte1);
+            ndArray.tofile(testFileName);
             var loadedArray = np.fromfile(testFileName, np.uint8);
-            var resultString = Encoding.ASCII.GetString(loadedArray.Data<byte>());
 
-            Assert.IsTrue(testString == resultString);
-        }    
+            Assert.AreEqual(np.uint8, loadedArray.dtype);
+            AssertAreEqual(ndArray.shape, loadedArray.shape);
+            AssertAreEqual(rawData, loadedArray.Array);         
+        }
+
+        [TestMethod]
+        public void NumpyToFromFileTestUShort1()
+        {
+            var testString = "Hallo World!";
+            var testData = Encoding.ASCII.GetBytes(testString);
+            ushort[] testArray = Array.ConvertAll(testData, d => (ushort)d);                                
+
+            NDArray ndArray = new NDArray(testArray);
+
+            var testFileName = @"test." + nameof(NumpyToFromFileTestByte1);
+            ndArray.tofile(testFileName);
+            var loadedArray = np.fromfile(testFileName, np.uint16);
+
+            Assert.AreEqual(np.uint16, loadedArray.dtype);
+            AssertAreEqual(ndArray.shape, loadedArray.shape);
+            AssertAreEqual(testArray, loadedArray.Array);
+        }
+
     }
 }


### PR DESCRIPTION
Includes unit tests for uint16 tofile/fromfile/divide.
Also includ workaround problem detecting correct uint16/int16 type in switch/case statement.

Using C# 7.3 compiler detect uint16/int16 array type incorrectly.  Work arround added for uint16/int16. Same problems also seems to exist for other unsigned/signed combinations:
https://developercommunity.visualstudio.com/content/problem/578478/switch-case-on-int-and-uint-type-alsways-pick-int.html
