### PR TITLE
Added implementation of np.expand_dims(NDArray a, int axis)

### DIFF
--- a/src/NumSharp.Core/Manipulation/np.expand_dims.cs
+++ b/src/NumSharp.Core/Manipulation/np.expand_dims.cs
@@ -1,0 +1,37 @@
+﻿using NumSharp.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NumSharp
+{
+    public static partial class np
+    {
+        private static readonly int[] __one = new int[] {1};
+
+        public static NDArray expand_dims(NDArray a, int axis)
+        {
+            //test if the ndarray is empty.
+            if (a.size == 0)
+                return a;
+
+            var shape = np.array(a.shape);
+            var left = shape[$":{axis}"].Array.Cast<int>();
+            var right = shape[$"{axis}:"].Array.Cast<int>();
+
+            return a.reshape(_combineEnumerables(left, __one, right).ToArray());
+        }
+
+        private static IEnumerable<T> _combineEnumerables<T>(params IEnumerable<T>[] arrays)
+        {
+            foreach (var arr in arrays)
+            {
+                foreach (var val in arr)
+                {
+                    yield return val;
+                }
+            }
+        }
+    }
+}

--- a/test/NumSharp.UnitTest/Manipulation/NDArray.expand_dims.Test.cs
+++ b/test/NumSharp.UnitTest/Manipulation/NDArray.expand_dims.Test.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Numerics;
+using System.Collections.Generic;
+using System.Text;
+using NumSharp.Extensions;
+using System.Linq;
+using NumSharp;
+
+namespace NumSharp.UnitTest
+{
+    [TestClass]
+    public class ExpandDimsTest
+    {
+        [TestMethod]
+        public void Simple1DArrayTo2DArray()
+        {
+            var input = np.array(1, 2, 3);
+            var expected = np.array(new int[] {1, 2, 3});
+
+            var result = np.expand_dims(input, 0);
+
+            Assert.IsTrue(result.shape[0] == 1);
+            Assert.IsTrue(result.shape[1] == 3);
+            Assert.IsTrue(result.ndim == 2);
+            Assert.IsTrue(Enumerable.SequenceEqual(result.Data<int>(), expected.Data<int>()));
+        }
+
+        [TestMethod]
+        public void Simple1DArrayToTransposed2D()
+        {
+            var input = np.array(1, 2, 3);
+            var expected = np.array(new int[] {1, 2, 3});
+
+            var result = np.expand_dims(input, 1);
+
+            Assert.IsTrue(result.shape[0] == 3);
+            Assert.IsTrue(result.shape[1] == 1);
+            Assert.IsTrue(result.ndim == 2);
+            Assert.IsTrue(Enumerable.SequenceEqual(result.Data<int>(), expected.Data<int>()));
+        }
+
+        [TestMethod]
+        public void Simple1DArrayToTransposed3D()
+        {
+            var input = np.array(1, 2, 3);
+            var expected = np.array(new int[] {1, 2, 3});
+
+            var result = np.expand_dims(np.expand_dims(input, 1), 2);
+
+            Assert.IsTrue(result.shape[0] == 3);
+            Assert.IsTrue(result.shape[1] == 1);
+            Assert.IsTrue(result.shape[2] == 1);
+            Assert.IsTrue(result.ndim == 3);
+            Assert.IsTrue(Enumerable.SequenceEqual(result.Data<int>(), expected.Data<int>()));
+        }
+    }
+}


### PR DESCRIPTION
Let me know if you think there is a better/faster way to handle the parsing of the reshape