### PR TITLE
Scalar api, ndarray.sum fixed, backend casting.

### DIFF
--- a/src/NumSharp.Core/APIs/np.logic.cs
+++ b/src/NumSharp.Core/APIs/np.logic.cs
@@ -1,6 +1,7 @@
 ﻿using NumSharp.Backends;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Text;
 using NumSharp.Generic;
 
@@ -114,3 +115,44 @@ namespace NumSharp
         {
             return a.array_equal(b);
         }
+
+        /// <summary>
+        ///     Returns true incase of a number, bool or string. If null, returns false.
+        /// </summary>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.isscalar.html</remarks>
+        public static bool isscalar(object obj)
+        {
+            switch (obj)
+            {
+                case null:
+                    return false;
+                case NDArray nd:
+                    return nd.ndim == 0 && nd.size == 1;
+                case Type _:
+                    break;
+                case Complex _:
+                case string _:
+                case bool _:
+                    return true;
+            }
+
+            var type = obj as Type ?? obj.GetType();
+            if (type.IsArray)
+            {
+                return false;
+            }
+
+            return type.IsPrimitive && (obj is sbyte
+                                        || obj is byte
+                                        || obj is short
+                                        || obj is ushort
+                                        || obj is int
+                                        || obj is uint
+                                        || obj is long
+                                        || obj is ulong
+                                        || obj is float
+                                        || obj is double
+                                        || obj is decimal);
+        }
+    }
+}

--- a/src/NumSharp.Core/APIs/np.logic.cs
+++ b/src/NumSharp.Core/APIs/np.logic.cs
@@ -103,11 +103,14 @@ namespace NumSharp
         public static NDArray<bool> isnan(NDArray a)
             => BackendFactory.GetEngine().IsNan(a);
 
-
+        /// <summary>
+        ///     True if two arrays have the same shape and elements, False otherwise.
+        /// </summary>
+        /// <param name="a">Input array.</param>
+        /// <param name="b">Input array.</param>
+        /// <returns>Returns True if the arrays are equal.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.array_equal.html</remarks>
         public static bool array_equal(NDArray a, NDArray b)
         {
             return a.array_equal(b);
         }
-    }
-}
-

--- a/src/NumSharp.Core/APIs/np.math.cs
+++ b/src/NumSharp.Core/APIs/np.math.cs
@@ -88,20 +88,21 @@ namespace NumSharp
         /// <summary>
         /// Return the product of array elements over a given axis.
         /// </summary>
-        public static NDArray prod(NDArray nd, int axis = -1, Type dtype = null)
+        /// <remarks>https://docs.scipy.org/doc/numpy-1.16.1/reference/generated/numpy.prod.html</remarks>
+        public static NDArray prod(NDArray nd, int axis = -1, Type dtype = null) //todo impl a version with keepdims
             => nd.prod(axis, dtype);
 
         /// <summary>
         /// Numerical positive, element-wise.
         /// </summary>
-        /// <seealso cref="https://docs.scipy.org/doc/numpy/reference/generated/numpy.positive.html"/>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.positive.html</remarks>
         public static NDArray positive(NDArray nd)
             => nd.positive();        
         
         /// <summary>
         /// Numerical negative, element-wise.
         /// </summary>
-        /// <seealso cref="https://docs.scipy.org/doc/numpy/reference/generated/numpy.negative.html"/>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.negative.html</remarks>
         public static NDArray negative(NDArray nd)
             => nd.negative();
     }

--- a/src/NumSharp.Core/APIs/np.statistics.cs
+++ b/src/NumSharp.Core/APIs/np.statistics.cs
@@ -19,6 +19,16 @@ namespace NumSharp
         public static NDArray max(NDArray nd, int axis)
             => nd.max(axis);
 
+        /// <summary>
+        ///     Compute the arithmetic mean along the specified axis.
+        ///     Returns the average of the array elements.
+        ///     The average is taken over the flattened array by default, otherwise over the specified axis.
+        ///     float64 intermediate and return values are used for integer inputs.
+        /// </summary>
+        /// <param name="nd"></param>
+        /// <param name="axis">Axis or axes along which the means are computed. The default is to compute the mean of the flattened array.</param>
+        /// <returns></returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy-1.16.1/reference/generated/numpy.mean.html</remarks>
         public static NDArray mean(NDArray nd, int axis = -1)
             => BackendFactory.GetEngine().Mean(nd, axis);
     }

--- a/src/NumSharp.Core/Backends/ArrayStorage.cs
+++ b/src/NumSharp.Core/Backends/ArrayStorage.cs
@@ -29,7 +29,7 @@ namespace NumSharp.Backends
 
         protected Type _DType;
         protected Shape _Shape;
-        
+
         protected Array _ChangeTypeOfArray(Array arrayVar, Type dtype)
         {
             if (dtype == arrayVar.GetType().GetElementType()) return arrayVar;
@@ -37,52 +37,105 @@ namespace NumSharp.Backends
             _DType = dtype;
             Array newValues = null;
 
-            switch (Type.GetTypeCode(dtype)) 
+            switch (Type.GetTypeCode(dtype))
             {
-                case TypeCode.Double : 
+                case TypeCode.Double:
                 {
                     newValues = new double[arrayVar.Length];
-                    for(int idx = 0;idx < arrayVar.Length;idx++)
-                        newValues.SetValue(Convert.ToDouble(arrayVar.GetValue(idx)),idx);
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToDouble(arrayVar.GetValue(idx)), idx);
                     break;
                 }
-                case TypeCode.Single : 
+
+                case TypeCode.Single:
                 {
                     newValues = new float[arrayVar.Length];
-                    for(int idx = 0;idx < arrayVar.Length;idx++)
-                        newValues.SetValue(Convert.ToSingle(arrayVar.GetValue(idx)),idx);
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToSingle(arrayVar.GetValue(idx)), idx);
                     break;
                 }
-                case TypeCode.Decimal : 
+
+                case TypeCode.Decimal:
                 {
                     newValues = new Decimal[arrayVar.Length];
-                    for(int idx = 0;idx < arrayVar.Length;idx++)
-                        newValues.SetValue(Convert.ToDecimal(arrayVar.GetValue(idx)),idx);
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToDecimal(arrayVar.GetValue(idx)), idx);
                     break;
                 }
-                case TypeCode.Int32 : 
+
+                case TypeCode.Int32:
                 {
                     newValues = new int[arrayVar.Length];
-                    for(int idx = 0;idx < arrayVar.Length;idx++)
-                        newValues.SetValue(Convert.ToInt32(arrayVar.GetValue(idx)),idx);
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToInt32(arrayVar.GetValue(idx)), idx);
                     break;
                 }
-                case TypeCode.Int64 :
+
+                case TypeCode.UInt32:
                 {
-                    newValues = new Int64[arrayVar.Length];
-                    for(int idx = 0;idx < arrayVar.Length;idx++)
-                        newValues.SetValue(Convert.ToInt64(arrayVar.GetValue(idx)),idx);
+                    newValues = new uint[arrayVar.Length];
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToUInt32(arrayVar.GetValue(idx)), idx);
                     break;
                 }
-                case TypeCode.Object : 
+
+                case TypeCode.Int64:
                 {
-                    if( dtype == typeof(System.Numerics.Complex) )
+                    newValues = new long[arrayVar.Length];
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToInt64(arrayVar.GetValue(idx)), idx);
+                    break;
+                }
+
+                case TypeCode.UInt64:
+                {
+                    newValues = new ulong[arrayVar.Length];
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToUInt64(arrayVar.GetValue(idx)), idx);
+                    break;
+                }
+
+                case TypeCode.Int16:
+                {
+                    newValues = new short[arrayVar.Length];
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToInt16(arrayVar.GetValue(idx)), idx);
+                    break;
+                }
+
+                case TypeCode.UInt16:
+                {
+                    newValues = new ushort[arrayVar.Length];
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToUInt16(arrayVar.GetValue(idx)), idx);
+                    break;
+                }
+
+                case TypeCode.Byte:
+                {
+                    newValues = new byte[arrayVar.Length];
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToByte(arrayVar.GetValue(idx)), idx);
+                    break;
+                }
+
+                case TypeCode.SByte:
+                {
+                    newValues = new sbyte[arrayVar.Length];
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ToSByte(arrayVar.GetValue(idx)), idx);
+                    break;
+                }
+
+                default:
+                    if (dtype == typeof(System.Numerics.Complex))
                     {
                         newValues = new System.Numerics.Complex[arrayVar.Length];
-                        for(int idx = 0;idx < arrayVar.Length;idx++)
-                            newValues.SetValue(new System.Numerics.Complex((double)arrayVar.GetValue(idx),0),idx);
+                        for (int idx = 0; idx < arrayVar.Length; idx++)
+                            newValues.SetValue(new System.Numerics.Complex((double)arrayVar.GetValue(idx), 0), idx);
                         break;
                     }
+
                     /*else if ( dtype == typeof(System.Numerics.Quaternion) )
                     {
                         newValues = new System.Numerics.Quaternion[arrayVar.Length];
@@ -90,17 +143,11 @@ namespace NumSharp.Backends
                             newValues.SetValue(new System.Numerics.Quaternion(new System.Numerics.Vector3(0,0,0) , (float)arrayVar.GetValue(idx)),idx);
                         break;
                     }*/
-                    else 
-                    {
-                        newValues = new object[arrayVar.Length];
-                        for(int idx = 0;idx < arrayVar.Length;idx++)
-                            newValues.SetValue(arrayVar.GetValue(idx),idx);
-                        break;
-                    }
-                    
-                }
-                default :
-                    newValues = arrayVar;
+
+                    //fallback
+                    newValues = Array.CreateInstance(dtype, arrayVar.Length);
+                    for (int idx = 0; idx < arrayVar.Length; idx++)
+                        newValues.SetValue(Convert.ChangeType(arrayVar.GetValue(idx), dtype), idx);
                     break;
             }
 
@@ -111,13 +158,13 @@ namespace NumSharp.Backends
         /// Data Type of stored elements
         /// </summary>
         /// <value>numpys equal dtype</value>
-        public Type DType {get {return _DType;}}
+        public Type DType => _DType;
 
         public int DTypeSize
         {
             get
             {
-                if(_DType == typeof(string))
+                if (_DType == typeof(string))
                 {
                     return 0;
                 }
@@ -127,6 +174,7 @@ namespace NumSharp.Backends
                 }
             }
         }
+
         /// <summary>
         /// storage shape for outside representation
         /// </summary>
@@ -178,14 +226,14 @@ namespace NumSharp.Backends
         public void Allocate(Array values)
         {
             int[] dim = new int[values.Rank];
-            for (int idx = 0; idx < dim.Length;idx++)
+            for (int idx = 0; idx < dim.Length; idx++)
                 dim[idx] = values.GetLength(idx);
-            
+
             _Shape = new Shape(dim);
             Type elementType = values.GetType();
             while (elementType.IsArray)
                 elementType = elementType.GetElementType();
-            
+
             _DType = elementType;
         }
 
@@ -197,8 +245,8 @@ namespace NumSharp.Backends
         public IStorage GetColumWiseStorage()
         {
             //if ( _TensorLayout != 2 )
-                //this._ChangeRowToColumnLayout();
-            
+            //this._ChangeRowToColumnLayout();
+
             return this;
         }
 
@@ -283,7 +331,7 @@ namespace NumSharp.Backends
         /// <returns>reference to cloned storage as System.Array</returns>
         public Array CloneData()
         {
-            return (Array) _values.Clone();
+            return (Array)_values.Clone();
         }
 
         /// <summary>
@@ -297,7 +345,7 @@ namespace NumSharp.Backends
             {
                 throw new Exception($"GetData {typeof(T).Name} is not {_DType.Name} of storage.");
             }
-                
+
             return _values as T[];
         }
 
@@ -308,7 +356,7 @@ namespace NumSharp.Backends
         /// <returns>reference to cloned storage as T[]</returns>
         public T[] CloneData<T>()
         {
-            var puffer = (Array) this.GetData().Clone();
+            var puffer = (Array)this.GetData().Clone();
             puffer = _ChangeTypeOfArray(puffer, typeof(T));
 
             return puffer as T[];
@@ -411,7 +459,7 @@ namespace NumSharp.Backends
                         _values.SetValue(values, idx);
                     break;
                 case NDArray nd:
-                    switch(nd.dtype.Name)
+                    switch (nd.dtype.Name)
                     {
                         case "Boolean":
                             _values.SetValue(nd.Data<bool>(0), idx);
@@ -437,11 +485,11 @@ namespace NumSharp.Backends
                         default:
                             throw new NotImplementedException($"SetData<T>(T value, Shape indexes)");
                     }
+
                     break;
                 default:
                     throw new NotImplementedException($"SetData<T>(T value, Shape indexes)");
             }
-                
         }
 
         /// <summary>
@@ -462,7 +510,7 @@ namespace NumSharp.Backends
         public void SetData(Array values, Type dtype)
         {
             _values = _ChangeTypeOfArray(values, dtype);
-        } 
+        }
 
         public void SetNewShape(params int[] dimensions)
         {

--- a/src/NumSharp.Core/Backends/ArrayStorage.cs
+++ b/src/NumSharp.Core/Backends/ArrayStorage.cs
@@ -167,6 +167,7 @@ namespace NumSharp.Backends
 
             if (dtype != null)
                 _DType = dtype;
+
             _values = Array.CreateInstance(_DType, shape.Size);
         }
 
@@ -334,6 +335,7 @@ namespace NumSharp.Backends
         /// <param name="values"></param>
         public void SetData(Array values)
         {
+            //if dtype doesn't match arrays type - change this dtype and attempt to cast.
             if (_DType != values.GetType().GetElementType())
             {
                 _values = _ChangeTypeOfArray(values, _DType);

--- a/src/NumSharp.Core/Backends/BackendFactory.cs
+++ b/src/NumSharp.Core/Backends/BackendFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace NumSharp.Backends
@@ -9,9 +10,10 @@ namespace NumSharp.Backends
         private static Dictionary<BackendType, ITensorEngine> cache
             = new Dictionary<BackendType, ITensorEngine>();
 
+        [DebuggerNonUserCode]
         public static ITensorEngine GetEngine(BackendType backendType = BackendType.SIMD)
         {
-            if(!cache.ContainsKey(backendType))
+            if (!cache.ContainsKey(backendType))
             {
                 switch (backendType)
                 {

--- a/src/NumSharp.Core/Backends/Default/ArrayManipulation/Default.Cast.cs
+++ b/src/NumSharp.Core/Backends/Default/ArrayManipulation/Default.Cast.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Numerics;
+
+namespace NumSharp.Backends
+{
+    public abstract partial class DefaultEngine
+    {
+        public NDArray Cast(NDArray nd, Type dtype, bool copy)
+        {
+            if (dtype == null)
+            {
+                throw new ArgumentNullException(nameof(dtype));
+            }
+
+            NDArray clone()
+            {
+                var copied = new NDArray(dtype);
+                var shapePuffer = new Shape(nd.shape);
+
+                //todo is there a need to allocate first? setdata should be sufficient.
+                copied.Storage.Allocate(shapePuffer);
+
+                copied.Storage.SetData(nd.Storage.CloneData());
+
+                return copied;
+            }
+
+            if (nd.dtype == dtype)
+            {
+                //casting not needed
+                return copy ? clone() : nd;
+            }
+            else
+            {
+                //casting needed
+                if (copy)
+                {
+                    return clone();
+                }
+
+                //just re-set the data, conversion is handled inside.
+                nd.Storage.SetData(nd.Storage.GetData(), dtype);
+                return nd;
+            }
+        }
+    }
+}

--- a/src/NumSharp.Core/Backends/Default/ArrayManipulation/Default.Transpose.cs
+++ b/src/NumSharp.Core/Backends/Default/ArrayManipulation/Default.Transpose.cs
@@ -30,5 +30,4 @@ namespace NumSharp.Backends
             return nd;
         }
     }
-
 }

--- a/src/NumSharp.Core/Backends/Default/Math/Default.Sum.cs
+++ b/src/NumSharp.Core/Backends/Default/Math/Default.Sum.cs
@@ -6,6 +6,7 @@ In case you want to do some changes do the following
 2 ) execute powershell file "GenerateCode.ps1" on root level
 
 */
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -39,19 +40,217 @@ namespace NumSharp.Backends
 
         private NDArray Sum(NDArray x)
         {
-            switch (Type.GetTypeCode(x.dtype))
+            #region Sum Methods
+
+            Double SumDouble(Double[] arr)
             {
-                case TypeCode.Int32:
-                    return x.Data<int>().Sum();
-                case TypeCode.Int64:
-                    return x.Data<long>().Sum();
-                case TypeCode.Single:
-                    return x.Data<float>().Sum();
-                case TypeCode.Double:
-                    return x.Data<double>().Sum();
+                Double sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
             }
 
-            throw new NotImplementedException($"DefaultEngine sum {x.dtype.Name}");
+            Single SumSingle(Single[] arr)
+            {
+                Single sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            Byte SumByte(Byte[] arr)
+            {
+                Byte sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            Int32 SumInt32(Int32[] arr)
+            {
+                Int32 sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            Int64 SumInt64(Int64[] arr)
+            {
+                Int64 sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            SByte SumSByte(SByte[] arr)
+            {
+                SByte sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            Int16 SumInt16(Int16[] arr)
+            {
+                Int16 sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            UInt32 SumUInt32(UInt32[] arr)
+            {
+                UInt32 sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            UInt64 SumUInt64(UInt64[] arr)
+            {
+                UInt64 sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            UInt16 SumUInt16(UInt16[] arr)
+            {
+                UInt16 sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            Decimal SumDecimal(Decimal[] arr)
+            {
+                Decimal sum = 0;
+                checked
+                {
+                    for (int i = 0; i < arr.Length; i++)
+                    {
+                        sum += arr[i];
+                    }
+                }
+
+                return sum;
+            }
+
+            #endregion
+
+            switch (Type.GetTypeCode(x.dtype))
+            {
+                case TypeCode.Double:
+                    return SumDouble(x.Data<Double>());
+                case TypeCode.Single:
+                    return SumSingle(x.Data<Single>());
+                case TypeCode.Byte:
+                case TypeCode.Char:
+                {
+                    var sum = SumByte(x.Data<Byte>());
+                    var nd = new NDArray(typeof(Byte), 1);
+                    nd.Array.SetValue(0, sum);
+                    return nd;
+                }
+
+                case TypeCode.Int32:
+                    return SumInt32(x.Data<Int32>());
+                case TypeCode.Int64:
+                    return SumInt64(x.Data<Int64>());
+                case TypeCode.SByte:
+                    return SumSByte(x.Data<SByte>());
+                case TypeCode.Int16:
+                    return SumInt16(x.Data<Int16>());
+                case TypeCode.UInt32:
+                {
+                    var sum = SumUInt32(x.Data<UInt32>());
+                    var nd = new NDArray(typeof(UInt32), 1);
+                    nd.Array.SetValue(0, sum);
+                    return nd;
+                }
+
+                case TypeCode.UInt64:
+                    return SumUInt64(x.Data<UInt64>());
+                case TypeCode.UInt16:
+                {
+                    var sum = SumUInt16(x.Data<UInt16>());
+                    var nd = new NDArray(typeof(UInt16), 1);
+                    nd.Array.SetValue(0, sum);
+                    return nd;
+                }
+
+                case TypeCode.Decimal:
+                    return SumDecimal(x.Data<Decimal>());
+
+                default:
+                    if (x.dtype == typeof(Complex))
+                    {
+                        var cplx = x.Data<Complex>();
+                        return new Complex(cplx.Select(c => c.Real).Sum(), cplx.Select(c => c.Imaginary).Sum());
+                    }
+
+                    throw new NotImplementedException($"DefaultEngine sum {x.dtype.Name}");
+            }
         }
 
         private NDArray Sum0(NDArray x, int axis)
@@ -63,67 +262,68 @@ namespace NumSharp.Backends
             switch (Type.GetTypeCode(x.dtype))
             {
                 case TypeCode.Int32:
+                {
+                    // allocate continuous memory
+                    var data = new int[size];
+                    switch (shape.Length)
                     {
-                        // allocate continuous memory
-                        var data = new int[size];
-                        switch (shape.Length)
-                        {
-                            case 1:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
+                        case 1:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int a = 0; a < x.shape[axis]; a++)
+                                    data[i] += x.GetInt32(a, d0);
+                                i++;
+                            }
+
+                            break;
+
+                        case 2:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int d1 = 0; d1 < shape[1]; d1++)
                                 {
                                     for (int a = 0; a < x.shape[axis]; a++)
-                                        data[i] += x.GetInt32(a, d0);
+                                        data[i] += x.GetInt32(a, d0, d1);
                                     i++;
                                 }
-                                break;
+                            }
 
-                            case 2:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
-                                {
-                                    for (int d1 = 0; d1 < shape[1]; d1++)
-                                    {
-                                        for (int a = 0; a < x.shape[axis]; a++)
-                                            data[i] += x.GetInt32(a, d0, d1);
-                                        i++;
-                                    }
-                                }
-                                break;
-                                
-                        }
-
-                        return new NDArray(data, shape);
+                            break;
                     }
+
+                    return new NDArray(data, shape);
+                }
 
                 case TypeCode.Single:
+                {
+                    // allocate continuous memory
+                    var data = new float[size];
+                    switch (shape.Length)
                     {
-                        // allocate continuous memory
-                        var data = new float[size];
-                        switch (shape.Length)
-                        {
-                            case 1:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
+                        case 1:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int a = 0; a < x.shape[axis]; a++)
+                                    data[i] += x.GetSingle(a, d0);
+                                i++;
+                            }
+
+                            return new NDArray(data, shape);
+
+                        case 2:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int d1 = 0; d1 < shape[1]; d1++)
                                 {
                                     for (int a = 0; a < x.shape[axis]; a++)
-                                        data[i] += x.GetSingle(a, d0);
+                                        data[i] += x.GetInt32(a, d0, d1);
                                     i++;
                                 }
+                            }
 
-                                return new NDArray(data, shape);
-
-                            case 2:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
-                                {
-                                    for (int d1 = 0; d1 < shape[1]; d1++)
-                                    {
-                                        for (int a = 0; a < x.shape[axis]; a++)
-                                            data[i] += x.GetInt32(a, d0, d1);
-                                        i++;
-                                    }
-                                }
-
-                                return new NDArray(data, shape);
-                        }
+                            return new NDArray(data, shape);
                     }
+                }
                     break;
             }
 
@@ -139,66 +339,70 @@ namespace NumSharp.Backends
             switch (Type.GetTypeCode(x.dtype))
             {
                 case TypeCode.Int32:
+                {
+                    // allocate continuous memory
+                    var data = new int[size];
+                    switch (shape.Length)
                     {
-                        // allocate continuous memory
-                        var data = new int[size];
-                        switch (shape.Length)
-                        {
-                            case 1:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
+                        case 1:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int a = 0; a < x.shape[axis]; a++)
+                                    data[i] += x.GetInt32(d0, a);
+                                i++;
+                            }
+
+                            break;
+
+                        case 2:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int d1 = 0; d1 < shape[1]; d1++)
                                 {
                                     for (int a = 0; a < x.shape[axis]; a++)
-                                        data[i] += x.GetInt32(d0, a);
+                                        data[i] += x.GetInt32(d0, a, d1);
                                     i++;
                                 }
-                                break;
+                            }
 
-                            case 2:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
-                                {
-                                    for (int d1 = 0; d1 < shape[1]; d1++)
-                                    {
-                                        for (int a = 0; a < x.shape[axis]; a++)
-                                            data[i] += x.GetInt32(d0, a, d1);
-                                        i++;
-                                    }
-                                }
-                                break;
-                        }
-
-                        return new NDArray(data, shape);
+                            break;
                     }
+
+                    return new NDArray(data, shape);
+                }
 
                 case TypeCode.Single:
+                {
+                    // allocate continuous memory
+                    var data = new float[size];
+                    switch (shape.Length)
                     {
-                        // allocate continuous memory
-                        var data = new float[size];
-                        switch (shape.Length)
-                        {
-                            case 1:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
+                        case 1:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int a = 0; a < x.shape[axis]; a++)
+                                    data[i] += x.GetSingle(d0, a);
+                                i++;
+                            }
+
+                            break;
+
+                        case 2:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int d1 = 0; d1 < shape[1]; d1++)
                                 {
                                     for (int a = 0; a < x.shape[axis]; a++)
-                                        data[i] += x.GetSingle(d0, a);
+                                        data[i] += x.GetSingle(d0, a, d1);
                                     i++;
                                 }
-                                break;
+                            }
 
-                            case 2:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
-                                {
-                                    for (int d1 = 0; d1 < shape[1]; d1++)
-                                    {
-                                        for (int a = 0; a < x.shape[axis]; a++)
-                                            data[i] += x.GetSingle(d0, a, d1);
-                                        i++;
-                                    }
-                                }
-                                break;
-                        }
-
-                        return new NDArray(data, shape);
+                            break;
                     }
+
+                    return new NDArray(data, shape);
+                }
             }
 
             throw new NotImplementedException($"DefaultEngine sum {x.dtype.Name} axis: {axis}");
@@ -213,53 +417,53 @@ namespace NumSharp.Backends
             switch (Type.GetTypeCode(x.dtype))
             {
                 case TypeCode.Int32:
+                {
+                    // allocate continuous memory
+                    var data = new int[size];
+                    switch (shape.Length)
                     {
-                        // allocate continuous memory
-                        var data = new int[size];
-                        switch (shape.Length)
-                        {
-                            case 2:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
+                        case 2:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int d1 = 0; d1 < shape[1]; d1++)
                                 {
-                                    for (int d1 = 0; d1 < shape[1]; d1++)
-                                    {
-                                        for (int a = 0; a < x.shape[axis]; a++)
-                                            data[i] += x.GetInt32(d0, d1, a);
-                                        i++;
-                                    }
+                                    for (int a = 0; a < x.shape[axis]; a++)
+                                        data[i] += x.GetInt32(d0, d1, a);
+                                    i++;
                                 }
-                                break;
-                        }
+                            }
 
-                        return new NDArray(data, shape);
+                            break;
                     }
+
+                    return new NDArray(data, shape);
+                }
 
                 case TypeCode.Single:
+                {
+                    // allocate continuous memory
+                    var data = new float[size];
+                    switch (shape.Length)
                     {
-                        // allocate continuous memory
-                        var data = new float[size];
-                        switch (shape.Length)
-                        {
-                            case 2:
-                                for (int d0 = 0; d0 < shape[0]; d0++)
+                        case 2:
+                            for (int d0 = 0; d0 < shape[0]; d0++)
+                            {
+                                for (int d1 = 0; d1 < shape[1]; d1++)
                                 {
-                                    for (int d1 = 0; d1 < shape[1]; d1++)
-                                    {
-                                        for (int a = 0; a < x.shape[axis]; a++)
-                                            data[i] += x.GetSingle(d0, d1, a);
-                                        i++;
-                                    }
+                                    for (int a = 0; a < x.shape[axis]; a++)
+                                        data[i] += x.GetSingle(d0, d1, a);
+                                    i++;
                                 }
-                                break;
-                        }
+                            }
 
-                        return new NDArray(data, shape);
+                            break;
                     }
+
+                    return new NDArray(data, shape);
+                }
             }
 
             throw new NotImplementedException($"DefaultEngine sum {x.dtype.Name} axis: {axis}");
         }
     }
-
 }
-

--- a/src/NumSharp.Core/Backends/IStorage.cs
+++ b/src/NumSharp.Core/Backends/IStorage.cs
@@ -35,7 +35,7 @@ namespace NumSharp
         /// storage shape for outside representation
         /// </summary>
         /// <value>numpys equal shape</value>
-        Shape Shape {get;}
+        Shape Shape { get; }
 
         /// <summary>
         /// Allocate memory by dtype, shape, tensororder (default column wise)
@@ -43,11 +43,13 @@ namespace NumSharp
         /// <param name="dtype">storage data type</param>
         /// <param name="shape">storage data shape</param>
         void Allocate(Shape shape, Type dtype = null);
+
         /// <summary>
         /// Allocate memory by Array and tensororder and deduce shape and dtype (default column wise)
         /// </summary>
         /// <param name="values">elements to store</param>
         void Allocate(Array values);
+
         /// <summary>
         /// Get Back Storage with Columnwise tensor Layout
         /// By this method the layout is changed if layout is not columnwise
@@ -65,6 +67,7 @@ namespace NumSharp
         /// </summary>
         /// <returns>reference to internal storage as System.Array</returns>
         Array GetData();
+
         /// <summary>
         /// Clone internal storage and get reference to it
         /// </summary>

--- a/src/NumSharp.Core/Backends/ITensorEngine.cs
+++ b/src/NumSharp.Core/Backends/ITensorEngine.cs
@@ -33,6 +33,8 @@ namespace NumSharp
         #region Array Manipulation
         NDArray NDArray(Shape shape, Type dtype = null, Array buffer = null, string order = "F");
         NDArray Transpose(NDArray nd, int[] axes = null);
+        NDArray Cast(NDArray x, Type dtype, bool copy);
+
         #endregion
 
         #region Sorting, searching, counting

--- a/src/NumSharp.Core/Backends/NDArray.cs
+++ b/src/NumSharp.Core/Backends/NDArray.cs
@@ -66,7 +66,7 @@ namespace NumSharp
         /// The internal storage for elements of NDArray
         /// </summary>
         /// <value>Internal Storage</value>
-        protected IStorage Storage { get; set; }
+        internal IStorage Storage { get; set; }
 
         public ITensorEngine TensorEngine { get; set; }
 
@@ -198,7 +198,7 @@ namespace NumSharp
             var puffer = new NDArray(this.dtype);
             var shapePuffer = new Shape(this.shape);
             puffer.Storage.Allocate(shapePuffer);
-
+            
             puffer.Storage.SetData(this.Storage.CloneData());
 
             return puffer;

--- a/src/NumSharp.Core/Backends/NDArray.cs
+++ b/src/NumSharp.Core/Backends/NDArray.cs
@@ -121,17 +121,7 @@ namespace NumSharp
         // NumPy Signature: ndarray.astype(dtype, order='K', casting='unsafe', subok=True, copy=True)
         public NDArray astype(Type dtype, bool copy = false)
         {
-            if (copy)
-            {
-                var result = new NDArray(dtype, Storage.Shape);
-                result.Storage.SetData(Storage.GetData(), dtype);
-                return result;
-            }
-            else
-            {
-                Storage.SetData(Storage.GetData(), dtype);
-                return this;
-            }
+            return BackendFactory.GetEngine().Cast(this, dtype, copy);
         }
 
         /// <summary>

--- a/src/NumSharp.Core/Casting/Implicit/NdArray.Implicit.ValueTypes.cs
+++ b/src/NumSharp.Core/Casting/Implicit/NdArray.Implicit.ValueTypes.cs
@@ -40,7 +40,7 @@ namespace NumSharp
         public static implicit operator NDArray(bool d)
         {
             var ndArray = new NDArray(typeof(bool), new int[0]);
-            ndArray.Storage.SetData(new bool[] { d });
+            ndArray.Storage.SetData(new bool[] {d});
 
             return ndArray;
         }
@@ -56,7 +56,7 @@ namespace NumSharp
         public static implicit operator NDArray(float d)
         {
             var ndArray = new NDArray(typeof(float), new int[0]);
-            ndArray.Storage.SetData(new float[] { d });
+            ndArray.Storage.SetData(new float[] {d});
 
             return ndArray;
         }
@@ -74,16 +74,8 @@ namespace NumSharp
 
         public static implicit operator NDArray(double d)
         {
-            var ndArray = new NDArray(typeof(double),new int[0]);
-            ndArray.Storage.SetData(new double[] { d });
-
-            return ndArray;
-        }
-
-        public static implicit operator NDArray(decimal d)
-        {
             var ndArray = new NDArray(typeof(double), new int[0]);
-            ndArray.Storage.SetData(new decimal[] { d });
+            ndArray.Storage.SetData(new double[] {d});
 
             return ndArray;
         }
@@ -99,7 +91,7 @@ namespace NumSharp
         public static implicit operator NDArray(short d)
         {
             var ndArray = new NDArray(typeof(short), new int[0]);
-            ndArray.Storage.SetData(new short[] { d });
+            ndArray.Storage.SetData(new short[] {d});
 
             return ndArray;
         }
@@ -114,8 +106,8 @@ namespace NumSharp
 
         public static implicit operator NDArray(int d)
         {
-            var ndArray = new NDArray(typeof(int),new int[0]);
-            ndArray.Storage.SetData(new int[]{d});
+            var ndArray = new NDArray(typeof(int), new int[0]);
+            ndArray.Storage.SetData(new int[] {d});
 
             return ndArray;
         }
@@ -130,8 +122,8 @@ namespace NumSharp
 
         public static implicit operator NDArray(long d)
         {
-            var ndArray = new NDArray(typeof(Int64),new int[0]);
-            ndArray.Storage.SetData(new Int64[]{d});
+            var ndArray = new NDArray(typeof(Int64), new int[0]);
+            ndArray.Storage.SetData(new Int64[] {d});
 
             return ndArray;
         }
@@ -144,10 +136,42 @@ namespace NumSharp
             return nd.Data<long>(0);
         }
 
+        public static implicit operator NDArray(ulong d)
+        {
+            var ndArray = new NDArray(typeof(UInt64), new int[0]);
+            ndArray.Storage.SetData(new UInt64[] {d});
+
+            return ndArray;
+        }
+
+        public static implicit operator ulong(NDArray nd)
+        {
+            if (nd.ndim > 0)
+                throw new IncorrectShapeException();
+
+            return nd.Data<ulong>(0);
+        }
+
+        public static implicit operator NDArray(decimal d)
+        {
+            var ndArray = new NDArray(typeof(decimal), new int[0]);
+            ndArray.Storage.SetData(new decimal[] {d});
+
+            return ndArray;
+        }
+
+        public static implicit operator decimal(NDArray nd)
+        {
+            if (nd.ndim > 0)
+                throw new IncorrectShapeException();
+
+            return nd.Data<decimal>(0);
+        }
+
         public static implicit operator NDArray(Complex d)
         {
-            var ndArray = new NDArray(typeof(Complex),new int[0]);
-            ndArray.Storage.SetData(new Complex[]{d});
+            var ndArray = new NDArray(typeof(Complex), new int[0]);
+            ndArray.Storage.SetData(new Complex[] {d});
 
             return ndArray;
         }

--- a/src/NumSharp.Core/Casting/NdArrayFromMultiDimArr.cs
+++ b/src/NumSharp.Core/Casting/NdArrayFromMultiDimArr.cs
@@ -35,7 +35,7 @@ namespace NumSharp
         /// <param name="dotNetArray"></param>
         public NDArray FromMultiDimArray<T>(Array dotNetArray)
         {
-            if(dotNetArray.GetType().GetElementType().IsArray)
+            if (dotNetArray.GetType().GetElementType().IsArray)
                 throw new Exception("Jagged arrays are not allowed here!");
 
             switch (dotNetArray.Rank)
@@ -48,10 +48,25 @@ namespace NumSharp
                     return np.array((T[,,])dotNetArray);
                 case 4:
                     return np.array((T[,,,])dotNetArray);
+                case 5:
+                    return np.array((T[,,,,])dotNetArray);
+                case 6:
+                    return np.array((T[,,,,,])dotNetArray);
+                case 7:
+                    return np.array((T[,,,,,,])dotNetArray);
+                case 8:
+                    return np.array((T[,,,,,,,])dotNetArray);
+                case 9:
+                    return np.array((T[,,,,,,,,])dotNetArray);
+                case 10:
+                    return np.array((T[,,,,,,,,,])dotNetArray);
+                case 11:
+                    return np.array((T[,,,,,,,,,,])dotNetArray);
+                case 12:
+                    return np.array((T[,,,,,,,,,,,])dotNetArray);
             }
 
             throw new NotImplementedException("FromMultiDimArray<T>(Array dotNetArray)");
         }
-        
     }
 }

--- a/src/NumSharp.Core/Creation/NDArray.Copy.cs
+++ b/src/NumSharp.Core/Creation/NDArray.Copy.cs
@@ -1,15 +1,13 @@
-using System;
+﻿using System;
 
 namespace NumSharp
 {
     public partial class NDArray
     {
         public NDArray copy(string order = null)
-        {   
-            NDArray puffer = this.Clone()  as NDArray;
-
+        {
+            NDArray puffer = this.Clone() as NDArray;
             return puffer;
         }
-
     }
 }

--- a/src/NumSharp.Core/Creation/NdArray.Ones.cs
+++ b/src/NumSharp.Core/Creation/NdArray.Ones.cs
@@ -1,5 +1,6 @@
 ﻿using NumSharp.Backends;
 using System;
+using System.Numerics;
 
 namespace NumSharp
 {
@@ -7,27 +8,29 @@ namespace NumSharp
     {
         public NDArray ones(Type dtype = null, params int[] shapes)
         {
-            dtype = (dtype == null ) ? typeof(double) : dtype;
+            dtype = (dtype == null) ? typeof(double) : dtype;
 
             int dataLength = 1;
-            for (int idx = 0; idx < shapes.Length;idx++)
+            for (int idx = 0; idx < shapes.Length; idx++)
                 dataLength *= shapes[idx];
 
-            Array dataArray = Array.CreateInstance(dtype,dataLength);
+            Array dataArray = Array.CreateInstance(dtype, dataLength);
+            object one = dtype == typeof(Complex) ? new Complex(1d, 0d) : Convert.ChangeType((byte)1, dtype);
 
-            for (int idx = 0; idx < dataLength;idx++)
-                dataArray.SetValue(1,idx);
-            
+            for (int idx = 0; idx < dataLength; idx++)
+                dataArray.SetValue(one, idx);
+
             this.Storage = new ArrayStorage(dtype);
             this.Storage.Allocate(new Shape(shapes));
-            
+
             this.Storage.SetData(dataArray);
 
             return this;
         }
+
         public NDArray ones(params int[] shapes)
         {
-            return this.ones(typeof(double),shapes);
+            return this.ones(typeof(double), shapes);
         }
     }
 }

--- a/src/NumSharp.Core/Creation/NdArray.Scalar.cs
+++ b/src/NumSharp.Core/Creation/NdArray.Scalar.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace NumSharp
+{
+    public partial class NDArray
+    {
+        /// <summary>
+        ///     Creates a scalar <see cref="NDArray"/> of <see cref="value"/> and <see cref="dtype"/>.
+        /// </summary>
+        /// <param name="value">The value of the scalar</param>
+        /// <param name="dtype">The type of the scalar.</param>
+        /// <returns></returns>
+        /// <remarks>In case when <see cref="value"/> is not <see cref="dtype"/>, <see cref="Convert.ChangeType(object,System.Type)"/> will be called.</remarks>
+        public static NDArray Scalar(object value, Type dtype)
+        {
+            var ndArray = new NDArray(dtype, new int[0]);
+            var arr = Array.CreateInstance(dtype, 1);
+            if (dtype != value.GetType())
+                value = Convert.ChangeType(value, dtype);
+
+            arr.SetValue(value, 0);
+            ndArray.Storage.SetData(arr);
+
+            return ndArray;
+        }
+
+        /// <summary>
+        ///     Creates a scalar <see cref="NDArray"/> of <see cref="value"/> from a known type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="value">The value of the scalar</param>
+        /// <param name="dtype">The type of the scalar.</param>
+        /// <returns></returns>
+        /// <remarks>In case when <see cref="value"/> is not <see cref="dtype"/>, <see cref="Convert.ChangeType(object,System.Type)"/> will be called.</remarks>
+        public static NDArray Scalar<T>(T value)
+        {
+            var ndArray = new NDArray(typeof(T), new int[0]);
+            ndArray.Storage.SetData(new T[] {value});
+
+            return ndArray;
+        }
+    }
+}

--- a/src/NumSharp.Core/Creation/np.ones.cs
+++ b/src/NumSharp.Core/Creation/np.ones.cs
@@ -9,59 +9,50 @@ namespace NumSharp
 {
     public static partial class np
     {
+        /// <summary>
+        ///     Return a new array of given shape and type, filled with ones.
+        /// </summary>
+        /// <param name="shapes">Shape of the new array.</param>
+        /// <param name="dtype">The desired data-type for the array, e.g., <see cref="uint8"/>. Default is <see cref="float64"/> / <see cref="double"/>.</param>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.ones.html</remarks>
         public static NDArray ones(params int[] shapes)
         {
-            Type dtype = typeof(double);
-
-            return ones(dtype,shapes);
-        }
-
-        public static NDArray ones(Type dtype = null, params int[] shapes)
-        {
-            dtype = (dtype == null ) ? typeof(double) : dtype;
-
-            return new NDArray(dtype).ones(dtype,shapes);
+            return ones(typeof(double), shapes);
         }
 
         /// <summary>
-        /// Return a new array of given shape and type, filled with ones.
+        ///     Return a new array of given shape and type, filled with ones.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="np"></param>
-        /// <param name="shape"></param>
-        /// <returns></returns>
-        public static NDArray ones(Shape shape, Type dtype = null)
+        /// <param name="shapes">Shape of the new array.</param>
+        /// <param name="dtype">The desired data-type for the array, e.g., <see cref="uint8"/>. Default is <see cref="float64"/> / <see cref="double"/>.</param>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.ones.html</remarks>
+        public static NDArray ones(Type dtype = null, params int[] shapes)
         {
-            if(dtype == null)
-            {
-                dtype = typeof(double);
-            }
-
-            var nd = new NDArray(dtype, shape);
-
-            switch (dtype.Name)
-            {
-                case "Int32":
-                    nd.SetData(Enumerable.Range(0, nd.size).Select(x => 1).ToArray());
-                    break;
-
-                case "Double":
-                    nd.SetData(Enumerable.Range(0, nd.size).Select(x => 1.0).ToArray());
-                    break;
-
-                case "Boolean":
-                   nd.SetData(Enumerable.Range(0, nd.size).Select(x => true).ToArray());
-                    break;
-            }
-
-            return nd;
+            return ones(typeof(double), shapes);
         }
 
+        /// <summary>
+        ///     Return a new array of given shape and type, filled with ones.
+        /// </summary>
+        /// <param name="shapes">Shape of the new array.</param>
+        /// <typeparam name="T">The desired data-type for the array, e.g., <see cref="uint8"/>. Default is <see cref="float64"/> / <see cref="double"/>.</typeparam>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.ones.html</remarks>
         public static NDArray ones<T>(params int[] shapes)
         {
             return ones(new Shape(shapes), typeof(T));
         }
-    }
 
-    
+        /// <summary>
+        ///     Return a new array of given shape and type, filled with ones.
+        /// </summary>
+        /// <param name="shape">Shape of the new array.</param>
+        /// <param name="dtype">The desired data-type for the array, e.g., <see cref="uint8"/>. Default is <see cref="float64"/> / <see cref="double"/>.</param>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.ones.html</remarks>
+        public static NDArray ones(Shape shape, Type dtype = null)
+        {
+            dtype = dtype ?? typeof(double);
+            var nd = new NDArray(dtype, 0).ones(dtype, shape);
+            return nd;
+        }
+    }
 }

--- a/src/NumSharp.Core/Creation/np.ones_like.cs
+++ b/src/NumSharp.Core/Creation/np.ones_like.cs
@@ -9,6 +9,7 @@ namespace NumSharp
     {
         public static NDArray ones_like(NDArray nd, string order = "C")
         {
+            //todo use parameter order.
             return np.ones(new Shape(nd.shape));
         }
     }

--- a/src/NumSharp.Core/Creation/np.zeros.cs
+++ b/src/NumSharp.Core/Creation/np.zeros.cs
@@ -7,28 +7,37 @@ namespace NumSharp
     public static partial class np
     {
         /// <summary>
-        /// Return a new float array of given shape, filled with zeros.
+        ///     Return a new float array of given shape, filled with zeros.
         /// </summary>
-        /// <param name="np"></param>
-        /// <param name="shape"></param>
-        /// <returns></returns>
-        public static NDArray zeros(params int[] shape)
+        /// <param name="shapes">Shape of the new array,</param>
+        /// <returns>Array of zeros with the given shape, dtype.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.zeros.html</remarks>
+        public static NDArray zeros(params int[] shapes)
         {
-            var nd = new NDArray(float64, new Shape(shape));
-            return nd;
+            return zeros(shapes, null); //theres a fallback from null.
         }
 
-        public static NDArray zeros<T>(params int[] shape)
+        /// <summary>
+        ///     Return a new float array of given shape, filled with zeros.
+        /// </summary>
+        /// <param name="shapes">Shape of the new array,</param>
+        /// <returns>Array of zeros with the given shape, type <typeparamref name="T"/>.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.zeros.html</remarks>
+        public static NDArray zeros<T>(params int[] shapes)
         {
-            var nd = new NDArray(typeof(T));
-            nd.reshape(shape);
-
-            return nd;
+            return zeros(shapes, typeof(T));
         }
 
+        /// <summary>
+        ///     Return a new float array of given shape, filled with zeros.
+        /// </summary>
+        /// <param name="shape">Shape of the new array,</param>
+        /// <param name="dtype">The desired data-type for the array, e.g., <see cref="uint8"/>. Default is <see cref="float64"/> / <see cref="double"/>.</param>
+        /// <returns>Array of zeros with the given shape, dtype.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.zeros.html</remarks>
         public static NDArray zeros(Shape shape, Type dtype = null)
         {
-            return new NDArray(dtype == null? float64 : dtype, shape);
+            return new NDArray(dtype ?? np.float64, shape);
         }
     }
 }

--- a/src/NumSharp.Core/Manipulation/np.asscalar.cs
+++ b/src/NumSharp.Core/Manipulation/np.asscalar.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NumSharp
+{
+    public static partial class np
+    {
+        /// <summary>
+        ///     Convert an array of size 1 to its scalar equivalent.
+        /// </summary>
+        /// <param name="nd">Input NDArray of size 1.</param>
+        /// <returns></returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.asscalar.html</remarks>
+        public static T asscalar<T>(NDArray nd)
+        {
+            if (nd.size != 1)
+                throw new IncorrectSizeException("Unable to convert NDArray to scalar because size is not 1.");
+            var value = nd.Storage.GetData().GetValue(0);
+            if (nd.dtype != typeof(T))
+                return (T)Convert.ChangeType(value, typeof(T));
+            return (T)value;
+        }
+
+        /// <summary>
+        ///     Convert an array of size 1 to its scalar equivalent.
+        /// </summary>
+        /// <param name="arr">Input array of size 1.</param>
+        /// <returns></returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.asscalar.html</remarks>
+        public static T asscalar<T>(Array arr)
+        {
+            if (arr.Length != 1)
+                throw new IncorrectSizeException("Unable to convert NDArray to scalar because size is not 1.");
+            var value = arr.GetValue(0);
+            if (value.GetType() != typeof(T))
+                return (T)Convert.ChangeType(value, typeof(T));
+            return (T)value;
+        }
+
+        /// <summary>
+        ///     Convert an array of size 1 to its scalar equivalent.
+        /// </summary>
+        /// <param name="nd">Input NDArray of size 1.</param>
+        /// <returns></returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.asscalar.html</remarks>
+        public static object asscalar(NDArray nd)
+        {
+            if (nd.size != 1)
+                throw new IncorrectSizeException("Unable to convert NDArray to scalar because size is not 1.");
+            return nd.Storage.GetData().GetValue(0);
+        }
+
+        /// <summary>
+        ///     Convert an array of size 1 to its scalar equivalent.
+        /// </summary>
+        /// <param name="arr">Input array of size 1.</param>
+        /// <returns></returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.asscalar.html</remarks>
+        public static object asscalar(Array arr)
+        {
+            if (arr.Length != 1)
+                throw new IncorrectSizeException("Unable to convert NDArray to scalar because size is not 1.");
+            return arr.GetValue(0);
+        }
+    }
+}

--- a/src/NumSharp.Core/Manipulation/np.reshape.cs
+++ b/src/NumSharp.Core/Manipulation/np.reshape.cs
@@ -6,6 +6,13 @@ namespace NumSharp
 {
     public static partial class np
     {
+        /// <summary>
+        ///     Gives a new shape to an array without changing its data.
+        /// </summary>
+        /// <param name="nd">Array to be reshaped.</param>
+        /// <param name="shape">The new shape should be compatible with the original shape. </param>
+        /// <returns>original <paramref name="nd"/> reshaped without copying.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.reshape.html</remarks>
         public static NDArray reshape(NDArray nd, params int[] shape)
         {
             return nd.reshape(shape);

--- a/test/NumSharp.UnitTest/Manipulation/NDArray.astype.Test.cs
+++ b/test/NumSharp.UnitTest/Manipulation/NDArray.astype.Test.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Numerics;
+using System.Collections.Generic;
+using System.Text;
+using NumSharp.Extensions;
+using System.Linq;
+using NumSharp;
+
+namespace NumSharp.UnitTest
+{
+    [TestClass]
+    public class astypeTests
+    {
+        [TestMethod]
+        public void Upcasting()
+        {
+            var nd = np.ones(np.int32, 3, 3, 3);
+            var int64_copied = nd.astype(np.int64, true);
+            var int64 = nd.astype(np.int64, false);
+
+            //test copying
+            Assert.IsTrue(int64_copied.Array!=nd.Array);
+            Assert.IsTrue(int64.Array==nd.Array);
+            Assert.IsTrue(int64_copied.Array.GetType().GetElementType() == typeof(Int64));
+            Assert.IsTrue(int64.Array.GetType().GetElementType() == typeof(Int64));
+        }        
+        
+        [TestMethod]
+        public void UpcastingByteToLong()
+        {
+            var nd = np.ones(np.uint8, 3, 3, 3);
+            var int64_copied = nd.astype(np.int64, true);
+            var int64 = nd.astype(np.int64, false);
+
+            //test copying
+            Assert.IsTrue(int64_copied.Array!=nd.Array);
+            Assert.IsTrue(int64.Array==nd.Array);
+            Assert.IsTrue(int64_copied.Array.GetType().GetElementType() == typeof(Int64));
+            Assert.IsTrue(int64.Array.GetType().GetElementType() == typeof(Int64));
+        }        
+        
+        [TestMethod]
+        public void UpcastingCharsToLong()
+        {
+            var nd = np.ones(np.chars, 3, 3, 3);
+            var int64_copied = nd.astype(np.int64, true);
+            var int64 = nd.astype(np.int64, false);
+
+            //test copying
+            Assert.IsTrue(int64_copied.Array!=nd.Array);
+            Assert.IsTrue(int64.Array==nd.Array);
+            Assert.IsTrue(int64_copied.Array.GetType().GetElementType() == typeof(Int64));
+            Assert.IsTrue(int64.Array.GetType().GetElementType() == typeof(Int64));
+        }        
+        
+        [TestMethod]
+        public void DowncastingIntToShort()
+        {
+            var nd = np.ones(np.int32, 3, 3, 3);
+            var int16_copied = nd.astype(np.int16, true);
+            var int16 = nd.astype(np.int16, false);
+
+            //test copying
+            Assert.IsTrue(int16_copied.Array!=nd.Array);
+            Assert.IsTrue(int16.Array==nd.Array);
+            Assert.IsTrue(int16_copied.Array.GetType().GetElementType() == typeof(Int16));
+            Assert.IsTrue(int16.Array.GetType().GetElementType() == typeof(Int16));
+        }        
+        
+        [TestMethod]
+        public void DowncastingIntToUShort()
+        {
+            var nd = np.ones(np.int32, 3, 3, 3);
+            var int16_copied = nd.astype(np.uint16, true);
+            var int16 = nd.astype(np.uint16, false);
+
+            //test copying
+            Assert.IsTrue(int16_copied.Array!=nd.Array);
+            Assert.IsTrue(int16.Array==nd.Array);
+            Assert.IsTrue(int16_copied.Array.GetType().GetElementType() == typeof(UInt16));
+            Assert.IsTrue(int16.Array.GetType().GetElementType() == typeof(UInt16));
+        }
+
+    }
+}


### PR DESCRIPTION
Hey, commit's descriptions describe exactly what was done.
`np.ones`, `np.zeros` were rewritten to fallback into a single method and `np.ones` implementation fixed. it failed in different dtype cases like `np.ones(np.uint8, ...)`.

I had to change `NDArray.Storage` to internal (from protected) to gain access in the backend engine.

I've added a backend method name Cast as progress with upcasting during math operations (#281).

Note: backend.Sum is still broken for types other than int32 (no due to my changes).