### PR TITLE
Replace incorrectly cached Sharp.size with calculation

### DIFF
--- a/src/NumSharp.Core/Shape.cs
+++ b/src/NumSharp.Core/Shape.cs
@@ -16,7 +16,6 @@ namespace NumSharp
         /// </summary>
         private int layout;
 
-        private int size;
         private int[] dimensions;
         private int[] strides;
 
@@ -31,7 +30,7 @@ namespace NumSharp
         /// <summary>
         ///     The linear size of this shape.
         /// </summary>
-        public int Size => size;
+        public int Size => GetSize(dimensions);
 
         public Shape(params int[] dims)
         {
@@ -151,15 +150,18 @@ namespace NumSharp
             dimensions = dims;
             strides = new int[dimensions.Length];
 
-            size = 1;
-
-            for (int idx = 0; idx < dims.Length; idx++)
-                size *= dims[idx];
             _SetDimOffset();
         }
 
+        /// <summary>
+        /// Defined by the numpy spec as the product of the array's dimensions
+        /// https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.size.html
+        /// </summary>
+        /// <param name="dims"></param>
+        /// <returns></returns>
         public static int GetSize(int[] dims)
         {
+            // Having dims of length 0 implies a scalar, which has size == 1 by definition
             int size = 1;
 
             for (int idx = 0; idx < dims.Length; idx++)

--- a/test/NumSharp.UnitTest/Extensions/NdArray.VStack.Test.cs
+++ b/test/NumSharp.UnitTest/Extensions/NdArray.VStack.Test.cs
@@ -29,19 +29,19 @@ namespace NumSharp.UnitTest.Extensions
             Assert.IsTrue(n[1, 2] == 4);
 
             //2D
-            n1 = np.array(new double[][] { new double[] { 1 }, new double[] { 2 }, new double[] { 3 } });
-            n2 = np.array(new double[][] { new double[] { 4 }, new double[] { 5 }, new double[] { 6 } });
+            var n01 = np.array(new double[][] { new double[] { 1 }, new double[] { 2 }, new double[] { 3 } });
+            var n02 = np.array(new double[][] { new double[] { 4 }, new double[] { 5 }, new double[] { 6 } });
 
-            n = np.vstack<double>(n1, n2).MakeGeneric<double>();
+            var n0 = np.vstack<double>(n01, n02).MakeGeneric<double>();
 
             Assert.IsTrue(n.size == (n1.size + n2.size));
             
-            Assert.IsTrue(n[0, 0] == 1);
-            Assert.IsTrue(n[1, 0] == 2);
-            Assert.IsTrue(n[2, 0] == 3);
-            Assert.IsTrue(n[3, 0] == 4);
-            Assert.IsTrue(n[4, 0] == 5);
-            Assert.IsTrue(n[5, 0] == 6);
+            Assert.IsTrue(n0[0, 0] == 1);
+            Assert.IsTrue(n0[1, 0] == 2);
+            Assert.IsTrue(n0[2, 0] == 3);
+            Assert.IsTrue(n0[3, 0] == 4);
+            Assert.IsTrue(n0[4, 0] == 5);
+            Assert.IsTrue(n0[5, 0] == 6);
         }
     }
 }

--- a/test/NumSharp.UnitTest/Selection/NDArray.AMax.Test.cs
+++ b/test/NumSharp.UnitTest/Selection/NDArray.AMax.Test.cs
@@ -45,6 +45,7 @@ namespace NumSharp.UnitTest.Selection
 
             //2D with axis
             var n1 = np.amax(n, 0).MakeGeneric<int>();
+            Assert.IsTrue(n1.size == 2);
             Assert.IsTrue(n1[0] == 2);
             Assert.IsTrue(n1[1] == 3);
             n1 = np.amax(n, 1).MakeGeneric<int>();


### PR DESCRIPTION
np.amax was returning corrupt Shapes that showed a size of 0 due to the way that Shape.size was being cached. Fixing the caching of size seemed inappropriate given the low cost of the calculation, so I replaced the cached value with the calculation.