### PR TITLE
Slicing: implemented Ellipsis (...)

### DIFF
--- a/src/NumSharp.Core/Backends/Unmanaged/UnmanagedStorage.Slicing.cs
+++ b/src/NumSharp.Core/Backends/Unmanaged/UnmanagedStorage.Slicing.cs
@@ -15,24 +15,53 @@ namespace NumSharp.Backends
         public UnmanagedStorage GetView(string slicing_notation) => GetView(Slice.ParseSlices(slicing_notation));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [SuppressMessage("ReSharper", "PossibleInvalidOperationException")]
         public UnmanagedStorage GetView(params Slice[] slices)
         {
             if (slices == null)
                 throw new ArgumentNullException(nameof(slices));
+            // deal with ellipsis and newaxis if any before continuing into GetViewInternal
             int ellipsis_count = 0;
+            int newaxis_count = 0;
             foreach (var slice in slices)
             {
                 if (slice.IsEllipsis)
                     ellipsis_count++;
                 if (slice.IsNewAxis)
-                    throw new NotSupportedException("np.newaxis slicing is not supported by NumSharp. Consider calling np.expand_dims after performing slicing");
+                    newaxis_count++;
             }
+
+            // deal with ellipsis
             if (ellipsis_count>1)
                 throw new ArgumentException("IndexError: an index can only have a single ellipsis ('...')");
             else if (ellipsis_count == 1)
                 slices = ExpandEllipsis(slices).ToArray();
 
+            // deal with newaxis
+            if (newaxis_count > 0)
+            {
+                var view = this;
+                var axis = 0;
+                foreach (var slice in slices)
+                {
+                    if (slice.IsNewAxis)
+                    {
+                        slices[axis] = Slice.All;
+                        view = view.Alias(view.Shape.ExpandDimension(axis));
+                    }
+                    axis++;
+                }
+                return view.GetViewInternal(slices);
+            }
+
+            // slicing without newaxis
+            return GetViewInternal(slices);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [SuppressMessage("ReSharper", "PossibleInvalidOperationException")]
+        private UnmanagedStorage GetViewInternal(params Slice[] slices)
+        {
+            // NOTE: GetViewInternal can not deal with Slice.Ellipsis or Slice.NewAxis! 
             //handle memory slice if possible
             if (!_shape.IsSliced)
             {
@@ -72,11 +101,20 @@ namespace NumSharp.Backends
 
         private IEnumerable<Slice> ExpandEllipsis(Slice[] slices)
         {
+            // count dimensions without counting ellipsis or newaxis
+            var count = 0;
+            foreach (var slice in slices)
+            {
+                if (slice.IsNewAxis || slice.IsEllipsis)
+                    continue;
+                count++;
+            }
+            // expand 
             foreach (var slice in slices)
             {
                 if (slice.IsEllipsis)
                 {
-                    for(int i=0; i<Shape.NDim-(slices.Length-1); i++)
+                    for(int i=0; i<Shape.NDim-count; i++)
                         yield return Slice.All;
                     continue;
                 }

--- a/test/NumSharp.UnitTest/Shape_and_Slice.Test.cs
+++ b/test/NumSharp.UnitTest/Shape_and_Slice.Test.cs
@@ -386,6 +386,8 @@ namespace NumSharp.UnitTest
             Assert.AreEqual(Slice.All, new Slice(":"));
             Assert.AreEqual(Slice.None, new Slice("0:0"));
             Assert.AreEqual(Slice.Index(17), new Slice("17:18"));
+            Assert.AreEqual(Slice.Ellipsis, new Slice("..."));
+            Assert.AreEqual(Slice.NewAxis, new Slice("np.newaxis"));
 
             // invalid values
             Assert.ThrowsException<ArgumentException>(() => new Slice(""));
@@ -398,13 +400,16 @@ namespace NumSharp.UnitTest
             Assert.ThrowsException<ArgumentException>(() => new Slice("209572048752047520934750283947529083475:"));
             Assert.ThrowsException<ArgumentException>(() => new Slice(":209572048752047520934750283947529083475:2"));
             Assert.ThrowsException<ArgumentException>(() => new Slice("::209572048752047520934750283947529083475"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice(".."));
+            Assert.ThrowsException<ArgumentException>(() => new Slice("...."));
         }
 
         [TestMethod]
         public void N_DimensionalSliceNotation()
         {
-            var s = "1:3,-5:-8,7:8:9,1:,999,:,:1,7::9,:7:9,::-1,-5:-8,5:8";
+            var s = "1:3,-5:-8,7:8:9,...,1:,999,:,:1,7::9,:7:9,::-1,-5:-8,5:8,...";
             Assert.AreEqual(s, Slice.FormatSlices(Slice.ParseSlices(s)));
+            //Assert.AreEqual("...,:,...", Slice.FormatSlices(Slice.ParseSlices("...,...,...,:,...,..."))); // <-- multiple ellipsis at the same location is reduced to one ??? todo test how it works
         }
 
         [TestMethod]

--- a/test/NumSharp.UnitTest/Shape_and_Slice.Test.cs
+++ b/test/NumSharp.UnitTest/Shape_and_Slice.Test.cs
@@ -384,6 +384,7 @@ namespace NumSharp.UnitTest
 
             // Create functions
             Assert.AreEqual(Slice.All, new Slice(":"));
+            Assert.AreEqual(Slice.None, new Slice("0:0"));
             Assert.AreEqual(Slice.Index(17), new Slice("17:18"));
 
             // invalid values

--- a/test/NumSharp.UnitTest/Shape_and_Slice.Test.cs
+++ b/test/NumSharp.UnitTest/Shape_and_Slice.Test.cs
@@ -313,6 +313,100 @@ namespace NumSharp.UnitTest
         }
 
         [TestMethod]
+        public void SliceNotation()
+        {
+            // items start through stop-1
+            Assert.AreEqual("1:3", new Slice("1:3").ToString());
+            Assert.AreEqual("-5:-8", new Slice("-5:-8").ToString());
+            Assert.AreEqual("3:4", new Slice(3, 4).ToString());
+            Assert.AreEqual("7:8:9", new Slice(7, 8, 9).ToString());
+            Assert.AreEqual("7:8:9", new Slice("7:8:9").ToString());
+
+            // items start through the rest of the array
+            Assert.AreEqual("1:", new Slice("1:").ToString());
+            Assert.AreEqual("1:", new Slice(1).ToString());
+            Assert.AreEqual("1:", new Slice(1, null).ToString());
+            Assert.AreEqual("1:", new Slice(1, null, 1).ToString());
+            Assert.AreEqual("7::9", new Slice(7, null, 9).ToString());
+            Assert.AreEqual("7::9", new Slice("7::9").ToString());
+
+            // items from the beginning through stop-1
+            Assert.AreEqual(":2", new Slice(":2").ToString());
+            Assert.AreEqual(":2", new Slice(null, 2).ToString());
+            Assert.AreEqual(":2", new Slice(stop: 2).ToString());
+            Assert.AreEqual(":7:9", new Slice(null, 7, 9).ToString());
+            Assert.AreEqual(":7:9", new Slice(":7:9").ToString());
+
+            // slice a view of the whole array or matrix
+            Assert.AreEqual(":", new Slice(":").ToString());
+            Assert.AreEqual(":", new Slice().ToString());
+            Assert.AreEqual(":", new Slice(null, null).ToString());
+            Assert.AreEqual(":", new Slice(null, null, 1).ToString());
+
+            // step
+            Assert.AreEqual("::-1", new Slice("::- 1").ToString());
+            Assert.AreEqual("::2", new Slice(step: 2).ToString());
+            Assert.AreEqual("::2", new Slice(null, null, 2).ToString());
+
+            // pick exactly one item and reduce the dimension
+            Assert.AreEqual("17", new Slice("17").ToString());
+            // pick exactly one item but keep the dimension
+            Assert.AreEqual("17:18", new Slice("17:18").ToString());
+
+
+            // equality
+            Assert.AreEqual(new Slice("::- 1"), new Slice("::- 1"));
+            Assert.AreEqual(new Slice(":"), new Slice(":"));
+            Assert.AreEqual(new Slice(":7:9"), new Slice(":7:9"));
+            Assert.AreEqual(new Slice(":2"), new Slice(":2"));
+            Assert.AreEqual(new Slice("7::9"), new Slice("7::9"));
+            Assert.AreEqual(new Slice("7:8:9"), new Slice("7:8:9"));
+            Assert.AreEqual(new Slice("17"), new Slice("17"));
+            Assert.AreEqual(new Slice("-5:-8"), new Slice("-5:-8"));
+            Assert.AreEqual(new Slice("-  5:- 8"), new Slice("-5:-8"));
+            Assert.AreEqual(new Slice("+  5:+ 8"), new Slice("+5:8"));
+            Assert.AreEqual(new Slice("        5:    8"), new Slice("+5:8"));
+            Assert.AreEqual(new Slice("\r\n\t:\t  "), new Slice(":"));
+            Assert.AreEqual(new Slice(":\t:\t    \t1"), new Slice(":"));
+            Assert.AreEqual(new Slice("  : \t:\t    \t2  "), new Slice("::2"));
+
+            // inequality
+            Assert.AreNotEqual(new Slice(":"), new Slice("1:"));
+            Assert.AreNotEqual(new Slice(":1"), new Slice("1:"));
+            Assert.AreNotEqual(new Slice(":8:9"), new Slice(":7:9"));
+            Assert.AreNotEqual(new Slice(":7:8"), new Slice(":7:9"));
+            Assert.AreNotEqual(new Slice(":-2"), new Slice(":2"));
+            Assert.AreNotEqual(new Slice("7::9"), new Slice("7::19"));
+            Assert.AreNotEqual(new Slice("17::9"), new Slice("7::9"));
+            Assert.AreNotEqual(new Slice("7:1:9"), new Slice("7::9"));
+            Assert.AreNotEqual(new Slice("7:8:9"), new Slice("7:18:9"));
+            Assert.AreNotEqual(new Slice("-5:-8"), new Slice("-5:-8:2"));
+
+            // Create functions
+            Assert.AreEqual(Slice.All, new Slice(":"));
+            Assert.AreEqual(Slice.Index(17), new Slice("17:18"));
+
+            // invalid values
+            Assert.ThrowsException<ArgumentException>(() => new Slice(""));
+            Assert.ThrowsException<ArgumentException>(() => new Slice(":::"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice("x"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice("0.5:"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice("0.00008"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice("x:y:z"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice("209572048752047520934750283947529083475"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice("209572048752047520934750283947529083475:"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice(":209572048752047520934750283947529083475:2"));
+            Assert.ThrowsException<ArgumentException>(() => new Slice("::209572048752047520934750283947529083475"));
+        }
+
+        [TestMethod]
+        public void N_DimensionalSliceNotation()
+        {
+            var s = "1:3,-5:-8,7:8:9,1:,999,:,:1,7::9,:7:9,::-1,-5:-8,5:8";
+            Assert.AreEqual(s, Slice.FormatSlices(Slice.ParseSlices(s)));
+        }
+
+        [TestMethod]
         public void SliceDef()
         {
             // slice sanitation (prerequisite for shape slicing and correct merging!)

--- a/test/NumSharp.UnitTest/View/NDArray.View.Test.cs
+++ b/test/NumSharp.UnitTest/View/NDArray.View.Test.cs
@@ -39,13 +39,13 @@ namespace NumSharp.UnitTest.View
             // return reduced view
             view = data["7:"];
             Assert.AreEqual(new Shape(3), new Shape(view.shape));
-            AssertAreEqual(new int[] {7, 8, 9}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 7, 8, 9 }, view.ToArray<int>());
             view = data[":5"];
             Assert.AreEqual(new Shape(5), new Shape(view.shape));
-            AssertAreEqual(new int[] {0, 1, 2, 3, 4}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 0, 1, 2, 3, 4 }, view.ToArray<int>());
             view = data["2:3"];
             Assert.AreEqual(new Shape(1), new Shape(view.shape));
-            AssertAreEqual(new int[] {2}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 2 }, view.ToArray<int>());
         }
 
         [TestMethod]
@@ -56,26 +56,26 @@ namespace NumSharp.UnitTest.View
             // return stepped view
             var view = data["::2"];
             Assert.AreEqual(new Shape(5), new Shape(view.shape));
-            AssertAreEqual(new int[] {0, 2, 4, 6, 8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 0, 2, 4, 6, 8 }, view.ToArray<int>());
             view = data["::3"];
             Assert.AreEqual(new Shape(4), new Shape(view.shape));
-            AssertAreEqual(new int[] {0, 3, 6, 9}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 0, 3, 6, 9 }, view.ToArray<int>());
             view = data["-77:77:77"];
             Assert.AreEqual(new Shape(1), new Shape(view.shape));
-            AssertAreEqual(new[] {0}, view.ToArray<int>());
+            AssertAreEqual(new[] { 0 }, view.ToArray<int>());
             // negative step!
             view = data["::-1"];
             Assert.AreEqual(new Shape(10), new Shape(view.shape));
             AssertAreEqual(data.ToArray<int>().OfType<int>().Reverse().ToArray(), view.ToArray<int>());
             view = data["::-2"];
             Assert.AreEqual(new Shape(5), new Shape(view.shape));
-            AssertAreEqual(new int[] {9, 7, 5, 3, 1}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 9, 7, 5, 3, 1 }, view.ToArray<int>());
             view = data["::-3"];
             Assert.AreEqual(new Shape(4), new Shape(view.shape));
-            AssertAreEqual(new int[] {9, 6, 3, 0}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 9, 6, 3, 0 }, view.ToArray<int>());
             view = data["77:-77:-77"];
             Assert.AreEqual(new Shape(1), new Shape(view.shape));
-            AssertAreEqual(new[] {9}, view.ToArray<int>());
+            AssertAreEqual(new[] { 9 }, view.ToArray<int>());
         }
 
         [TestMethod]
@@ -154,12 +154,12 @@ namespace NumSharp.UnitTest.View
             // return identical view
             var view = data[":"];
             Assert.AreEqual(new Shape(10), new Shape(view.shape));
-            AssertAreEqual(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, view.ToArray<int>());
             data[9] = 99;
             Assert.AreEqual(99, (int)view[9]);
             view[1] = 11;
             Assert.AreEqual(11, (int)data[1]);
-            data.SetData(new int[] {0, -1, -2, -3, -4, -5, -6, -7, -8, -9});
+            data.SetData(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, -8, -9 });
             Assert.AreEqual(-1, (int)data[1]);
             Assert.AreEqual(-1, (int)view[1]);
         }
@@ -173,30 +173,30 @@ namespace NumSharp.UnitTest.View
             Assert.AreEqual(new Shape(10), new Shape(identical.shape));
             var view1 = identical["1:9"];
             Assert.AreEqual(new Shape(8), new Shape(view1.shape));
-            AssertAreEqual(new int[] {1, 2, 3, 4, 5, 6, 7, 8,}, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 1, 2, 3, 4, 5, 6, 7, 8, }, view1.ToArray<int>());
             var view2 = view1["4:"];
             Assert.AreEqual(new Shape(4), new Shape(view2.shape));
-            AssertAreEqual(new int[] {5, 6, 7, 8,}, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 5, 6, 7, 8, }, view2.ToArray<int>());
             var view3 = view2[":2"];
             Assert.AreEqual(new Shape(2), new Shape(view3.shape));
-            AssertAreEqual(new int[] {5, 6}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 5, 6 }, view3.ToArray<int>());
             // all must see the same modifications, no matter if original or any view is modified
             // modify original
-            data.SetData(new int[] {0, -1, -2, -3, -4, -5, -6, -7, -8, -9});
-            AssertAreEqual(new int[] {-1, -2, -3, -4, -5, -6, -7, -8,}, view1.ToArray<int>());
-            AssertAreEqual(new int[] {-5, -6, -7, -8,}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {-5, -6}, view3.ToArray<int>());
+            data.SetData(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, -8, -9 });
+            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, -8, }, view1.ToArray<int>());
+            AssertAreEqual(new int[] { -5, -6, -7, -8, }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { -5, -6 }, view3.ToArray<int>());
             // modify views
             view1.SetValue(55, 4);
-            AssertAreEqual(new int[] {0, -1, -2, -3, -4, 55, -6, -7, -8, -9}, data.ToArray<int>());
-            AssertAreEqual(new int[] {-1, -2, -3, -4, 55, -6, -7, -8,}, view1.ToArray<int>());
-            AssertAreEqual(new int[] {55, -6, -7, -8,}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {55, -6}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 0, -1, -2, -3, -4, 55, -6, -7, -8, -9 }, data.ToArray<int>());
+            AssertAreEqual(new int[] { -1, -2, -3, -4, 55, -6, -7, -8, }, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 55, -6, -7, -8, }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 55, -6 }, view3.ToArray<int>());
             view3.SetValue(66, 1);
-            AssertAreEqual(new int[] {0, -1, -2, -3, -4, 55, 66, -7, -8, -9}, data.ToArray<int>());
-            AssertAreEqual(new int[] {-1, -2, -3, -4, 55, 66, -7, -8,}, view1.ToArray<int>());
-            AssertAreEqual(new int[] {55, 66, -7, -8,}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {55, 66,}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 0, -1, -2, -3, -4, 55, 66, -7, -8, -9 }, data.ToArray<int>());
+            AssertAreEqual(new int[] { -1, -2, -3, -4, 55, 66, -7, -8, }, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 55, 66, -7, -8, }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 55, 66, }, view3.ToArray<int>());
         }
 
         [TestMethod]
@@ -208,30 +208,30 @@ namespace NumSharp.UnitTest.View
             Assert.AreEqual(new Shape(10), new Shape(identical.shape));
             var view1 = identical["1:9"];
             Assert.AreEqual(new Shape(8), new Shape(view1.shape));
-            AssertAreEqual(new int[] {1, 2, 3, 4, 5, 6, 7, 8,}, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 1, 2, 3, 4, 5, 6, 7, 8, }, view1.ToArray<int>());
             var view2 = view1["::-2"];
             Assert.AreEqual(new Shape(4), new Shape(view2.shape));
-            AssertAreEqual(new int[] {8, 6, 4, 2,}, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 8, 6, 4, 2, }, view2.ToArray<int>());
             var view3 = view2["::-3"];
             Assert.AreEqual(new Shape(2), new Shape(view3.shape));
-            AssertAreEqual(new int[] {2, 8}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 2, 8 }, view3.ToArray<int>());
             // all must see the same modifications, no matter if original or any view is modified
             // modify original
-            data.SetData(new int[] {0, -1, -2, -3, -4, -5, -6, -7, -8, -9});
-            AssertAreEqual(new int[] {-1, -2, -3, -4, -5, -6, -7, -8,}, view1.ToArray<int>());
-            AssertAreEqual(new int[] {-8, -6, -4, -2,}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {-2, -8}, view3.ToArray<int>());
+            data.SetData(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, -8, -9 });
+            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, -8, }, view1.ToArray<int>());
+            AssertAreEqual(new int[] { -8, -6, -4, -2, }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { -2, -8 }, view3.ToArray<int>());
             // modify views
             view1.SetValue(88, 7);
-            AssertAreEqual(new int[] {0, -1, -2, -3, -4, -5, -6, -7, 88, -9}, data.ToArray<int>());
-            AssertAreEqual(new int[] {-1, -2, -3, -4, -5, -6, -7, 88,}, view1.ToArray<int>());
-            AssertAreEqual(new int[] {88, -6, -4, -2,}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {-2, 88}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, 88, -9 }, data.ToArray<int>());
+            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, 88, }, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 88, -6, -4, -2, }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { -2, 88 }, view3.ToArray<int>());
             view3.SetValue(22, 0);
-            AssertAreEqual(new int[] {0, -1, 22, -3, -4, -5, -6, -7, 88, -9}, data.ToArray<int>());
-            AssertAreEqual(new int[] {-1, 22, -3, -4, -5, -6, -7, 88,}, view1.ToArray<int>());
-            AssertAreEqual(new int[] {88, -6, -4, 22,}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {22, 88}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 0, -1, 22, -3, -4, -5, -6, -7, 88, -9 }, data.ToArray<int>());
+            AssertAreEqual(new int[] { -1, 22, -3, -4, -5, -6, -7, 88, }, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 88, -6, -4, 22, }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 22, 88 }, view3.ToArray<int>());
         }
 
         [TestMethod]
@@ -267,10 +267,10 @@ namespace NumSharp.UnitTest.View
             // return reduced view
             view = data["1:"];
             Assert.AreEqual(new Shape(2, 3), new Shape(view.shape));
-            AssertAreEqual(new int[] {3, 4, 5, 6, 7, 8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 3, 4, 5, 6, 7, 8 }, view.ToArray<int>());
             view = data["1:,:"];
             Assert.AreEqual(new Shape(2, 3), new Shape(view.shape));
-            AssertAreEqual(new int[] {3, 4, 5, 6, 7, 8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 3, 4, 5, 6, 7, 8 }, view.ToArray<int>());
         }
 
         [TestMethod]
@@ -280,10 +280,10 @@ namespace NumSharp.UnitTest.View
             Assert.AreEqual(new Shape(3, 3), new Shape(data.shape));
             var view = data[":,1:"];
             Assert.AreEqual(new Shape(3, 2), new Shape(view.shape));
-            AssertAreEqual(new int[] {1, 2, 4, 5, 7, 8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 1, 2, 4, 5, 7, 8 }, view.ToArray<int>());
             view = data["1:2, 0:1"];
             Assert.AreEqual(new Shape(1, 1), new Shape(view.shape));
-            AssertAreEqual(new int[] {3}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 3 }, view.ToArray<int>());
             // return stepped view
             //>>> x
             //array([[0, 1, 2],
@@ -305,19 +305,19 @@ namespace NumSharp.UnitTest.View
             //array([[6, 7, 8]])
             view = data["::2"];
             Assert.AreEqual(new Shape(2, 3), new Shape(view.shape));
-            AssertAreEqual(new int[] {0, 1, 2, 6, 7, 8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 0, 1, 2, 6, 7, 8 }, view.ToArray<int>());
             view = data["::3"];
             Assert.AreEqual(new Shape(1, 3), new Shape(view.shape));
-            AssertAreEqual(new int[] {0, 1, 2}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 0, 1, 2 }, view.ToArray<int>());
             view = data["::-1"];
             Assert.AreEqual(new Shape(3, 3), new Shape(view.shape));
-            AssertAreEqual(new int[] {6, 7, 8, 3, 4, 5, 0, 1, 2,}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 6, 7, 8, 3, 4, 5, 0, 1, 2, }, view.ToArray<int>());
             view = data["::-2"];
             Assert.AreEqual(new Shape(2, 3), new Shape(view.shape));
-            AssertAreEqual(new int[] {6, 7, 8, 0, 1, 2,}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 6, 7, 8, 0, 1, 2, }, view.ToArray<int>());
             view = data["::-3"];
             Assert.AreEqual(new Shape(1, 3), new Shape(view.shape));
-            AssertAreEqual(new int[] {6, 7, 8,}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 6, 7, 8, }, view.ToArray<int>());
             // N-Dim Stepping
             //>>> x[::2,::2]
             //array([[0, 2],
@@ -328,16 +328,16 @@ namespace NumSharp.UnitTest.View
             //       [2, 0]])
             view = data["::2, ::2"];
             Assert.AreEqual(new Shape(2, 2), new Shape(view.shape));
-            AssertAreEqual(new int[] {0, 2, 6, 8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 0, 2, 6, 8 }, view.ToArray<int>());
             view = data["::-1, ::-2"];
             Assert.AreEqual(new Shape(3, 2), new Shape(view.shape));
-            AssertAreEqual(new int[] {8, 6, 5, 3, 2, 0}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 8, 6, 5, 3, 2, 0 }, view.ToArray<int>());
         }
 
         [TestMethod]
         public void NestedView_2D()
         {
-            var data = np.array(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+            var data = np.array(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
             data = data.reshape(2, 10);
             //>>> x = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
             //>>> x = x.reshape(2, 10)
@@ -352,42 +352,42 @@ namespace NumSharp.UnitTest.View
             //       [1, 2, 3, 4, 5, 6, 7, 8]])
             var view1 = identical[":,1:9"];
             Assert.AreEqual(new Shape(2, 8), new Shape(view1.shape));
-            AssertAreEqual(new int[] {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8 }, view1.ToArray<int>());
             //>>> x[:, 1:9][:,::- 2]
             //array([[8, 6, 4, 2],
             //       [8, 6, 4, 2]])
             var view2 = view1[":,::-2"];
             Assert.AreEqual(new Shape(2, 4), new Shape(view2.shape));
-            AssertAreEqual(new int[] {8, 6, 4, 2, 8, 6, 4, 2}, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 8, 6, 4, 2, 8, 6, 4, 2 }, view2.ToArray<int>());
             //>>> x[:, 1:9][:,::- 2][:,::- 3]
             //array([[2, 8],
             //       [2, 8]])
             var view3 = view2[":,::-3"];
             Assert.AreEqual(new Shape(2, 2), new Shape(view3.shape));
-            AssertAreEqual(new int[] {2, 8, 2, 8}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 2, 8, 2, 8 }, view3.ToArray<int>());
             // all must see the same modifications, no matter if original or any view is modified
             // modify original
-            data.SetData(new int[,] {{0, -1, -2, -3, -4, -5, -6, -7, -8, -9}, {0, -1, -2, -3, -4, -5, -6, -7, -8, -9}});
-            AssertAreEqual(new int[] {-1, -2, -3, -4, -5, -6, -7, -8, -1, -2, -3, -4, -5, -6, -7, -8}, view1.ToArray<int>());
-            AssertAreEqual(new int[] {-8, -6, -4, -2, -8, -6, -4, -2}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {-2, -8, -2, -8}, view3.ToArray<int>());
+            data.SetData(new int[,] { { 0, -1, -2, -3, -4, -5, -6, -7, -8, -9 }, { 0, -1, -2, -3, -4, -5, -6, -7, -8, -9 } });
+            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, -8, -1, -2, -3, -4, -5, -6, -7, -8 }, view1.ToArray<int>());
+            AssertAreEqual(new int[] { -8, -6, -4, -2, -8, -6, -4, -2 }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { -2, -8, -2, -8 }, view3.ToArray<int>());
             // modify views
             view1.SetValue(88, 0, 7);
             view1.SetValue(888, 1, 7);
-            AssertAreEqual(new int[] {0, -1, -2, -3, -4, -5, -6, -7, 88, -9, 0, -1, -2, -3, -4, -5, -6, -7, 888, -9},
+            AssertAreEqual(new int[] { 0, -1, -2, -3, -4, -5, -6, -7, 88, -9, 0, -1, -2, -3, -4, -5, -6, -7, 888, -9 },
                 data.ToArray<int>());
-            AssertAreEqual(new int[] {-1, -2, -3, -4, -5, -6, -7, 88, -1, -2, -3, -4, -5, -6, -7, 888},
+            AssertAreEqual(new int[] { -1, -2, -3, -4, -5, -6, -7, 88, -1, -2, -3, -4, -5, -6, -7, 888 },
                 view1.ToArray<int>());
-            AssertAreEqual(new int[] {88, -6, -4, -2, 888, -6, -4, -2}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {-2, 88, -2, 888}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 88, -6, -4, -2, 888, -6, -4, -2 }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { -2, 88, -2, 888 }, view3.ToArray<int>());
             view3.SetValue(22, 0, 0);
             view3.SetValue(222, 1, 0);
-            AssertAreEqual(new int[] {0, -1, 22, -3, -4, -5, -6, -7, 88, -9, 0, -1, 222, -3, -4, -5, -6, -7, 888, -9},
+            AssertAreEqual(new int[] { 0, -1, 22, -3, -4, -5, -6, -7, 88, -9, 0, -1, 222, -3, -4, -5, -6, -7, 888, -9 },
                 data.ToArray<int>());
-            AssertAreEqual(new int[] {-1, 22, -3, -4, -5, -6, -7, 88, -1, 222, -3, -4, -5, -6, -7, 888},
+            AssertAreEqual(new int[] { -1, 22, -3, -4, -5, -6, -7, 88, -1, 222, -3, -4, -5, -6, -7, 888 },
                 view1.ToArray<int>());
-            AssertAreEqual(new int[] {88, -6, -4, 22, 888, -6, -4, 222}, view2.ToArray<int>());
-            AssertAreEqual(new int[] {22, 88, 222, 888}, view3.ToArray<int>());
+            AssertAreEqual(new int[] { 88, -6, -4, 22, 888, -6, -4, 222 }, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 22, 88, 222, 888 }, view3.ToArray<int>());
         }
 
         [TestMethod]
@@ -398,7 +398,7 @@ namespace NumSharp.UnitTest.View
             // return scalar
             var view = data["7"];
             Assert.AreEqual(Shape.Scalar, new Shape(view.shape));
-            AssertAreEqual(new int[] {7}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 7 }, view.ToArray<int>());
         }
 
         [TestMethod]
@@ -418,15 +418,15 @@ namespace NumSharp.UnitTest.View
             // return identical view
             var view = data["1"];
             Assert.AreEqual(new Shape(3), new Shape(view.shape));
-            AssertAreEqual(new int[] {3, 4, 5}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 3, 4, 5 }, view.ToArray<int>());
             // return reduced view
             view = data["2,2"];
             Assert.AreEqual(Shape.Scalar, new Shape(view.shape));
-            AssertAreEqual(new int[] {8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 8 }, view.ToArray<int>());
             // recursive dimensionality reduction
             view = data["2"]["2"];
             Assert.AreEqual(Shape.Scalar, new Shape(view.shape));
-            AssertAreEqual(new int[] {8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 8 }, view.ToArray<int>());
         }
 
         [TestMethod]
@@ -448,18 +448,18 @@ namespace NumSharp.UnitTest.View
             // return identical view
             var view = data["1"];
             Assert.AreEqual(new Shape(3), new Shape(view.shape));
-            AssertAreEqual(new int[] {3, 4, 5}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 3, 4, 5 }, view.ToArray<int>());
             // return reduced view
             view = data[":,1"];
             Assert.AreEqual(new Shape(3), new Shape(view.shape));
-            AssertAreEqual(new int[] {1, 4, 7}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 1, 4, 7 }, view.ToArray<int>());
             view = data["2,2"];
             Assert.AreEqual(Shape.Scalar, new Shape(view.shape));
-            AssertAreEqual(new int[] {8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 8 }, view.ToArray<int>());
             // recursive dimensionality reduction
             view = data["2"]["2"];
             Assert.AreEqual(Shape.Scalar, new Shape(view.shape));
-            AssertAreEqual(new int[] {8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 8 }, view.ToArray<int>());
         }
 
         [TestMethod]
@@ -483,13 +483,13 @@ namespace NumSharp.UnitTest.View
             Assert.AreEqual(new Shape(3, 3), new Shape(data.shape));
             var view = data["2"];
             Assert.AreEqual(new Shape(3), new Shape(view.shape));
-            AssertAreEqual(new int[] {6, 7, 8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 6, 7, 8 }, view.ToArray<int>());
             var view1 = view["2"];
             Assert.AreEqual(Shape.Scalar, new Shape(view1.shape));
-            AssertAreEqual(new int[] {8}, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 8 }, view1.ToArray<int>());
             var view2 = view[":2:1"];
             Assert.AreEqual(new Shape(2), new Shape(view2.shape));
-            AssertAreEqual(new int[] {6, 7}, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 6, 7 }, view2.ToArray<int>());
         }
 
         [TestMethod]
@@ -499,13 +499,13 @@ namespace NumSharp.UnitTest.View
             Assert.AreEqual(new Shape(3, 3), new Shape(data.shape));
             var view = data["2"];
             Assert.AreEqual(new Shape(3), new Shape(view.shape));
-            AssertAreEqual(new int[] {6, 7, 8}, view.ToArray<int>());
+            AssertAreEqual(new int[] { 6, 7, 8 }, view.ToArray<int>());
             var view1 = view["2"];
             Assert.AreEqual(Shape.Scalar, new Shape(view1.shape));
-            AssertAreEqual(new int[] {8}, view1.ToArray<int>());
+            AssertAreEqual(new int[] { 8 }, view1.ToArray<int>());
             var view2 = view["1::-1"];
             Assert.AreEqual(new Shape(2), new Shape(view2.shape));
-            AssertAreEqual(new int[] {7, 6}, view2.ToArray<int>());
+            AssertAreEqual(new int[] { 7, 6 }, view2.ToArray<int>());
         }
 
         [TestMethod]
@@ -588,11 +588,11 @@ namespace NumSharp.UnitTest.View
             a[Slice.Index(2), Slice.Index(2), Slice.Index(2)].Should().NotBeSliced().And.BeScalar(value: 26);
 
             ret = a[Slice.Index(0), Slice.Index(1)];
-            ret.Should().NotBeSliced().And.BeShaped(3).And.BeOfValues(3,4,5);
+            ret.Should().NotBeSliced().And.BeShaped(3).And.BeOfValues(3, 4, 5);
 
             ret = a[Slice.Index(0), Slice.Index(1), Slice.All];
             ret.Should().NotBeSliced(); //its a a memory slice
-            
+
             ret = a[Slice.Index(0), Slice.All, Slice.Index(1)];
             ret.Should().BeSliced(); //its a a memory slice
         }
@@ -610,15 +610,30 @@ namespace NumSharp.UnitTest.View
             b.Should().BeShaped(1, 3).And.BeOfValues(21, 22, 23);
         }
 
-
         [TestMethod]
         public void SlicingWithEllipsis()
         {
             var a = np.arange(16).reshape(2, 2, 2, 2);
-            a["..., 0"].flatten().ToString().Should().Be("[0, 2, 4, 6, 8, 10, 12, 14]");
-            a["0, ..."].flatten().ToString().Should().Be("[0, 1, 2, 3, 4, 5, 6, 7]");
-            a["0, ... ,0"].flatten().ToString().Should().Be("[0, 2, 4, 6]");
+            a[Slice.Ellipsis].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(2, 2, 2, 2);
+            a["..., 0"].Should().BeOfValues(0, 2, 4, 6, 8, 10, 12, 14).And.BeShaped(2, 2, 2);
+            a["0, ..."].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7).And.BeShaped(2, 2, 2);
+            a["0, ... ,0"].Should().BeOfValues(0, 2, 4, 6).And.BeShaped(2, 2);
             new Action(() => a["..., 0, ..."].flatten()).Should().Throw<ArgumentException>();
         }
+
+        [TestMethod]
+        public void SlicingWithNewAxis()
+        {
+            var a = np.arange(16).reshape(2, 2, 2, 2);
+            a[1, 1, np.newaxis, 1, 1].Should().BeOfValues(15).And.BeShaped(1);
+            a[Slice.NewAxis].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(2, 2, 2, 2, 1);
+            a["..., newaxis"].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(2, 2, 2, 2, 1);
+            a["newaxis, ..."].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(1, 2, 2, 2, 2);
+            a["np.newaxis, ..., np.newaxis"].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(1, 2, 2, 2, 2, 1);
+            a["0, newaxis"].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7).And.BeShaped(1, 2, 2, 2);
+            a["0, newaxis, ... ,0"].Should().BeOfValues(0, 2, 4, 6).And.BeShaped(1, 2, 2);
+            a["0, ..., newaxis, 0"].Should().BeOfValues(0, 2, 4, 6).And.BeShaped(2, 2, 1);
+        }
+
     }
 }

--- a/test/NumSharp.UnitTest/View/NDArray.View.Test.cs
+++ b/test/NumSharp.UnitTest/View/NDArray.View.Test.cs
@@ -609,5 +609,16 @@ namespace NumSharp.UnitTest.View
 
             b.Should().BeShaped(1, 3).And.BeOfValues(21, 22, 23);
         }
+
+
+        [TestMethod]
+        public void SlicingWithEllipsis()
+        {
+            var a = np.arange(16).reshape(2, 2, 2, 2);
+            a["..., 0"].flatten().ToString().Should().Be("[0, 2, 4, 6, 8, 10, 12, 14]");
+            a["0, ..."].flatten().ToString().Should().Be("[0, 1, 2, 3, 4, 5, 6, 7]");
+            a["0, ... ,0"].flatten().ToString().Should().Be("[0, 2, 4, 6]");
+            new Action(() => a["..., 0, ..."].flatten()).Should().Throw<ArgumentException>();
+        }
     }
 }


### PR DESCRIPTION
```C#

        [TestMethod]
        public void SlicingWithEllipsis()
        {
            var a = np.arange(16).reshape(2, 2, 2, 2);
            a[Slice.Ellipsis].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(2, 2, 2, 2);
            a["..., 0"].Should().BeOfValues(0, 2, 4, 6, 8, 10, 12, 14).And.BeShaped(2, 2, 2);
            a["0, ..."].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7).And.BeShaped(2, 2, 2);
            a["0, ... ,0"].Should().BeOfValues(0, 2, 4, 6).And.BeShaped(2, 2);
            new Action(() => a["..., 0, ..."].flatten()).Should().Throw<ArgumentException>();
        }

        [TestMethod]
        public void SlicingWithNewAxis()
        {
            var a = np.arange(16).reshape(2, 2, 2, 2);
            a[1, 1, np.newaxis, 1, 1].Should().BeOfValues(15).And.BeShaped(1);
            a[Slice.NewAxis].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(2, 2, 2, 2, 1);
            a["..., newaxis"].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(2, 2, 2, 2, 1);
            a["newaxis, ..."].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(1, 2, 2, 2, 2);
            a["np.newaxis, ..., np.newaxis"].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).And.BeShaped(1, 2, 2, 2, 2, 1);
            a["0, newaxis"].Should().BeOfValues(0, 1, 2, 3, 4, 5, 6, 7).And.BeShaped(1, 2, 2, 2);
            a["0, newaxis, ... ,0"].Should().BeOfValues(0, 2, 4, 6).And.BeShaped(1, 2, 2);
            a["0, ..., newaxis, 0"].Should().BeOfValues(0, 2, 4, 6).And.BeShaped(2, 2, 1);
        }

```