### PR TITLE
Extending NPY and fixing NPZ

### DIFF
--- a/src/NumSharp.Core/APIs/np.load.cs
+++ b/src/NumSharp.Core/APIs/np.load.cs
@@ -380,6 +380,14 @@ namespace NumSharp
                 return typeof(Int32);
             if (typeCode == "i8")
                 return typeof(Int64);
+            if (typeCode == "u1")
+                return typeof(Byte);
+            if (typeCode == "u2")
+                return typeof(UInt16);
+            if (typeCode == "u4")
+                return typeof(UInt32);
+            if (typeCode == "u8")
+                return typeof(UInt64);
             if (typeCode == "f4")
                 return typeof(Single);
             if (typeCode == "f8")

--- a/src/NumSharp.Core/APIs/np.save.cs
+++ b/src/NumSharp.Core/APIs/np.save.cs
@@ -252,6 +252,12 @@ namespace NumSharp
                 return "<f4";
             if (type == typeof(Double))
                 return "<f8";
+            if (type == typeof(UInt16))
+                return "<u2";
+            if (type == typeof(UInt32))
+                return "<u4";
+            if (type == typeof(UInt64))
+                return "<u8";
             if (type == typeof(String))
                 return "|S" + bytes;
 
@@ -301,12 +307,15 @@ namespace NumSharp
 
         public static void Save_Npz(Dictionary<string, Array> arrays, Stream stream, CompressionLevel compression = DEFAULT_COMPRESSION, bool leaveOpen = false)
         {
-            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: leaveOpen))
             {
                 foreach (KeyValuePair<string, Array> p in arrays)
                 {
                     var entry = zip.CreateEntry(p.Key, compression);
-                    Save(p.Value, entry.Open());
+                    using (Stream s = entry.Open())
+                    {
+                        Save(p.Value, s);
+                    }
                 }
             }
         }
@@ -316,7 +325,11 @@ namespace NumSharp
             using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: leaveOpen))
             {
                 var entry = zip.CreateEntry("arr_0");
-                Save(array, entry.Open());
+                using (Stream s = entry.Open())
+                {
+                    Save(array, s);
+                }
+                
             }
         }
 

--- a/src/NumSharp.Core/Utilities/NpzDictionary.cs
+++ b/src/NumSharp.Core/Utilities/NpzDictionary.cs
@@ -32,7 +32,7 @@ namespace NumSharp
 
             this.entries = new Dictionary<string, ZipArchiveEntry>();
             foreach (var entry in archive.Entries)
-                this.entries[entry.Name] = entry;
+                this.entries[entry.FullName] = entry;
 
             this.arrays = new Dictionary<string, T>();
         }
@@ -79,13 +79,15 @@ namespace NumSharp
         private T OpenEntry(ZipArchiveEntry entry)
         {
             T array;
-            if (arrays.TryGetValue(entry.Name, out array))
+            if (arrays.TryGetValue(entry.FullName, out array))
                 return array;
 
-            Stream s = entry.Open();
-            array = Load_Npz(s);
-            arrays[entry.Name] = array;
-            return array;
+            using (Stream s = entry.Open())
+            {
+                array = Load_Npz(s);
+                arrays[entry.FullName] = array;
+                return array;
+            }
         }
 
         protected virtual T Load_Npz(Stream s)
@@ -111,13 +113,13 @@ namespace NumSharp
         public IEnumerator<KeyValuePair<string, T>> GetEnumerator()
         {
             foreach (var entry in archive.Entries)
-                yield return new KeyValuePair<string, T>(entry.Name, OpenEntry(entry));
+                yield return new KeyValuePair<string, T>(entry.FullName, OpenEntry(entry));
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
             foreach (var entry in archive.Entries)
-                yield return new KeyValuePair<string, T>(entry.Name, OpenEntry(entry));
+                yield return new KeyValuePair<string, T>(entry.FullName, OpenEntry(entry));
         }
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator()

--- a/test/NumSharp.UnitTest/APIs/np.load.Test.cs
+++ b/test/NumSharp.UnitTest/APIs/np.load.Test.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NumSharp;
 using System;
 using System.Collections.Generic;
@@ -27,6 +27,20 @@ namespace NumSharp.UnitTest.APIs
             Assert.IsTrue(arr[1] == 1);
             Assert.IsTrue(arr[2] == 2);
             Assert.IsTrue(arr[3] == 3);
+        }
+
+        [TestMethod]
+        public void NumpyNPZRoundTripTest()
+        {
+            int[] arr = np.Load<int[]>(@"data/1-dim-int32_4_comma_empty.npy");
+            var d = new Dictionary<string, Array>();
+            d.Add("A/A",arr);
+            d.Add("B/A",arr); // Tests zip entity.Name
+            var ms = new System.IO.MemoryStream();
+            np.Save_Npz(d,ms,leaveOpen:true);
+            ms.Position = 0L;
+            var d2 = np.Load_Npz<Array>(ms);
+            Assert.IsTrue(d2.Count == 2);
         }
     }
 }


### PR DESCRIPTION
I'm using NPZ files for weights. I'd like to use NumSharp for this.

* NPY supporting UInts..
* NPZ load; entry.Name -> entry.FullName
* NPZ open; using given leaveOpen value with the default of false