### PR TITLE
Add missing casting operators and rewrite bitwise AND for NDArray

### DIFF
--- a/src/NumSharp.Core/Backends/NPTypeCode.cs
+++ b/src/NumSharp.Core/Backends/NPTypeCode.cs
@@ -23,6 +23,9 @@ namespace NumSharp
         /// <summary>An integral type representing unsigned 16-bit integers with values between 0 and 65535. The set of possible values for the <see cref="F:System.TypeCode.Char"></see> type corresponds to the Unicode character set.</summary>
         Char = 4,
 
+        /// <summary>An integral type representing unsigned 8-bit integers with values between -128 and 127.</summary>
+        SByte = 5,
+
         /// <summary>An integral type representing unsigned 8-bit integers with values between 0 and 255.</summary>
         Byte = 6,
 
@@ -134,6 +137,7 @@ namespace NumSharp
 #else
                 case NPTypeCode.Complex: return typeof(Complex);
                 case NPTypeCode.Boolean: return typeof(bool);
+                case NPTypeCode.SByte: return typeof(sbyte);
                 case NPTypeCode.Byte: return typeof(byte);
                 case NPTypeCode.Int16: return typeof(short);
                 case NPTypeCode.UInt16: return typeof(ushort);
@@ -183,6 +187,7 @@ namespace NumSharp
 #else
                 case NPTypeCode.Complex: return InfoOf<Complex>.Size;
                 case NPTypeCode.Boolean: return 1;
+                case NPTypeCode.SByte: return 1;
                 case NPTypeCode.Byte: return 1;
                 case NPTypeCode.Int16: return 2;
                 case NPTypeCode.UInt16: return 2;
@@ -219,6 +224,7 @@ namespace NumSharp
 #else
                 case NPTypeCode.Complex: return true;
                 case NPTypeCode.Boolean: return false;
+                case NPTypeCode.SByte: return false;
                 case NPTypeCode.Byte: return false;
                 case NPTypeCode.Int16: return false;
                 case NPTypeCode.UInt16: return false;
@@ -255,6 +261,7 @@ namespace NumSharp
 #else
                 case NPTypeCode.Complex: return false;
                 case NPTypeCode.Boolean: return true;
+                case NPTypeCode.SByte: return true;
                 case NPTypeCode.Byte: return true;
                 case NPTypeCode.Int16: return false;
                 case NPTypeCode.UInt16: return true;
@@ -291,6 +298,7 @@ namespace NumSharp
 #else
                 case NPTypeCode.Complex: return false;
                 case NPTypeCode.Boolean: return false;
+                case NPTypeCode.SByte: return false;
                 case NPTypeCode.Byte: return false;
                 case NPTypeCode.Int16: return true;
                 case NPTypeCode.UInt16: return false;
@@ -328,6 +336,7 @@ namespace NumSharp
                 case NPTypeCode.Boolean: return -1;
                 
                 case NPTypeCode.String: return 0;
+                case NPTypeCode.SByte: return 0;
                 case NPTypeCode.Byte: return 0;
                 case NPTypeCode.Char: return 0;
 
@@ -369,6 +378,7 @@ namespace NumSharp
 #else
                 case NPTypeCode.Boolean: return 0;
                 case NPTypeCode.String: return 0;
+                case NPTypeCode.SByte: return 0;
                 case NPTypeCode.Byte: return 0;
                 case NPTypeCode.Char: return 0;
 
@@ -404,11 +414,10 @@ namespace NumSharp
                     return NPTypeCode.Boolean;
 
                 case NPY_TYPECHAR.NPY_BYTELTR:
-                    return NPTypeCode.Byte;
+                    return NPTypeCode.SByte;
 
                 case NPY_TYPECHAR.NPY_UBYTELTR:
-                    //case NPY_TYPECHAR.NPY_CHARLTR: //char has been deprecated in favor of string.
-                    return NPTypeCode.Char;
+                    return NPTypeCode.Byte;
 
                 case NPY_TYPECHAR.NPY_SHORTLTR:
                     return NPTypeCode.Int16;
@@ -454,8 +463,6 @@ namespace NumSharp
                 case NPY_TYPECHAR.NPY_COMPLEXLTR:
                     return NPTypeCode.Complex;
 
-                    return NPTypeCode.Decimal;
-
                 default:
                     throw new NotSupportedException($"NPY_TYPECHAR of type {typeCode} is not supported.");
             }
@@ -476,8 +483,10 @@ namespace NumSharp
                     return NPY_TYPECHAR.NPY_BOOLLTR;
                 case NPTypeCode.Char:
                     return NPY_TYPECHAR.NPY_CHARLTR;
-                case NPTypeCode.Byte:
+                case NPTypeCode.SByte:
                     return NPY_TYPECHAR.NPY_BYTELTR;
+                case NPTypeCode.Byte:
+                    return NPY_TYPECHAR.NPY_UBYTELTR;
                 case NPTypeCode.Int16:
                     return NPY_TYPECHAR.NPY_SHORTLTR;
                 case NPTypeCode.UInt16:
@@ -541,6 +550,8 @@ namespace NumSharp
                     return "bool";
                 case NPTypeCode.Char:
                     return "uint8";
+                case NPTypeCode.SByte:
+                    return "int8";
                 case NPTypeCode.Byte:
                     return "uint8";
                 case NPTypeCode.Int16:
@@ -604,6 +615,7 @@ namespace NumSharp
 		    switch (typeCode)
 		    {
 			    case NPTypeCode.Boolean: return NPTypeCode.Int32;
+			    case NPTypeCode.SByte: return NPTypeCode.Int32;
 			    case NPTypeCode.Byte: return NPTypeCode.UInt32;
 			    case NPTypeCode.Int16: return NPTypeCode.Int32;
 			    case NPTypeCode.UInt16: return NPTypeCode.UInt32;
@@ -645,6 +657,7 @@ namespace NumSharp
 		    switch (typeCode)
 		    {
 			    case NPTypeCode.Boolean: return default(bool);
+			    case NPTypeCode.SByte: return default(sbyte);
 			    case NPTypeCode.Byte: return default(byte);
 			    case NPTypeCode.Int16: return default(short);
 			    case NPTypeCode.UInt16: return default(ushort);

--- a/src/NumSharp.Core/Backends/Unmanaged/ArraySlice.cs
+++ b/src/NumSharp.Core/Backends/Unmanaged/ArraySlice.cs
@@ -27,6 +27,7 @@ namespace NumSharp.Backends.Unmanaged
 #else
 
                 case NPTypeCode.Boolean: return new ArraySlice<Boolean>(UnmanagedMemoryBlock<Boolean>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToBoolean(CultureInfo.InvariantCulture)};
+                case NPTypeCode.SByte: return new ArraySlice<SByte>(UnmanagedMemoryBlock<SByte>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToSByte(CultureInfo.InvariantCulture)};
                 case NPTypeCode.Byte: return new ArraySlice<Byte>(UnmanagedMemoryBlock<Byte>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToByte(CultureInfo.InvariantCulture)};
                 case NPTypeCode.Int16: return new ArraySlice<Int16>(UnmanagedMemoryBlock<Int16>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToInt16(CultureInfo.InvariantCulture)};
                 case NPTypeCode.UInt16: return new ArraySlice<UInt16>(UnmanagedMemoryBlock<UInt16>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToUInt16(CultureInfo.InvariantCulture)};
@@ -63,6 +64,7 @@ namespace NumSharp.Backends.Unmanaged
 #else
 
                 case NPTypeCode.Boolean: return new ArraySlice<Boolean>(UnmanagedMemoryBlock<Boolean>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToBoolean(CultureInfo.InvariantCulture)};
+                case NPTypeCode.SByte: return new ArraySlice<SByte>(UnmanagedMemoryBlock<SByte>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToSByte(CultureInfo.InvariantCulture)};
                 case NPTypeCode.Byte: return new ArraySlice<Byte>(UnmanagedMemoryBlock<Byte>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToByte(CultureInfo.InvariantCulture)};
                 case NPTypeCode.Int16: return new ArraySlice<Int16>(UnmanagedMemoryBlock<Int16>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToInt16(CultureInfo.InvariantCulture)};
                 case NPTypeCode.UInt16: return new ArraySlice<UInt16>(UnmanagedMemoryBlock<UInt16>.FromPool(_buffer)) {[0] = ((IConvertible)val).ToUInt16(CultureInfo.InvariantCulture)};
@@ -218,6 +220,7 @@ namespace NumSharp.Backends.Unmanaged
 		            throw new NotSupportedException();
 #else
                 case NPTypeCode.Boolean: return new ArraySlice<bool>(UnmanagedMemoryBlock<bool>.FromArray(copy ? (bool[])arr.Clone() : (bool[])arr));
+                case NPTypeCode.SByte: return new ArraySlice<sbyte>(UnmanagedMemoryBlock<sbyte>.FromArray(copy ? (sbyte[])arr.Clone() : (sbyte[])arr));
                 case NPTypeCode.Byte: return new ArraySlice<byte>(UnmanagedMemoryBlock<byte>.FromArray(copy ? (byte[])arr.Clone() : (byte[])arr));
                 case NPTypeCode.Int16: return new ArraySlice<short>(UnmanagedMemoryBlock<short>.FromArray(copy ? (short[])arr.Clone() : (short[])arr));
                 case NPTypeCode.UInt16: return new ArraySlice<ushort>(UnmanagedMemoryBlock<ushort>.FromArray(copy ? (ushort[])arr.Clone() : (ushort[])arr));
@@ -256,6 +259,7 @@ namespace NumSharp.Backends.Unmanaged
 #else
 
                     case NPTypeCode.Boolean: return new ArraySlice<bool>(copy ? ((UnmanagedMemoryBlock<bool>)block).Clone() : (UnmanagedMemoryBlock<bool>)block);
+                    case NPTypeCode.SByte: return new ArraySlice<sbyte>(copy ? ((UnmanagedMemoryBlock<sbyte>)block).Clone() : (UnmanagedMemoryBlock<sbyte>)block);
                     case NPTypeCode.Byte: return new ArraySlice<byte>(copy ? ((UnmanagedMemoryBlock<byte>)block).Clone() : (UnmanagedMemoryBlock<byte>)block);
                     case NPTypeCode.Int16: return new ArraySlice<short>(copy ? ((UnmanagedMemoryBlock<short>)block).Clone() : (UnmanagedMemoryBlock<short>)block);
                     case NPTypeCode.UInt16: return new ArraySlice<ushort>(copy ? ((UnmanagedMemoryBlock<ushort>)block).Clone() : (UnmanagedMemoryBlock<ushort>)block);
@@ -281,6 +285,7 @@ namespace NumSharp.Backends.Unmanaged
         %
 #else
         public static ArraySlice<bool> FromArray(bool[] bools, bool copy = false) => new ArraySlice<bool>(UnmanagedMemoryBlock<bool>.FromArray(bools, copy));
+        public static ArraySlice<sbyte> FromArray(sbyte[] bytes, bool copy = false) => new ArraySlice<sbyte>(UnmanagedMemoryBlock<sbyte>.FromArray(bytes, copy));
         public static ArraySlice<byte> FromArray(byte[] bytes, bool copy = false) => new ArraySlice<byte>(UnmanagedMemoryBlock<byte>.FromArray(bytes, copy));
         public static ArraySlice<short> FromArray(short[] shorts, bool copy = false) => new ArraySlice<short>(UnmanagedMemoryBlock<short>.FromArray(shorts, copy));
         public static ArraySlice<ushort> FromArray(ushort[] ushorts, bool copy = false) => new ArraySlice<ushort>(UnmanagedMemoryBlock<ushort>.FromArray(ushorts, copy));
@@ -306,6 +311,7 @@ namespace NumSharp.Backends.Unmanaged
 		            throw new NotSupportedException();
 #else
                 case NPTypeCode.Boolean: return new ArraySlice<bool>(new UnmanagedMemoryBlock<bool>(count, ((IConvertible)fill).ToBoolean(CultureInfo.InvariantCulture)));
+                case NPTypeCode.SByte: return new ArraySlice<sbyte>(new UnmanagedMemoryBlock<sbyte>(count, ((IConvertible)fill).ToSByte(CultureInfo.InvariantCulture)));
                 case NPTypeCode.Byte: return new ArraySlice<byte>(new UnmanagedMemoryBlock<byte>(count, ((IConvertible)fill).ToByte(CultureInfo.InvariantCulture)));
                 case NPTypeCode.Int16: return new ArraySlice<short>(new UnmanagedMemoryBlock<short>(count, ((IConvertible)fill).ToInt16(CultureInfo.InvariantCulture)));
                 case NPTypeCode.UInt16: return new ArraySlice<ushort>(new UnmanagedMemoryBlock<ushort>(count, ((IConvertible)fill).ToUInt16(CultureInfo.InvariantCulture)));
@@ -338,6 +344,7 @@ namespace NumSharp.Backends.Unmanaged
 		            throw new NotSupportedException();
 #else
                 case NPTypeCode.Boolean: return new ArraySlice<bool>(new UnmanagedMemoryBlock<bool>(count, default));
+                case NPTypeCode.SByte: return new ArraySlice<sbyte>(new UnmanagedMemoryBlock<sbyte>(count, default));
                 case NPTypeCode.Byte: return new ArraySlice<byte>(new UnmanagedMemoryBlock<byte>(count, default));
                 case NPTypeCode.Int16: return new ArraySlice<short>(new UnmanagedMemoryBlock<short>(count, default));
                 case NPTypeCode.UInt16: return new ArraySlice<ushort>(new UnmanagedMemoryBlock<ushort>(count, default));
@@ -367,6 +374,7 @@ namespace NumSharp.Backends.Unmanaged
 		            throw new NotSupportedException();
 #else
                 case NPTypeCode.Boolean: return new ArraySlice<bool>(new UnmanagedMemoryBlock<bool>(count));
+                case NPTypeCode.SByte: return new ArraySlice<sbyte>(new UnmanagedMemoryBlock<sbyte>(count));
                 case NPTypeCode.Byte: return new ArraySlice<byte>(new UnmanagedMemoryBlock<byte>(count));
                 case NPTypeCode.Int16: return new ArraySlice<short>(new UnmanagedMemoryBlock<short>(count));
                 case NPTypeCode.UInt16: return new ArraySlice<ushort>(new UnmanagedMemoryBlock<ushort>(count));
@@ -396,6 +404,7 @@ namespace NumSharp.Backends.Unmanaged
 		            throw new NotSupportedException();
 #else
                 case NPTypeCode.Boolean: return new ArraySlice<bool>(new UnmanagedMemoryBlock<bool>(count, ((IConvertible)fill).ToBoolean(CultureInfo.InvariantCulture)));
+                case NPTypeCode.SByte: return new ArraySlice<sbyte>(new UnmanagedMemoryBlock<sbyte>(count, ((IConvertible)fill).ToSByte(CultureInfo.InvariantCulture)));
                 case NPTypeCode.Byte: return new ArraySlice<byte>(new UnmanagedMemoryBlock<byte>(count, ((IConvertible)fill).ToByte(CultureInfo.InvariantCulture)));
                 case NPTypeCode.Int16: return new ArraySlice<short>(new UnmanagedMemoryBlock<short>(count, ((IConvertible)fill).ToInt16(CultureInfo.InvariantCulture)));
                 case NPTypeCode.UInt16: return new ArraySlice<ushort>(new UnmanagedMemoryBlock<ushort>(count, ((IConvertible)fill).ToUInt16(CultureInfo.InvariantCulture)));
@@ -428,6 +437,7 @@ namespace NumSharp.Backends.Unmanaged
 		            throw new NotSupportedException();
 #else
                 case NPTypeCode.Boolean: return new ArraySlice<bool>(new UnmanagedMemoryBlock<bool>(count, default));
+                case NPTypeCode.SByte: return new ArraySlice<sbyte>(new UnmanagedMemoryBlock<sbyte>(count, default));
                 case NPTypeCode.Byte: return new ArraySlice<byte>(new UnmanagedMemoryBlock<byte>(count, default));
                 case NPTypeCode.Int16: return new ArraySlice<short>(new UnmanagedMemoryBlock<short>(count, default));
                 case NPTypeCode.UInt16: return new ArraySlice<ushort>(new UnmanagedMemoryBlock<ushort>(count, default));
@@ -457,6 +467,7 @@ namespace NumSharp.Backends.Unmanaged
 		            throw new NotSupportedException();
 #else
                 case NPTypeCode.Boolean: return new ArraySlice<bool>(new UnmanagedMemoryBlock<bool>(count));
+                case NPTypeCode.SByte: return new ArraySlice<sbyte>(new UnmanagedMemoryBlock<sbyte>(count));
                 case NPTypeCode.Byte: return new ArraySlice<byte>(new UnmanagedMemoryBlock<byte>(count));
                 case NPTypeCode.Int16: return new ArraySlice<short>(new UnmanagedMemoryBlock<short>(count));
                 case NPTypeCode.UInt16: return new ArraySlice<ushort>(new UnmanagedMemoryBlock<ushort>(count));

--- a/src/NumSharp.Core/Backends/Unmanaged/UnmanagedStorage.Getters.cs
+++ b/src/NumSharp.Core/Backends/Unmanaged/UnmanagedStorage.Getters.cs
@@ -217,6 +217,15 @@ namespace NumSharp.Backends
             => _arrayBoolean[_shape.GetOffset(indices)];
 
         /// <summary>
+        ///     Retrieves value of type <see cref="sbyte"/> from internal storage.
+        /// </summary>
+        /// <param name="indices">The shape's indices to get.</param>
+        /// <returns></returns>
+        /// <exception cref="NullReferenceException">When <see cref="DType"/> is not <see cref="sbyte"/></exception>
+        public sbyte GetSByte(params int[] indices)
+            => _arraySByte[_shape.GetOffset(indices)];
+
+        /// <summary>
         ///     Retrieves value of type <see cref="byte"/> from internal storage.
         /// </summary>
         /// <param name="indices">The shape's indices to get.</param>

--- a/src/NumSharp.Core/Backends/Unmanaged/UnmanagedStorage.cs
+++ b/src/NumSharp.Core/Backends/Unmanaged/UnmanagedStorage.cs
@@ -30,6 +30,7 @@ namespace NumSharp.Backends
         protected ArraySlice<#2> _array#1;
 #else
         protected ArraySlice<bool> _arrayBoolean;
+        protected ArraySlice<sbyte> _arraySByte;
         protected ArraySlice<byte> _arrayByte;
         protected ArraySlice<short> _arrayInt16;
         protected ArraySlice<ushort> _arrayUInt16;
@@ -242,6 +243,19 @@ namespace NumSharp.Backends
             }
         }
 
+        public UnmanagedStorage(sbyte scalar)
+        {
+            _dtype = typeof(SByte);
+            _typecode = InfoOf<sbyte>.NPTypeCode;
+            _shape = Shape.Scalar;
+            InternalArray = _arraySByte = ArraySlice.Scalar<sbyte>(scalar);
+            unsafe
+            {
+                Address = (byte*)_arraySByte.Address;
+                Count = _arraySByte.Count;
+            }
+        }
+
         public UnmanagedStorage(byte scalar)
         {
             _dtype = typeof(Byte);
@@ -414,6 +428,21 @@ namespace NumSharp.Backends
             unsafe
             {
                 Address = (byte*)_arrayBoolean.Address;
+                Count = values.Length;
+            }
+        }
+
+        public UnmanagedStorage(SByte[] values)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+            _dtype = typeof(SByte);
+            _typecode = _dtype.GetTypeCode();
+            _shape = new Shape(values.Length);
+            InternalArray = _arraySByte = new ArraySlice<sbyte>(UnmanagedMemoryBlock<sbyte>.FromArray(values));
+            unsafe
+            {
+                Address = (byte*)_arraySByte.Address;
                 Count = values.Length;
             }
         }
@@ -618,6 +647,14 @@ namespace NumSharp.Backends
                     break;
                 }
 
+                case NPTypeCode.SByte:
+                {
+                    InternalArray = _arraySByte = ArraySlice.FromArray<sbyte>((sbyte[])array);
+                    Address = (byte*)_arraySByte.Address;
+                    Count = _arraySByte.Count;
+                    break;
+                }
+
                 case NPTypeCode.Byte:
                 {
                     InternalArray = _arrayByte = ArraySlice.FromArray<byte>((byte[])array);
@@ -741,6 +778,14 @@ namespace NumSharp.Backends
                     InternalArray = _arrayBoolean = (ArraySlice<bool>)array;
                     Address = (byte*)_arrayBoolean.Address;
                     Count = _arrayBoolean.Count;
+                    break;
+                }
+
+                case NPTypeCode.SByte:
+                {
+                    InternalArray = _arraySByte = (ArraySlice<sbyte>)array;
+                    Address = (byte*)_arraySByte.Address;
+                    Count = _arraySByte.Count;
                     break;
                 }
 

--- a/src/NumSharp.Core/Casting/Implicit/NdArray.Implicit.Array.cs
+++ b/src/NumSharp.Core/Casting/Implicit/NdArray.Implicit.Array.cs
@@ -169,7 +169,7 @@ namespace NumSharp
                 {
                     for (int jdx = 0; jdx < splitted[0].Length; jdx++)
                     {
-                        nd[idx, jdx] = (NDArray)Double.Parse(splitted[idx][jdx]);
+                        nd[idx, jdx] = (NDArray)double.Parse(splitted[idx][jdx]);
                     }
                 }
 

--- a/src/NumSharp.Core/Casting/Implicit/NdArray.Implicit.ValueTypes.cs
+++ b/src/NumSharp.Core/Casting/Implicit/NdArray.Implicit.ValueTypes.cs
@@ -125,6 +125,17 @@ namespace NumSharp
             return nd.GetAtIndex<ulong>(0);
         }
 
+        //byte operators
+        public static implicit operator NDArray(byte d) => NDArray.Scalar<byte>(d);
+
+        public static implicit operator byte(NDArray nd)
+        {
+            if (nd.ndim != 0)
+                throw new IncorrectShapeException();
+
+            return nd.GetAtIndex<byte>(0);
+        }
+
         //char operators
         public static implicit operator NDArray(char d) => NDArray.Scalar<char>(d);
 

--- a/src/NumSharp.Core/Generics/NDArray`1.cs
+++ b/src/NumSharp.Core/Generics/NDArray`1.cs
@@ -161,7 +161,7 @@ namespace NumSharp.Generic
             get => (TDType*)Storage.Address;
         }
 
-        public new TDType this[params int[] indices]
+        public TDType this[params int[] indices]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get

--- a/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
+++ b/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
@@ -1,168 +1,173 @@
 ﻿using System;
 using NumSharp.Generic;
+using NumSharp.Utilities.Maths;
 
 namespace NumSharp
 {
     public partial class NDArray
     {
         /// <summary>
-        /// Aplies the (x, y) => z projection delegate to each element of <see cref="NDArray"/> and converts it to <typeparamref name="TResult"/>.
-        /// </summary>
-        /// <typeparam name="TElement">The type of <see cref="NDArray"/> element.</typeparam>
-        /// <typeparam name="TResult">The type of resulting element.</typeparam>
-        /// <param name="lhs">The left <see cref="NDArray"/> to pass to projector.</param>
-        /// <param name="rhs">The right <see cref="NDArray"/> to pass to projector.</param>
-        /// <param name="projector">The projection delegate that handles the array elements.</param>
-        /// <returns>The resulting <see cref="NDArray{TDType}"/> that contains the projection result.</returns>
-        private static NDArray<TResult> Apply<TElement, TResult>(NDArray lhs, TElement rhs, Func<TElement, TElement, TResult> projector)
-            where TElement : unmanaged
-            where TResult : unmanaged
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-            if (projector is null)
-                throw new ArgumentNullException(nameof(projector));
-
-            var result = new NDArray(typeof(TResult), lhs.shape);
-            var storage = result.Storage.GetData<TResult>();
-
-            var lha = lhs.Storage.GetData<TElement>();
-
-            for (var i = 0; i < storage.Count; i++)
-                storage[i] = projector(lha[i], rhs);
-
-            return result.AsGeneric<TResult>();
-        }
-
-        /// <summary>
-        /// Aplies the (x, y) => z projection delegate to each element of <see cref="NDArray"/> and a scalar and converts it to <typeparamref name="TResult"/>.
-        /// </summary>
-        /// <typeparam name="TElement">The type of <see cref="NDArray"/> element.</typeparam>
-        /// <typeparam name="TResult">The type of resulting element.</typeparam>
-        /// <param name="lhs">The left <see cref="NDArray"/> to pass to projector.</param>
-        /// <param name="rhs">The right <typeparamref name="TElement"/> scalar value to pass to projector.</param>
-        /// <param name="projector">The projection delegate that handles the array elements.</param>
-        /// <returns>The resulting <see cref="NDArray{TDType}"/> that contains the projection result.</returns>
-        private static NDArray<TResult> Apply<TElement, TResult>(NDArray lhs, NDArray rhs, Func<TElement, TElement, TResult> projector)
-            where TElement : unmanaged
-            where TResult : unmanaged
-        {
-            if (rhs is null)
-                throw new ArgumentNullException(nameof(rhs));
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-            if (projector is null)
-                throw new ArgumentNullException(nameof(projector));
-
-            var result = new NDArray(typeof(TResult), lhs.shape);
-            var storage = result.Storage.GetData<TResult>();
-
-            var lha = lhs.Storage.GetData<TElement>();
-            var rha = rhs.Storage.GetData<TElement>();
-
-            for (var i = 0; i < storage.Count; i++)
-                storage[i] = projector(lha[i], rha[i]);
-
-            return result.AsGeneric<TResult>();
-        }
-
-        /// <summary>
-        /// Performs bitwize and operation on the elements of two <see cref="NDArray"/> values.
+        /// Performs bitwise and operation on the elements of two <see cref="NDArray"/> values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> to pass to perform the operation on.</param>
-        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the the operation result.</returns>
-        public static NDArray<bool> operator &(NDArray lhs, NDArray rhs)
+        /// <returns>The resulting <see cref="NDArray"/> that contains the the operation result.</returns>
+        public static NDArray operator &(NDArray lhs, NDArray rhs)
         {
-            return Apply<bool, bool>(lhs, rhs, (r, l) => r & l);
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+            if (rhs is null)
+                throw new ArgumentNullException(nameof(rhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetTypeCode;
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinary.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, rhs, @operator);
         }
 
         /// <summary>
-        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray<byte> operator &(NDArray lhs, byte rhs)
+        public static NDArray operator &(NDArray lhs, char rhs)
         {
-            return Apply<byte, byte>(lhs, rhs, (r, l) => (byte)(r & l));
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
         /// <summary>
-        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray<ushort> operator &(NDArray lhs, ushort rhs)
+        public static NDArray operator &(NDArray lhs, byte rhs)
         {
-            return Apply<ushort, ushort>(lhs, rhs, (r, l) => (ushort)(r & l));
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
         /// <summary>
-        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray<uint> operator &(NDArray lhs, uint rhs)
+        public static NDArray operator &(NDArray lhs, short rhs)
         {
-            return Apply<uint, uint>(lhs, rhs, (r, l) => r & l);
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
         /// <summary>
-        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray<ulong> operator &(NDArray lhs, ulong rhs)
+        public static NDArray operator &(NDArray lhs, ushort rhs)
         {
-            return Apply<ulong, ulong>(lhs, rhs, (r, l) => r & l);
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
         /// <summary>
-        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray<char> operator &(NDArray lhs, char rhs)
+        public static NDArray operator &(NDArray lhs, int rhs)
         {
-            return Apply<char, char>(lhs, rhs, (r, l) => (char)(r & l));
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
         /// <summary>
-        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray<short> operator &(NDArray lhs, short rhs)
+        public static NDArray operator &(NDArray lhs, uint rhs)
         {
-            return Apply<short, short>(lhs, rhs, (r, l) => (short)(r & l));
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
         /// <summary>
-        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray<int> operator &(NDArray lhs, int rhs)
+        public static NDArray operator &(NDArray lhs, long rhs)
         {
-            return Apply<int, int>(lhs, rhs, (r, l) => r & l);
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
         /// <summary>
-        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray<long> operator &(NDArray lhs, long rhs)
+        public static NDArray operator &(NDArray lhs, ulong rhs)
         {
-            return Apply<long, long>(lhs, rhs, (r, l) => r & l);
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
+            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
     }
 }

--- a/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
+++ b/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
@@ -1,36 +1,168 @@
-﻿using NumSharp.Generic;
+﻿using System;
+using NumSharp.Generic;
 
 namespace NumSharp
 {
     public partial class NDArray
     {
-        public static NDArray<bool> operator &(NDArray lhs, NDArray rhs)
+        /// <summary>
+        /// Aplies the (x, y) => z projection delegate to each element of <see cref="NDArray"/> and converts it to <typeparamref name="TResult"/>.
+        /// </summary>
+        /// <typeparam name="TElement">The type of <see cref="NDArray"/> element.</typeparam>
+        /// <typeparam name="TResult">The type of resulting element.</typeparam>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to projector.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> to pass to projector.</param>
+        /// <param name="projector">The projection delegate that handles the array elements.</param>
+        /// <returns>The resulting <see cref="NDArray{TDType}"/> that contains the projection result.</returns>
+        private static NDArray<TResult> Apply<TElement, TResult>(NDArray lhs, TElement rhs, Func<TElement, TElement, TResult> projector)
+            where TElement : unmanaged
+            where TResult : unmanaged
         {
-            return null;
-            //var boolTensor = new NDArray(typeof(bool),lhs.shape);
-            //bool[] bools = boolTensor.Storage.GetData<bool>();
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+            if (projector is null)
+                throw new ArgumentNullException(nameof(projector));
 
-            //bool[] np = lhs.Storage.GetData<bool>();
-            //bool[] obj = rhs.Storage.GetData<bool>();
+            var result = new NDArray(typeof(TResult), lhs.shape);
+            var storage = result.Storage.GetData<TResult>();
 
-            // for(int i = 0;i < bools.Length;i++)
-            //    bools[i] = np[i] && obj[i];
+            var lha = lhs.Storage.GetData<TElement>();
 
-            //return boolTensor.MakeGeneric<bool>();
+            for (var i = 0; i < storage.Count; i++)
+                storage[i] = projector(lha[i], rhs);
+
+            return result.AsGeneric<TResult>();
         }
 
+        /// <summary>
+        /// Aplies the (x, y) => z projection delegate to each element of <see cref="NDArray"/> and a scalar and converts it to <typeparamref name="TResult"/>.
+        /// </summary>
+        /// <typeparam name="TElement">The type of <see cref="NDArray"/> element.</typeparam>
+        /// <typeparam name="TResult">The type of resulting element.</typeparam>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to projector.</param>
+        /// <param name="rhs">The right <typeparamref name="TElement"/> scalar value to pass to projector.</param>
+        /// <param name="projector">The projection delegate that handles the array elements.</param>
+        /// <returns>The resulting <see cref="NDArray{TDType}"/> that contains the projection result.</returns>
+        private static NDArray<TResult> Apply<TElement, TResult>(NDArray lhs, NDArray rhs, Func<TElement, TElement, TResult> projector)
+            where TElement : unmanaged
+            where TResult : unmanaged
+        {
+            if (rhs is null)
+                throw new ArgumentNullException(nameof(rhs));
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+            if (projector is null)
+                throw new ArgumentNullException(nameof(projector));
+
+            var result = new NDArray(typeof(TResult), lhs.shape);
+            var storage = result.Storage.GetData<TResult>();
+
+            var lha = lhs.Storage.GetData<TElement>();
+            var rha = rhs.Storage.GetData<TElement>();
+
+            for (var i = 0; i < storage.Count; i++)
+                storage[i] = projector(lha[i], rha[i]);
+
+            return result.AsGeneric<TResult>();
+        }
+
+        /// <summary>
+        /// Performs bitwize and operation on the elements of two <see cref="NDArray"/> values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the the operation result.</returns>
+        public static NDArray<bool> operator &(NDArray lhs, NDArray rhs)
+        {
+            return Apply<bool, bool>(lhs, rhs, (r, l) => r & l);
+        }
+
+        /// <summary>
+        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
         public static NDArray<byte> operator &(NDArray lhs, byte rhs)
         {
-            return null;
-            //var result = new NDArray(typeof(byte), lhs.shape);
-            //byte[] resultBytes = result.Storage.GetData<byte>();
+            return Apply<byte, byte>(lhs, rhs, (r, l) => (byte)(r & l));
+        }
 
-            //byte[] lhsValues = lhs.Storage.GetData<byte>();
+        /// <summary>
+        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
+        public static NDArray<ushort> operator &(NDArray lhs, ushort rhs)
+        {
+            return Apply<ushort, ushort>(lhs, rhs, (r, l) => (ushort)(r & l));
+        }
 
-            //for (int i = 0; i < resultBytes.Length; i++)
-            //    resultBytes[i] = (byte)(lhsValues[i] & rhs);
+        /// <summary>
+        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
+        public static NDArray<uint> operator &(NDArray lhs, uint rhs)
+        {
+            return Apply<uint, uint>(lhs, rhs, (r, l) => r & l);
+        }
 
-            //return result.MakeGeneric<byte>();
+        /// <summary>
+        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
+        public static NDArray<ulong> operator &(NDArray lhs, ulong rhs)
+        {
+            return Apply<ulong, ulong>(lhs, rhs, (r, l) => r & l);
+        }
+
+        /// <summary>
+        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
+        public static NDArray<char> operator &(NDArray lhs, char rhs)
+        {
+            return Apply<char, char>(lhs, rhs, (r, l) => (char)(r & l));
+        }
+
+        /// <summary>
+        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
+        public static NDArray<short> operator &(NDArray lhs, short rhs)
+        {
+            return Apply<short, short>(lhs, rhs, (r, l) => (short)(r & l));
+        }
+
+        /// <summary>
+        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
+        public static NDArray<int> operator &(NDArray lhs, int rhs)
+        {
+            return Apply<int, int>(lhs, rhs, (r, l) => r & l);
+        }
+
+        /// <summary>
+        /// Performs bitwize and operation on the elements of <see cref="NDArray"/> and the scalar values.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
+        /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
+        /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
+        public static NDArray<long> operator &(NDArray lhs, long rhs)
+        {
+            return Apply<long, long>(lhs, rhs, (r, l) => r & l);
         }
     }
 }

--- a/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
+++ b/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
@@ -12,19 +12,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray"/> that contains the the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, NDArray rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-            if (rhs is null)
-                throw new ArgumentNullException(nameof(rhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetTypeCode;
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinary.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, NDArray rhs) => OpBinary.Invoke(lhs, rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -32,17 +20,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, char rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, (ValueType)rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, char rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -50,17 +28,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, byte rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, (ValueType)rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, byte rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -68,17 +36,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, short rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, (ValueType)rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, short rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -86,17 +44,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, ushort rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, (ValueType)rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, ushort rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -104,17 +52,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, int rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, (ValueType)rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, int rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -122,17 +60,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, uint rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, (ValueType)rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, uint rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -140,17 +68,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, long rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, (ValueType)rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, long rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -158,16 +76,6 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, ulong rhs)
-        {
-            if (lhs is null)
-                throw new ArgumentNullException(nameof(lhs));
-
-            var ltc = lhs.GetTypeCode;
-            var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
-            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
-            return operation.Invoke(lhs, (ValueType)rhs, @operator);
-        }
+        public static NDArray operator &(NDArray lhs, ulong rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
     }
 }

--- a/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
+++ b/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
@@ -21,8 +21,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetTypeCode;
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinary.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinary.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, rhs, @operator);
         }
 
@@ -39,8 +39,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
@@ -57,8 +57,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
@@ -75,8 +75,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
@@ -93,8 +93,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
@@ -111,8 +111,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
@@ -129,8 +129,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
@@ -147,8 +147,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
 
@@ -165,8 +165,8 @@ namespace NumSharp
 
             var ltc = lhs.GetTypeCode;
             var rtc = rhs.GetType().GetTypeCode();
-            var @operator = Operator.OpBitwiseAnd.GetCaller(ltc, rtc);
-            var operation = OpBinaryLeft.GetCaller(ltc, rtc, @operator.ReturnCode);
+            var @operator = Operator.OpBitwiseAnd.Get(ltc, rtc);
+            var operation = OpBinaryLeft.Get(ltc, rtc, @operator.ReturnCode);
             return operation.Invoke(lhs, (ValueType)rhs, @operator);
         }
     }

--- a/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
+++ b/src/NumSharp.Core/Operations/Elementwise/NDArray.AND.cs
@@ -20,7 +20,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, char rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
+        public static NDArray operator &(NDArray lhs, char rhs) => OpBinaryLeft.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -28,7 +28,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, byte rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
+        public static NDArray operator &(NDArray lhs, byte rhs) => OpBinaryLeft.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -36,7 +36,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, short rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
+        public static NDArray operator &(NDArray lhs, short rhs) => OpBinaryLeft.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -44,7 +44,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, ushort rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
+        public static NDArray operator &(NDArray lhs, ushort rhs) => OpBinaryLeft.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -52,7 +52,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, int rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
+        public static NDArray operator &(NDArray lhs, int rhs) => OpBinaryLeft.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -60,7 +60,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, uint rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
+        public static NDArray operator &(NDArray lhs, uint rhs) => OpBinaryLeft.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -68,7 +68,7 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, long rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
+        public static NDArray operator &(NDArray lhs, long rhs) => OpBinaryLeft.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
 
         /// <summary>
         /// Performs bitwise and operation on the elements of <see cref="NDArray"/> and the scalar values.
@@ -76,6 +76,6 @@ namespace NumSharp
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to perform the operation on.</param>
         /// <param name="rhs">The right scalar value to pass to perform the operation on.</param>
         /// <returns>The resulting <see cref="NDArray{bool}"/> that contains the operation result.</returns>
-        public static NDArray operator &(NDArray lhs, ulong rhs) => OpBinary.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
+        public static NDArray operator &(NDArray lhs, ulong rhs) => OpBinaryLeft.Invoke(lhs, (ValueType)rhs, Operator.OpBitwiseAnd);
     }
 }

--- a/src/NumSharp.Core/Operations/Elementwise/NDArray.Core.cs
+++ b/src/NumSharp.Core/Operations/Elementwise/NDArray.Core.cs
@@ -70,7 +70,7 @@ namespace NumSharp
 
             if (typeof(TLElement).GetTypeCode() != lhs.GetTypeCode)
                 throw new ArgumentException($"The left argument array type {lhs.GetTypeCode} does not match the expected type {typeof(TLElement).GetTypeCode()}.", nameof(lhs));
-            if (typeof(TLElement).GetTypeCode() != rhs.GetTypeCode)
+            if (typeof(TRElement).GetTypeCode() != rhs.GetTypeCode)
                 throw new ArgumentException($"The right argument array type {rhs.GetTypeCode} does not match the expected type {typeof(TLElement).GetTypeCode()}.", nameof(rhs));
 
             var (ls, rs) = DefaultEngine.Broadcast(lhs.Shape, rhs.Shape);
@@ -78,7 +78,7 @@ namespace NumSharp
             var result = new NDArray(np._FindCommonType(lhs, rhs), resultShape);
 
             if (typeof(TResult).GetTypeCode() != result.GetTypeCode)
-                throw new InvalidOperationException($"The resulting array type {lhs.GetTypeCode} does not match the expected type {typeof(TResult).GetTypeCode()}.");
+                throw new InvalidOperationException($"The resulting array type {result.GetTypeCode} does not match the expected type {typeof(TResult).GetTypeCode()}.");
 
             var lhsAddress = (TLElement*)lhs.Address;
             var rhsAddress = (TRElement*)rhs.Address;

--- a/src/NumSharp.Core/Operations/Elementwise/NDArray.Core.cs
+++ b/src/NumSharp.Core/Operations/Elementwise/NDArray.Core.cs
@@ -10,12 +10,13 @@ namespace NumSharp
     {
         protected static BinaryOperationIndex OpBinary = new BinaryOperationIndex(typeof(NDArray), nameof(BinaryOperation));
         protected static BinaryOperationIndex OpBinaryLeft = new BinaryOperationIndex(typeof(NDArray), nameof(BinaryOperationLeft));
+        protected static BinaryOperationIndex OpBinaryRight = new BinaryOperationIndex(typeof(NDArray), nameof(BinaryOperationRight));
 
         /// <summary>
         /// Aplies the (x, y) => z projection delegate to each element of <see cref="NDArray"/> and converts it to <typeparamref name="TResult"/>.
         /// </summary>
         /// <typeparam name="TLElement">The type of a left <see cref="NDArray"/> element.</typeparam>
-        /// <typeparam name="TRElement">The type of a right <see cref="NDArray"/> element.</typeparam>
+        /// <typeparam name="TRElement">The type of a right scalar element.</typeparam>
         /// <param name="lhs">The left <see cref="NDArray"/> to pass to the projector.</param>
         /// <param name="rhs">The right <typeparamref name="TRElement"/> scalar value to pass to the projector.</param>
         /// <param name="projector">The projection delegate that handles the array elements.</param>
@@ -33,15 +34,44 @@ namespace NumSharp
             if (typeof(TLElement).GetTypeCode() != lhs.GetTypeCode)
                 throw new ArgumentException($"The left argument array type {lhs.GetTypeCode} does not match the expected type {typeof(TLElement).GetTypeCode()}.", nameof(lhs));
 
-            var result = new NDArray(np._FindCommonArrayScalarType(lhs.GetTypeCode, typeof(TRElement).GetTypeCode()), lhs.Shape.Clean());
-
-            if (typeof(TResult).GetTypeCode() != result.GetTypeCode)
-                throw new InvalidOperationException($"The resulting array type {lhs.GetTypeCode} does not match the expected type {typeof(TResult).GetTypeCode()}.");
+            var result = new NDArray(typeof(TResult).GetTypeCode(), lhs.Shape.Clean());
 
             var lhsAddress = (TLElement*)lhs.Address;
             var resultAddress = (TResult*)result.Address;
 
             @operator.ParallelFor(0, result.size, resultAddress, lhsAddress, rhs);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Aplies the (x, y) => z projection delegate to each element of <see cref="NDArray"/> and converts it to <typeparamref name="TResult"/>.
+        /// </summary>
+        /// <typeparam name="TLElement">The type of a left scalar element.</typeparam>
+        /// <typeparam name="TRElement">The type of a right <see cref="NDArray"/> element.</typeparam>
+        /// <param name="lhs">The right <typeparamref name="TRElement"/> scalar value to pass to the projector.</param>
+        /// <param name="rhs">The left <see cref="NDArray"/> to pass to the projector.</param>
+        /// <param name="projector">The projection delegate that handles the array elements.</param>
+        /// <returns>The resulting <see cref="NDArray{TDType}"/> that contains the projection result.</returns>
+        private static unsafe NDArray BinaryOperationRight<TLElement, TRElement, TResult>(TLElement lhs, NDArray rhs, BinaryOperator<TLElement, TRElement, TResult> @operator)
+            where TLElement : unmanaged
+            where TRElement : unmanaged
+            where TResult : unmanaged
+        {
+            if (rhs is null)
+                throw new ArgumentNullException(nameof(rhs));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
+
+            if (typeof(TLElement).GetTypeCode() != rhs.GetTypeCode)
+                throw new ArgumentException($"The right argument array type {rhs.GetTypeCode} does not match the expected type {typeof(TRElement).GetTypeCode()}.", nameof(lhs));
+
+            var result = new NDArray(typeof(TResult).GetTypeCode(), rhs.Shape.Clean());
+
+            var rhsAddress = (TRElement*)rhs.Address;
+            var resultAddress = (TResult*)result.Address;
+
+            @operator.ParallelFor(0, result.size, resultAddress, lhs, rhsAddress);
 
             return result;
         }
@@ -75,10 +105,7 @@ namespace NumSharp
 
             var (ls, rs) = DefaultEngine.Broadcast(lhs.Shape, rhs.Shape);
             var resultShape = ls.Clean();
-            var result = new NDArray(np._FindCommonType(lhs, rhs), resultShape);
-
-            if (typeof(TResult).GetTypeCode() != result.GetTypeCode)
-                throw new InvalidOperationException($"The resulting array type {result.GetTypeCode} does not match the expected type {typeof(TResult).GetTypeCode()}.");
+            var result = new NDArray(typeof(TResult).GetTypeCode(), resultShape);
 
             var lhsAddress = (TLElement*)lhs.Address;
             var rhsAddress = (TRElement*)rhs.Address;

--- a/src/NumSharp.Core/Operations/Elementwise/NDArray.Core.cs
+++ b/src/NumSharp.Core/Operations/Elementwise/NDArray.Core.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Diagnostics;
+using NumSharp.Backends;
+using NumSharp.Generic;
+using NumSharp.Utilities.Maths;
+
+namespace NumSharp
+{
+    public partial class NDArray
+    {
+        protected static BinaryOperationIndex OpBinary = new BinaryOperationIndex(typeof(NDArray), nameof(BinaryOperation));
+        protected static BinaryOperationIndex OpBinaryLeft = new BinaryOperationIndex(typeof(NDArray), nameof(BinaryOperationLeft));
+
+        /// <summary>
+        /// Aplies the (x, y) => z projection delegate to each element of <see cref="NDArray"/> and converts it to <typeparamref name="TResult"/>.
+        /// </summary>
+        /// <typeparam name="TLElement">The type of a left <see cref="NDArray"/> element.</typeparam>
+        /// <typeparam name="TRElement">The type of a right <see cref="NDArray"/> element.</typeparam>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to the projector.</param>
+        /// <param name="rhs">The right <typeparamref name="TRElement"/> scalar value to pass to the projector.</param>
+        /// <param name="projector">The projection delegate that handles the array elements.</param>
+        /// <returns>The resulting <see cref="NDArray{TDType}"/> that contains the projection result.</returns>
+        private static unsafe NDArray BinaryOperationLeft<TLElement, TRElement, TResult>(NDArray lhs, TRElement rhs, BinaryOperator<TLElement, TRElement, TResult> @operator)
+            where TLElement : unmanaged
+            where TRElement : unmanaged
+            where TResult : unmanaged
+        {
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
+
+            if (typeof(TLElement).GetTypeCode() != lhs.GetTypeCode)
+                throw new ArgumentException($"The left argument array type {lhs.GetTypeCode} does not match the expected type {typeof(TLElement).GetTypeCode()}.", nameof(lhs));
+
+            var result = new NDArray(np._FindCommonArrayScalarType(lhs.GetTypeCode, typeof(TRElement).GetTypeCode()), lhs.Shape.Clean());
+
+            if (typeof(TResult).GetTypeCode() != result.GetTypeCode)
+                throw new InvalidOperationException($"The resulting array type {lhs.GetTypeCode} does not match the expected type {typeof(TResult).GetTypeCode()}.");
+
+            var lhsAddress = (TLElement*)lhs.Address;
+            var resultAddress = (TResult*)result.Address;
+
+            @operator.ParallelFor(0, result.size, resultAddress, lhsAddress, rhs);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Aplies the (x, y) => z projection delegate to each element of left and right <see cref="NDArray"/> arguments.
+        /// </summary>
+        /// <typeparam name="TLElement">The type of a left <see cref="NDArray"/> element.</typeparam>
+        /// <typeparam name="TRElement">The type of a right <see cref="NDArray"/> element.</typeparam>
+        /// <typeparam name="TResult">The type of a resultint <see cref="NDArray"/> element.</typeparam>
+        /// <param name="lhs">The left <see cref="NDArray"/> to pass to the projector.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> to pass to the projector.</param>
+        /// <param name="operator">The projection delegate that handles the array elements.</param>
+        /// <returns>The resulting <see cref="NDArray"/> that contains the projection result.</returns>
+        public static unsafe NDArray BinaryOperation<TLElement, TRElement, TResult>(NDArray lhs, NDArray rhs, BinaryOperator<TLElement, TRElement, TResult> @operator)
+            where TLElement : unmanaged
+            where TRElement : unmanaged
+            where TResult : unmanaged
+        {
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+            if (rhs is null)
+                throw new ArgumentNullException(nameof(rhs));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
+
+            if (typeof(TLElement).GetTypeCode() != lhs.GetTypeCode)
+                throw new ArgumentException($"The left argument array type {lhs.GetTypeCode} does not match the expected type {typeof(TLElement).GetTypeCode()}.", nameof(lhs));
+            if (typeof(TLElement).GetTypeCode() != rhs.GetTypeCode)
+                throw new ArgumentException($"The right argument array type {rhs.GetTypeCode} does not match the expected type {typeof(TLElement).GetTypeCode()}.", nameof(rhs));
+
+            var (ls, rs) = DefaultEngine.Broadcast(lhs.Shape, rhs.Shape);
+            var resultShape = ls.Clean();
+            var result = new NDArray(np._FindCommonType(lhs, rhs), resultShape);
+
+            if (typeof(TResult).GetTypeCode() != result.GetTypeCode)
+                throw new InvalidOperationException($"The resulting array type {lhs.GetTypeCode} does not match the expected type {typeof(TResult).GetTypeCode()}.");
+
+            var lhsAddress = (TLElement*)lhs.Address;
+            var rhsAddress = (TRElement*)rhs.Address;
+            var resultAddress = (TResult*)result.Address;
+
+            switch ((l: ls.IsLinear, r: rs.IsLinear))
+            {
+                // ls.IsLinear && rs.IsLinear
+                case var isLinear when isLinear.l && isLinear.r:
+                    Debug.Assert(ls.size == result.size && rs.size == result.size);
+                    switch (result.size)
+                    {
+                        case var length when rs.IsBroadcasted && rs.BroadcastInfo.OriginalShape.IsScalar:
+                            @operator.ParallelFor(0, length, resultAddress, lhsAddress, *rhsAddress);
+                            break;
+                        case var length when ls.IsBroadcasted && ls.BroadcastInfo.OriginalShape.IsScalar:
+                            @operator.ParallelFor(0, length, resultAddress, *lhsAddress, rhsAddress);
+                            break;
+                        case var length:
+                            @operator.ParallelFor(0, length, resultAddress, lhsAddress, rhsAddress);
+                            break;
+                    }
+                    break;
+
+                // ls.IsLinear && !rs.IsLinear
+                case var isLinear when isLinear.l:
+                    switch (result.size)
+                    {
+                        case var length when rs.IsBroadcasted && rs.BroadcastInfo.OriginalShape.IsScalar:
+                            @operator.ParallelFor(0, length, resultAddress, lhsAddress, *rhsAddress);
+                            break;
+                        default:
+                            @operator.IncrementFor(resultAddress, lhsAddress, rhsAddress, ref rs);
+                            break;
+                    }
+                    break;
+
+                // !ls.IsLinear && rs.IsLinear
+                case var isLinear when isLinear.r:
+                    switch (result.size)
+                    {
+                        case var length when ls.IsBroadcasted && ls.BroadcastInfo.OriginalShape.IsScalar && *lhsAddress is var lval:
+                            @operator.ParallelFor(0, length, resultAddress, *lhsAddress, rhsAddress);
+                            break;
+
+                        default:
+                            @operator.IncrementFor(resultAddress, lhsAddress, ref ls, rhsAddress);
+                            break;
+                    }
+                    break;
+
+                // !ls.IsLinear && !rs.IsLinear
+                default:
+                    @operator.IncrementFor(resultAddress, lhsAddress, ref ls, rhsAddress, ref rs);
+                    break;
+            }
+            return result;
+        }
+    }
+}

--- a/src/NumSharp.Core/RandomSampling/np.random.randint.cs
+++ b/src/NumSharp.Core/RandomSampling/np.random.randint.cs
@@ -44,6 +44,14 @@ namespace NumSharp
                 }
                 %
 #else
+                case NPTypeCode.SByte:
+                {
+                    var data = (ArraySlice<sbyte>)nd.Array;
+                    for (int i = 0; i < data.Count; i++)
+                        data[i] = Converts.ToSByte(randomizer.NextLong(low, high));
+                    
+                    break;
+                }
                 case NPTypeCode.Byte:
                 {
                     var data = (ArraySlice<byte>)nd.Array;

--- a/src/NumSharp.Core/RandomSampling/np.random.shuffle.cs
+++ b/src/NumSharp.Core/RandomSampling/np.random.shuffle.cs
@@ -68,6 +68,23 @@ namespace NumSharp
                         break;
                     }
 
+                    case NPTypeCode.SByte:
+                    {
+                        var addr = (sbyte*)x.Address;
+                        var addr_index0 = addr + transformOffset(0);
+                        sbyte tmp; //index 0
+                        sbyte* addr_swap;
+                        while (count-- > 1)
+                        {
+                            tmp = *addr_index0;
+                            addr_swap = addr + transformOffset(randomizer.Next(size));
+                            *addr_index0 = *addr_swap;
+                            *addr_swap = tmp;
+                        }
+
+                        break;
+                    }
+
                     case NPTypeCode.Byte:
                     {
                         var addr = (byte*)x.Address;

--- a/src/NumSharp.Core/Selection/NDArray.Indexing.Selection.Getter.cs
+++ b/src/NumSharp.Core/Selection/NDArray.Indexing.Selection.Getter.cs
@@ -255,6 +255,7 @@ namespace NumSharp
             switch (src.typecode)
             {
                 case NPTypeCode.Boolean: return FetchIndices<bool>(src.MakeGeneric<bool>(), indices, @out, extraDim);
+                case NPTypeCode.SByte: return FetchIndices<sbyte>(src.MakeGeneric<sbyte>(), indices, @out, extraDim);
                 case NPTypeCode.Byte: return FetchIndices<byte>(src.MakeGeneric<byte>(), indices, @out, extraDim);
                 case NPTypeCode.Int16: return FetchIndices<short>(src.MakeGeneric<short>(), indices, @out, extraDim);
                 case NPTypeCode.UInt16: return FetchIndices<ushort>(src.MakeGeneric<ushort>(), indices, @out, extraDim);

--- a/src/NumSharp.Core/Selection/NDArray.Indexing.Selection.Setter.cs
+++ b/src/NumSharp.Core/Selection/NDArray.Indexing.Selection.Setter.cs
@@ -273,6 +273,9 @@ namespace NumSharp
                 case NPTypeCode.Boolean:
                     SetIndices<bool>(src.MakeGeneric<bool>(), indices, values);
                     break;
+                case NPTypeCode.SByte:
+                    SetIndices<sbyte>(src.MakeGeneric<sbyte>(), indices, values);
+                    break;
                 case NPTypeCode.Byte:
                     SetIndices<byte>(src.MakeGeneric<byte>(), indices, values);
                     break;

--- a/src/NumSharp.Core/Utilities/ArrayConvert.cs
+++ b/src/NumSharp.Core/Utilities/ArrayConvert.cs
@@ -158,6 +158,7 @@ namespace NumSharp.Utilities
                 %
 #else
                 case NPTypeCode.Boolean: return ToBoolean(sourceArray);
+                case NPTypeCode.SByte: return ToSByte(sourceArray);
                 case NPTypeCode.Byte: return ToByte(sourceArray);
                 case NPTypeCode.Int16: return ToInt16(sourceArray);
                 case NPTypeCode.UInt16: return ToUInt16(sourceArray);
@@ -193,6 +194,7 @@ namespace NumSharp.Utilities
 #else
 
                 case NPTypeCode.Boolean: return ToBoolean(sourceArray);
+                case NPTypeCode.SByte: return ToSByte(sourceArray);
                 case NPTypeCode.Byte: return ToByte(sourceArray);
                 case NPTypeCode.Int16: return ToInt16(sourceArray);
                 case NPTypeCode.UInt16: return ToUInt16(sourceArray);
@@ -241,6 +243,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return To#1((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return To#1((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return To#1((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -313,6 +317,49 @@ namespace NumSharp.Utilities
             }
         }
 
+        public static SByte[] ToSByte(Array sourceArray)
+        {
+            if (sourceArray == null)
+            {
+                throw new ArgumentNullException(nameof(sourceArray));
+            }
+
+            var fromTypeCode = sourceArray.GetType().GetElementType().GetTypeCode();
+            switch (fromTypeCode)
+            {
+                case NPTypeCode.Boolean:
+                    return ToSByte((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToSByte((SByte[]) sourceArray);
+                case NPTypeCode.Byte:
+                    return ToSByte((Byte[]) sourceArray);
+                case NPTypeCode.Int16:
+                    return ToSByte((Int16[]) sourceArray);
+                case NPTypeCode.UInt16:
+                    return ToSByte((UInt16[]) sourceArray);
+                case NPTypeCode.Int32:
+                    return ToSByte((Int32[]) sourceArray);
+                case NPTypeCode.UInt32:
+                    return ToSByte((UInt32[]) sourceArray);
+                case NPTypeCode.Int64:
+                    return ToSByte((Int64[]) sourceArray);
+                case NPTypeCode.UInt64:
+                    return ToSByte((UInt64[]) sourceArray);
+                case NPTypeCode.Char:
+                    return ToSByte((Char[]) sourceArray);
+                case NPTypeCode.Double:
+                    return ToSByte((Double[]) sourceArray);
+                case NPTypeCode.Single:
+                    return ToSByte((Single[]) sourceArray);
+                case NPTypeCode.Decimal:
+                    return ToSByte((Decimal[]) sourceArray);
+                case NPTypeCode.String:
+                    return ToSByte((String[]) sourceArray);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
         public static Byte[] ToByte(Array sourceArray)
         {
             if (sourceArray == null)
@@ -325,6 +372,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToByte((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToByte((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToByte((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -366,6 +415,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToInt16((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToInt16((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToInt16((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -407,6 +458,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToUInt16((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToUInt16((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToUInt16((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -448,6 +501,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToInt32((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToInt32((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToInt32((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -489,8 +544,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToUInt32((Boolean[]) sourceArray);
-                case NPTypeCode.Byte:
-                    return ToUInt32((Byte[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToUInt32((SByte[]) sourceArray);
                 case NPTypeCode.Int16:
                     return ToUInt32((Int16[]) sourceArray);
                 case NPTypeCode.UInt16:
@@ -530,6 +585,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToInt64((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToInt64((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToInt64((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -571,6 +628,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToUInt64((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToUInt64((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToUInt64((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -612,6 +671,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToChar((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToChar((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToChar((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -653,6 +714,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToDouble((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToDouble((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToDouble((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -694,6 +757,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToSingle((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToSingle((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToSingle((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -735,6 +800,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToDecimal((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToDecimal((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToDecimal((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -776,6 +843,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToString((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToString((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToString((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -817,6 +886,8 @@ namespace NumSharp.Utilities
             {
                 case NPTypeCode.Boolean:
                     return ToComplex((Boolean[]) sourceArray);
+                case NPTypeCode.SByte:
+                    return ToComplex((SByte[]) sourceArray);
                 case NPTypeCode.Byte:
                     return ToComplex((Byte[]) sourceArray);
                 case NPTypeCode.Int16:
@@ -892,6 +963,25 @@ namespace NumSharp.Utilities
 
             var length = sourceArray.Length;
             var output = new Boolean[length];
+            sourceArray.AsSpan().CopyTo(output);
+
+            return output;
+        }
+
+        /// <summary>
+        ///     Converts <see cref="SByte"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        /// <remarks>Based on benchmark ArrayCopying</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(SByte[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+
+            var length = sourceArray.Length;
+            var output = new SByte[length];
             sourceArray.AsSpan().CopyTo(output);
 
             return output;
@@ -1173,6 +1263,23 @@ namespace NumSharp.Utilities
 
 
         #region Compute
+        
+        /// <summary>
+        ///     Converts <see cref="Boolean"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(Boolean[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
+            return output;
+        }
         
         /// <summary>
         ///     Converts <see cref="Boolean"/> array to a <see cref="Byte"/> array.
@@ -1807,6 +1914,23 @@ namespace NumSharp.Utilities
         ///     Converts <see cref="UInt16"/> array to a <see cref="Byte"/> array.
         /// </summary>
         /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(UInt16[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
+        ///     Converts <see cref="UInt16"/> array to a <see cref="Byte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
         /// <returns>Converted array of type Byte</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Byte[] ToByte(UInt16[] sourceArray)
@@ -2004,6 +2128,23 @@ namespace NumSharp.Utilities
             var length = sourceArray.Length;
             var output = new Boolean[length];
             Parallel.For(0, length, i=> output[i] = Converts.ToBoolean(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
+        ///     Converts <see cref="Int32"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(Int32[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
             return output;
         }
         
@@ -2212,6 +2353,23 @@ namespace NumSharp.Utilities
         }
         
         /// <summary>
+        ///     Converts <see cref="UInt32"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(UInt32[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
         ///     Converts <see cref="UInt32"/> array to a <see cref="Byte"/> array.
         /// </summary>
         /// <param name="sourceArray">The array to convert</param>
@@ -2412,6 +2570,23 @@ namespace NumSharp.Utilities
             var length = sourceArray.Length;
             var output = new Boolean[length];
             Parallel.For(0, length, i=> output[i] = Converts.ToBoolean(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
+        ///     Converts <see cref="Int64"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(Int64[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
             return output;
         }
         
@@ -2620,6 +2795,23 @@ namespace NumSharp.Utilities
         }
         
         /// <summary>
+        ///     Converts <see cref="UInt64"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(UInt64[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
         ///     Converts <see cref="UInt64"/> array to a <see cref="Byte"/> array.
         /// </summary>
         /// <param name="sourceArray">The array to convert</param>
@@ -2820,6 +3012,23 @@ namespace NumSharp.Utilities
             var length = sourceArray.Length;
             var output = new Boolean[length];
             Parallel.For(0, length, i=> output[i] = Converts.ToBoolean(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
+        ///     Converts <see cref="Char"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(Char[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
             return output;
         }
         
@@ -3028,6 +3237,23 @@ namespace NumSharp.Utilities
         }
         
         /// <summary>
+        ///     Converts <see cref="Double"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(Double[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
         ///     Converts <see cref="Double"/> array to a <see cref="Byte"/> array.
         /// </summary>
         /// <param name="sourceArray">The array to convert</param>
@@ -3228,6 +3454,23 @@ namespace NumSharp.Utilities
             var length = sourceArray.Length;
             var output = new Boolean[length];
             Parallel.For(0, length, i=> output[i] = Converts.ToBoolean(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
+        ///     Converts <see cref="Single"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(Single[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
             return output;
         }
         
@@ -3436,6 +3679,23 @@ namespace NumSharp.Utilities
         }
         
         /// <summary>
+        ///     Converts <see cref="Decimal"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(Decimal[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
         ///     Converts <see cref="Decimal"/> array to a <see cref="Byte"/> array.
         /// </summary>
         /// <param name="sourceArray">The array to convert</param>
@@ -3636,6 +3896,23 @@ namespace NumSharp.Utilities
             var length = sourceArray.Length;
             var output = new Boolean[length];
             Parallel.For(0, length, i=> output[i] = Converts.ToBoolean(sourceArray[i]));
+            return output;
+        }
+        
+        /// <summary>
+        ///     Converts <see cref="String"/> array to a <see cref="SByte"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type SByte</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static SByte[] ToSByte(String[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new SByte[length];
+            Parallel.For(0, length, i=> output[i] = Converts.ToSByte(sourceArray[i]));
             return output;
         }
         
@@ -3864,6 +4141,24 @@ namespace NumSharp.Utilities
         /// <returns>Converted array of type Complex</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Complex[] ToComplex(Boolean[] sourceArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException(nameof(sourceArray));
+            
+            var length = sourceArray.Length;
+            var output = new Complex[length];
+
+            Parallel.For(0, length, i => new Complex(Converts.ToDouble(sourceArray[i]), 0d));
+            return output;
+        }
+        
+        /// <summary>
+        ///     Converts <see cref="SByte"/> array to a <see cref="Complex"/> array.
+        /// </summary>
+        /// <param name="sourceArray">The array to convert</param>
+        /// <returns>Converted array of type Complex</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Complex[] ToComplex(SByte[] sourceArray)
         {
             if (sourceArray == null)
                 throw new ArgumentNullException(nameof(sourceArray));

--- a/src/NumSharp.Core/Utilities/Arrays.cs
+++ b/src/NumSharp.Core/Utilities/Arrays.cs
@@ -446,6 +446,11 @@ namespace NumSharp.Utilities
                     return new bool[length];
                 }
 
+                case NPTypeCode.SByte:
+                {
+                    return new sbyte[length];
+                }
+
                 case NPTypeCode.Byte:
                 {
                     return new byte[length];
@@ -540,6 +545,11 @@ namespace NumSharp.Utilities
                 case NPTypeCode.Boolean:
                 {
                     return new bool[1] {(Boolean)value};
+                }
+
+                case NPTypeCode.SByte:
+                {
+                    return new sbyte[1] {(SByte)value};
                 }
 
                 case NPTypeCode.Byte:

--- a/src/NumSharp.Core/Utilities/Converts.cs
+++ b/src/NumSharp.Core/Utilities/Converts.cs
@@ -39,6 +39,8 @@ namespace NumSharp.Utilities
                     return (TOut)(object)((IConvertible)value).ToBoolean(CultureInfo.InvariantCulture);
                 case NPTypeCode.Char:
                     return (TOut)(object)((IConvertible)value).ToChar(CultureInfo.InvariantCulture);
+                case NPTypeCode.SByte:
+                    return (TOut)(object)((IConvertible)value).ToSByte(CultureInfo.InvariantCulture);
                 case NPTypeCode.Byte:
                     return (TOut)(object)((IConvertible)value).ToByte(CultureInfo.InvariantCulture);
                 case NPTypeCode.Int16:
@@ -98,6 +100,8 @@ namespace NumSharp.Utilities
                     return ((IConvertible)value).ToBoolean(CultureInfo.InvariantCulture);
                 case NPTypeCode.Char:
                     return ((IConvertible)value).ToChar(CultureInfo.InvariantCulture);
+                case NPTypeCode.SByte:
+                    return ((IConvertible)value).ToSByte(CultureInfo.InvariantCulture);
                 case NPTypeCode.Byte:
                     return ((IConvertible)value).ToByte(CultureInfo.InvariantCulture);
                 case NPTypeCode.Int16:
@@ -156,6 +160,8 @@ namespace NumSharp.Utilities
                     return ((IConvertible)value).ToBoolean(provider);
                 case NPTypeCode.Char:
                     return ((IConvertible)value).ToChar(provider);
+                case NPTypeCode.SByte:
+                    return ((IConvertible)value).ToSByte(provider);
                 case NPTypeCode.Byte:
                     return ((IConvertible)value).ToByte(provider);
                 case NPTypeCode.Int16:
@@ -241,6 +247,11 @@ namespace NumSharp.Utilities
                             Func<bool, bool> ret = Converts.ToBoolean;
                             return (Func<TIn, TOut>)(object)ret;
                         }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<bool, sbyte> ret = Converts.ToSByte;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
                         case NPTypeCode.Byte:
                         {
                             Func<bool, byte> ret = Converts.ToByte;
@@ -303,6 +314,77 @@ namespace NumSharp.Utilities
                         }
                     }
                 }
+                case NPTypeCode.SByte:
+                {
+                    switch (InfoOf<TOut>.NPTypeCode)
+                    {
+                        case NPTypeCode.Boolean:
+                        {
+                            Func<sbyte, bool> ret = Converts.ToBoolean;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<sbyte, sbyte> ret = Converts.ToSByte;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.Int16:
+                        {
+                            Func<sbyte, short> ret = Converts.ToInt16;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.UInt16:
+                        {
+                            Func<sbyte, ushort> ret = Converts.ToUInt16;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.Int32:
+                        {
+                            Func<sbyte, int> ret = Converts.ToInt32;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.UInt32:
+                        {
+                            Func<sbyte, uint> ret = Converts.ToUInt32;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.Int64:
+                        {
+                            Func<sbyte, long> ret = Converts.ToInt64;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.UInt64:
+                        {
+                            Func<sbyte, ulong> ret = Converts.ToUInt64;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.Char:
+                        {
+                            Func<sbyte, char> ret = Converts.ToChar;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.Double:
+                        {
+                            Func<sbyte, double> ret = Converts.ToDouble;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.Single:
+                        {
+                            Func<sbyte, float> ret = Converts.ToSingle;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.Decimal:
+                        {
+                            Func<sbyte, decimal> ret = Converts.ToDecimal;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        default:
+                        {
+                            var tout = typeof(TOut);
+                            return @in => (TOut)Convert.ChangeType(@in, tout);
+                        }
+                    }
+                }
                 case NPTypeCode.Byte:
                 {
                     switch (InfoOf<TOut>.NPTypeCode)
@@ -310,6 +392,11 @@ namespace NumSharp.Utilities
                         case NPTypeCode.Boolean:
                         {
                             Func<byte, bool> ret = Converts.ToBoolean;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<byte, sbyte> ret = Converts.ToSByte;
                             return (Func<TIn, TOut>)(object)ret;
                         }
                         case NPTypeCode.Byte:
@@ -383,6 +470,11 @@ namespace NumSharp.Utilities
                             Func<short, bool> ret = Converts.ToBoolean;
                             return (Func<TIn, TOut>)(object)ret;
                         }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<short, sbyte> ret = Converts.ToSByte;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
                         case NPTypeCode.Byte:
                         {
                             Func<short, byte> ret = Converts.ToByte;
@@ -452,6 +544,11 @@ namespace NumSharp.Utilities
                         case NPTypeCode.Boolean:
                         {
                             Func<ushort, bool> ret = Converts.ToBoolean;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<ushort, sbyte> ret = Converts.ToSByte;
                             return (Func<TIn, TOut>)(object)ret;
                         }
                         case NPTypeCode.Byte:
@@ -525,6 +622,11 @@ namespace NumSharp.Utilities
                             Func<int, bool> ret = Converts.ToBoolean;
                             return (Func<TIn, TOut>)(object)ret;
                         }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<int, sbyte> ret = Converts.ToSByte;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
                         case NPTypeCode.Byte:
                         {
                             Func<int, byte> ret = Converts.ToByte;
@@ -594,6 +696,11 @@ namespace NumSharp.Utilities
                         case NPTypeCode.Boolean:
                         {
                             Func<uint, bool> ret = Converts.ToBoolean;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<uint, sbyte> ret = Converts.ToSByte;
                             return (Func<TIn, TOut>)(object)ret;
                         }
                         case NPTypeCode.Byte:
@@ -667,6 +774,11 @@ namespace NumSharp.Utilities
                             Func<long, bool> ret = Converts.ToBoolean;
                             return (Func<TIn, TOut>)(object)ret;
                         }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<long, sbyte> ret = Converts.ToSByte;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
                         case NPTypeCode.Byte:
                         {
                             Func<long, byte> ret = Converts.ToByte;
@@ -736,6 +848,11 @@ namespace NumSharp.Utilities
                         case NPTypeCode.Boolean:
                         {
                             Func<ulong, bool> ret = Converts.ToBoolean;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<ulong, sbyte> ret = Converts.ToSByte;
                             return (Func<TIn, TOut>)(object)ret;
                         }
                         case NPTypeCode.Byte:
@@ -809,6 +926,11 @@ namespace NumSharp.Utilities
                             Func<char, bool> ret = Converts.ToBoolean;
                             return (Func<TIn, TOut>)(object)ret;
                         }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<char, sbyte> ret = Converts.ToSByte;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
                         case NPTypeCode.Byte:
                         {
                             Func<char, byte> ret = Converts.ToByte;
@@ -878,6 +1000,11 @@ namespace NumSharp.Utilities
                         case NPTypeCode.Boolean:
                         {
                             Func<double, bool> ret = Converts.ToBoolean;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<double, sbyte> ret = Converts.ToSByte;
                             return (Func<TIn, TOut>)(object)ret;
                         }
                         case NPTypeCode.Byte:
@@ -951,6 +1078,11 @@ namespace NumSharp.Utilities
                             Func<float, bool> ret = Converts.ToBoolean;
                             return (Func<TIn, TOut>)(object)ret;
                         }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<float, sbyte> ret = Converts.ToSByte;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
                         case NPTypeCode.Byte:
                         {
                             Func<float, byte> ret = Converts.ToByte;
@@ -1020,6 +1152,11 @@ namespace NumSharp.Utilities
                         case NPTypeCode.Boolean:
                         {
                             Func<decimal, bool> ret = Converts.ToBoolean;
+                            return (Func<TIn, TOut>)(object)ret;
+                        }
+                        case NPTypeCode.SByte:
+                        {
+                            Func<decimal, sbyte> ret = Converts.ToSByte;
                             return (Func<TIn, TOut>)(object)ret;
                         }
                         case NPTypeCode.Byte:

--- a/src/NumSharp.Core/Utilities/InfoOf.cs
+++ b/src/NumSharp.Core/Utilities/InfoOf.cs
@@ -37,6 +37,9 @@ namespace NumSharp.Utilities
                 case NPTypeCode.Char:
                     Size = 2;
                     break;
+                case NPTypeCode.SByte:
+                    Size = 1;
+                    break;
                 case NPTypeCode.Byte:
                     Size = 1;
                     break;

--- a/src/NumSharp.Core/Utilities/Maths/BinaryLOperation.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryLOperation.cs
@@ -1,0 +1,89 @@
+﻿using System;
+
+namespace NumSharp.Utilities.Maths
+{
+    /// <summary>
+    /// Encapsulates the <see cref="BinaryLOperation{TLElement, TRElement, TResult}"/> operation caller data necessary to call the operation based on argument type codes.
+    /// </summary>
+    /// <typeparam name="TLElement">The type of a left operation operand.</typeparam>
+    /// <typeparam name="TRElement">The type of a right operation operand.</typeparam>
+    /// <typeparam name="TResult">THe type of an operation result.</typeparam>
+    public class BinaryLOperation<TLElement, TRElement, TResult> : BinaryOperation
+        where TLElement : unmanaged
+        where TRElement : unmanaged
+        where TResult : unmanaged
+    {
+        private readonly Func<NDArray, TRElement, BinaryOperator<TLElement, TRElement, TResult>, NDArray> _operation;
+
+        /// <summary>
+        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation caller.
+        /// </summary>
+        /// <param name="operation">The operation delegate to invoke when operation is executed.</param>
+        public BinaryLOperation(Func<NDArray, TRElement, BinaryOperator<TLElement, TRElement, TResult>, NDArray> operation)
+        {
+            _operation = operation ?? throw new ArgumentNullException(nameof(operation));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="BinaryOperation"/> operation caller type signature key.
+        /// </summary>
+        public override (NPTypeCode, NPTypeCode) GetTypeKey => (typeof(TLElement).GetTypeCode(), typeof(TRElement).GetTypeCode());
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left scalar operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator caller)
+        {
+            throw new NotSupportedException($"The binary operation on a scalar and an array is not supported.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right scalar operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator caller)
+        {
+            if (caller is null)
+                throw new ArgumentNullException(nameof(caller));
+
+            if (caller is BinaryOperator<TLElement, TRElement, TResult> generic)
+                return _operation(lhs, (TRElement)rhs, generic);
+            else
+                throw new ArgumentException($"The operator signature is not compatible with operation.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator caller)
+        {
+            throw new NotSupportedException($"The binary operation on two arrays is not supported.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public NDArray Invoke(NDArray lhs, TRElement rhs, BinaryOperator<TLElement, TRElement, TResult> caller)
+        {
+            if (caller is null)
+                throw new ArgumentNullException(nameof(caller));
+
+            return _operation(lhs, rhs, caller);
+        }
+    }
+}

--- a/src/NumSharp.Core/Utilities/Maths/BinaryLOperation.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryLOperation.cs
@@ -3,7 +3,7 @@
 namespace NumSharp.Utilities.Maths
 {
     /// <summary>
-    /// Encapsulates the <see cref="BinaryLOperation{TLElement, TRElement, TResult}"/> operation caller data necessary to call the operation based on argument type codes.
+    /// Encapsulates the <see cref="BinaryLOperation{TLElement, TRElement, TResult}"/> operation data necessary to call the operation based on argument type codes.
     /// </summary>
     /// <typeparam name="TLElement">The type of a left operation operand.</typeparam>
     /// <typeparam name="TRElement">The type of a right operation operand.</typeparam>
@@ -16,7 +16,7 @@ namespace NumSharp.Utilities.Maths
         private readonly Func<NDArray, TRElement, BinaryOperator<TLElement, TRElement, TResult>, NDArray> _operation;
 
         /// <summary>
-        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation caller.
+        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation.
         /// </summary>
         /// <param name="operation">The operation delegate to invoke when operation is executed.</param>
         public BinaryLOperation(Func<NDArray, TRElement, BinaryOperator<TLElement, TRElement, TResult>, NDArray> operation)
@@ -25,7 +25,7 @@ namespace NumSharp.Utilities.Maths
         }
 
         /// <summary>
-        /// Gets the <see cref="BinaryOperation"/> operation caller type signature key.
+        /// Gets the <see cref="BinaryOperation"/> operation type signature key.
         /// </summary>
         public override (NPTypeCode, NPTypeCode) GetTypeKey => (typeof(TLElement).GetTypeCode(), typeof(TRElement).GetTypeCode());
 
@@ -34,9 +34,9 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left scalar operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator caller)
+        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator @operator)
         {
             throw new NotSupportedException($"The binary operation on a scalar and an array is not supported.");
         }
@@ -46,14 +46,14 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right scalar operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator caller)
+        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator @operator)
         {
-            if (caller is null)
-                throw new ArgumentNullException(nameof(caller));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
 
-            if (caller is BinaryOperator<TLElement, TRElement, TResult> generic)
+            if (@operator is BinaryOperator<TLElement, TRElement, TResult> generic)
                 return _operation(lhs, (TRElement)rhs, generic);
             else
                 throw new ArgumentException($"The operator signature is not compatible with operation.");
@@ -64,9 +64,9 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator caller)
+        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator @operator)
         {
             throw new NotSupportedException($"The binary operation on two arrays is not supported.");
         }
@@ -76,14 +76,14 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public NDArray Invoke(NDArray lhs, TRElement rhs, BinaryOperator<TLElement, TRElement, TResult> caller)
+        public NDArray Invoke(NDArray lhs, TRElement rhs, BinaryOperator<TLElement, TRElement, TResult> @operator)
         {
-            if (caller is null)
-                throw new ArgumentNullException(nameof(caller));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
 
-            return _operation(lhs, rhs, caller);
+            return _operation(lhs, rhs, @operator);
         }
     }
 }

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperation.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperation.cs
@@ -3,12 +3,12 @@
 namespace NumSharp.Utilities.Maths
 {
     /// <summary>
-    /// Encapsulates the <see cref="BinaryOperation"/> operation caller data necessary to call the operation based on argument type codes.
+    /// Encapsulates the <see cref="BinaryOperation"/> operation data necessary to call the operation based on argument type codes.
     /// </summary>
     public abstract class BinaryOperation
     {
         /// <summary>
-        /// Gets the <see cref="BinaryOperation"/> operation caller type signature key.
+        /// Gets the <see cref="BinaryOperation"/> operation type signature key.
         /// </summary>
         public abstract (NPTypeCode, NPTypeCode) GetTypeKey { get; }
 
@@ -17,31 +17,31 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left scalar operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public abstract NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator caller);
+        public abstract NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator @operator);
 
         /// <summary>
         /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right scalar operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public abstract NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator caller);
+        public abstract NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator @operator);
 
         /// <summary>
         /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public abstract NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator caller);
+        public abstract NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator @operator);
     }
 
     /// <summary>
-    /// Encapsulates the <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation caller data necessary to call the operation based on argument type codes.
+    /// Encapsulates the <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation data necessary to call the operation based on argument type codes.
     /// </summary>
     /// <typeparam name="TLElement">The type of a left operation operand.</typeparam>
     /// <typeparam name="TRElement">The type of a right operation operand.</typeparam>
@@ -54,7 +54,7 @@ namespace NumSharp.Utilities.Maths
         private readonly Func<NDArray, NDArray, BinaryOperator<TLElement, TRElement, TResult>, NDArray> _operation;
 
         /// <summary>
-        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation caller.
+        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation.
         /// </summary>
         /// <param name="operation">The operation delegate to invoke when operation is executed.</param>
         public BinaryOperation(Func<NDArray, NDArray, BinaryOperator<TLElement, TRElement, TResult>, NDArray> operation)
@@ -63,7 +63,7 @@ namespace NumSharp.Utilities.Maths
         }
 
         /// <summary>
-        /// Gets the <see cref="BinaryOperation"/> operation caller type signature key.
+        /// Gets the <see cref="BinaryOperation"/> operation type signature key.
         /// </summary>
         public override (NPTypeCode, NPTypeCode) GetTypeKey => (typeof(TLElement).GetTypeCode(), typeof(TRElement).GetTypeCode());
 
@@ -72,9 +72,9 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left scalar operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator caller)
+        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator @operator)
         {
             throw new NotSupportedException($"The binary operation on a scalar and an array is not supported.");
         }
@@ -84,9 +84,9 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right scalar operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator caller)
+        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator @operator)
         {
             throw new NotSupportedException($"The binary operation on an array and scalar a is not supported.");
         }
@@ -96,14 +96,14 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator caller)
+        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator @operator)
         {
-            if (caller is null)
-                throw new ArgumentNullException(nameof(caller));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
 
-            if (caller is BinaryOperator<TLElement, TRElement, TResult> generic)
+            if (@operator is BinaryOperator<TLElement, TRElement, TResult> generic)
                 return _operation(lhs, rhs, generic);
             else
                 throw new ArgumentException($"The operator signature is not compatible with operation.");
@@ -114,14 +114,14 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator<TLElement, TRElement, TResult> caller)
+        public NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator<TLElement, TRElement, TResult> @operator)
         {
-            if (caller is null)
-                throw new ArgumentNullException(nameof(caller));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
 
-            return _operation(lhs, rhs, caller);
+            return _operation(lhs, rhs, @operator);
         }
     }
 }

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperation.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperation.cs
@@ -1,0 +1,127 @@
+﻿using System;
+
+namespace NumSharp.Utilities.Maths
+{
+    /// <summary>
+    /// Encapsulates the <see cref="BinaryOperation"/> operation caller data necessary to call the operation based on argument type codes.
+    /// </summary>
+    public abstract class BinaryOperation
+    {
+        /// <summary>
+        /// Gets the <see cref="BinaryOperation"/> operation caller type signature key.
+        /// </summary>
+        public abstract (NPTypeCode, NPTypeCode) GetTypeKey { get; }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left scalar operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public abstract NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator caller);
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right scalar operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public abstract NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator caller);
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public abstract NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator caller);
+    }
+
+    /// <summary>
+    /// Encapsulates the <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation caller data necessary to call the operation based on argument type codes.
+    /// </summary>
+    /// <typeparam name="TLElement">The type of a left operation operand.</typeparam>
+    /// <typeparam name="TRElement">The type of a right operation operand.</typeparam>
+    /// <typeparam name="TResult">THe type of an operation result.</typeparam>
+    public class BinaryOperation<TLElement, TRElement, TResult> : BinaryOperation
+        where TLElement : unmanaged
+        where TRElement : unmanaged
+        where TResult : unmanaged
+    {
+        private readonly Func<NDArray, NDArray, BinaryOperator<TLElement, TRElement, TResult>, NDArray> _operation;
+
+        /// <summary>
+        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation caller.
+        /// </summary>
+        /// <param name="operation">The operation delegate to invoke when operation is executed.</param>
+        public BinaryOperation(Func<NDArray, NDArray, BinaryOperator<TLElement, TRElement, TResult>, NDArray> operation)
+        {
+            _operation = operation ?? throw new ArgumentNullException(nameof(operation));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="BinaryOperation"/> operation caller type signature key.
+        /// </summary>
+        public override (NPTypeCode, NPTypeCode) GetTypeKey => (typeof(TLElement).GetTypeCode(), typeof(TRElement).GetTypeCode());
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left scalar operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator caller)
+        {
+            throw new NotSupportedException($"The binary operation on a scalar and an array is not supported.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right scalar operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator caller)
+        {
+            throw new NotSupportedException($"The binary operation on an array and scalar a is not supported.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator caller)
+        {
+            if (caller is null)
+                throw new ArgumentNullException(nameof(caller));
+
+            if (caller is BinaryOperator<TLElement, TRElement, TResult> generic)
+                return _operation(lhs, rhs, generic);
+            else
+                throw new ArgumentException($"The operator signature is not compatible with operation.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator<TLElement, TRElement, TResult> caller)
+        {
+            if (caller is null)
+                throw new ArgumentNullException(nameof(caller));
+
+            return _operation(lhs, rhs, caller);
+        }
+    }
+}

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperationIndex.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperationIndex.cs
@@ -97,5 +97,79 @@ namespace NumSharp.Utilities.Maths
         {
             return _operations.GetOrAdd((argl, argr, ret), Create);
         }
+
+        /// <summary>
+        /// Invokes the operation/operator combination on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/>.
+        /// </summary>
+        /// <param name="lhs">The left scalar operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperatorIndex operators)
+        {
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var rtc = lhs.GetType().GetTypeCode();
+            var ltc = rhs.GetTypeCode;
+
+            if (operators.Get(ltc, rtc) is BinaryOperator @operator)
+                if (Get(ltc, rtc, @operator.ReturnCode) is BinaryOperation operation)
+                    return operation.Invoke(lhs, rhs, @operator);
+                else
+                    throw new InvalidOperationException($"The operation is not found for types: {lhs}, {rhs}, {@operator.ReturnCode}.");
+            else
+                throw new InvalidOperationException($"The operation is not found for types: {lhs}, {rhs}.");
+        }
+
+        /// <summary>
+        /// Invokes the operation/operator combination on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/>.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right scalar operand to call the operator for.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperatorIndex operators)
+        {
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetType().GetTypeCode();
+
+            if (operators.Get(ltc, rtc) is BinaryOperator @operator)
+                if (Get(ltc, rtc, @operator.ReturnCode) is BinaryOperation operation)
+                    return operation.Invoke(lhs, rhs, @operator);
+                else
+                    throw new InvalidOperationException($"The operation is not found for types: {lhs}, {rhs}, {@operator.ReturnCode}.");
+            else
+                throw new InvalidOperationException($"The operation is not found for types: {lhs}, {rhs}.");
+        }
+
+        /// <summary>
+        /// Invokes the operation/operator combination for on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/>.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperatorIndex operators)
+        {
+            if (lhs is null)
+                throw new ArgumentNullException(nameof(lhs));
+            if (rhs is null)
+                throw new ArgumentNullException(nameof(rhs));
+
+            var ltc = lhs.GetTypeCode;
+            var rtc = rhs.GetTypeCode;
+
+            if (operators.Get(ltc, rtc) is BinaryOperator @operator)
+                if (Get(ltc, rtc, @operator.ReturnCode) is BinaryOperation operation)
+                    return operation.Invoke(lhs, rhs, @operator);
+                else
+                    throw new InvalidOperationException($"The operation is not found for types: {lhs}, {rhs}, {@operator.ReturnCode}.");
+            else
+                throw new InvalidOperationException($"The operation is not found for types: {lhs}, {rhs}.");
+        }
     }
 }

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperationIndex.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperationIndex.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace NumSharp.Utilities.Maths
 {
-    using OperationCallerIndex = ConcurrentDictionary<(NPTypeCode argl, NPTypeCode argr, NPTypeCode ret), BinaryOperation>;
+    using OperationIndex = ConcurrentDictionary<(NPTypeCode argl, NPTypeCode argr, NPTypeCode ret), BinaryOperation>;
 
     /// <summary>
     /// Encapsulates the binary operation metadata index for the specified static container type and operaton method name.
@@ -15,10 +15,10 @@ namespace NumSharp.Utilities.Maths
     public class BinaryOperationIndex : OperationMetadataIndex
     {
         private readonly MethodInfo _method;
-        private readonly OperationCallerIndex _operations = new OperationCallerIndex();
+        private readonly OperationIndex _operations = new OperationIndex();
         private readonly Type _parameter1;
         private readonly Type _parameter2;
-        private readonly Type _caller;
+        private readonly Type _operator;
         private readonly Type _return;
 
         /// <summary>
@@ -36,18 +36,18 @@ namespace NumSharp.Utilities.Maths
                 _method = method;
                 var parameters = _method.GetParameters().Select(x => x.ParameterType).ToList();
                 if (parameters.Count == 3)
-                    if (parameters[2].GetGenericTypeDefinition() is var caller && caller == typeof(BinaryOperator<,,>))
+                    if (parameters[2].GetGenericTypeDefinition() is var @operator && @operator == typeof(BinaryOperator<,,>))
                         if (_method.ReturnType != typeof(void))
                         {
                             _parameter1 = parameters[0];
                             _parameter2 = parameters[1];
-                            _caller = caller;
+                            _operator = @operator;
                             _return = _method.ReturnType;
                         }
                         else
                             throw new ArgumentException($"The operation {method} is supposed to have return value.", nameof(methodName));
                     else
-                        throw new ArgumentException($"The operation {method} last argument should be a gneric operator caller.", nameof(methodName));
+                        throw new ArgumentException($"The operation {method} last argument should be a gneric operator.", nameof(methodName));
                 else
                     throw new ArgumentException($"The operation {method} is supposed to have {3} arguments.", nameof(methodName));
             }
@@ -56,46 +56,46 @@ namespace NumSharp.Utilities.Maths
         }
 
         /// <summary>
-        /// Creates the <see cref="BinaryOperation"/> operation caller helper based on the argument type codes.
+        /// Creates the <see cref="BinaryOperation"/> operation helper based on the argument type codes.
         /// </summary>
         /// <param name="key">The tuple encapsulating the type codes for arguments.</param>
-        /// <returns>The <see cref="BinaryOperation"/> operation caller created.</returns>
-        private BinaryOperation CreateCaller((NPTypeCode argl, NPTypeCode argr, NPTypeCode ret) key)
+        /// <returns>The <see cref="BinaryOperation"/> operation created.</returns>
+        private BinaryOperation Create((NPTypeCode argl, NPTypeCode argr, NPTypeCode ret) key)
         {
             var (argl, argr, ret) = (Translate(key.argl), Translate(key.argr), Translate(key.ret));
-            var caller = typeof(BinaryOperation<,,>);
+            var @operator = typeof(BinaryOperation<,,>);
             switch ((l: _parameter1, r: _parameter2))
             {
                 case var p when p.l.IsGenericParameter && p.r.IsGenericParameter:
                     throw new InvalidOperationException($"The operation {_method} does not support scalar arguments.");
                 case var p when p.l.IsGenericParameter:
-                    caller = typeof(BinaryROperation<,,>);
+                    @operator = typeof(BinaryROperation<,,>);
                     break;
                 case var p when p.r.IsGenericParameter:
-                    caller = typeof(BinaryLOperation<,,>);
+                    @operator = typeof(BinaryLOperation<,,>);
                     break;
             };
             var parameters = new[] {
                 _parameter1.IsGenericParameter ? argl : _parameter1,
                 _parameter2.IsGenericParameter ? argr : _parameter1,
-                _caller.MakeGenericType(argl, argr, ret),
+                _operator.MakeGenericType(argl, argr, ret),
                 _return
             };
             var signature = typeof(Func<,,,>).MakeGenericType(parameters.ToArray());
             var operation = Delegate.CreateDelegate(signature, _method.MakeGenericMethod(argl, argr, ret));
-            return Activator.CreateInstance(caller.MakeGenericType(argl, argr, ret), operation) as BinaryOperation;
+            return Activator.CreateInstance(@operator.MakeGenericType(argl, argr, ret), operation) as BinaryOperation;
         }
 
         /// <summary>
-        /// Gets the <see cref="BinaryOperation"/> operation caller for the requested argument type codes.
+        /// Gets the <see cref="BinaryOperation"/> operation for the requested argument type codes.
         /// </summary>
         /// <param name="argl">The left operation argument type code.</param>
         /// <param name="argr">The right operation argument type code.</param>
         /// <param name="ret">The return type code.</param>
-        /// <returns>The <see cref="BinaryOperation"/> operation caller returned.</returns>
-        public BinaryOperation GetCaller(NPTypeCode argl, NPTypeCode argr, NPTypeCode ret)
+        /// <returns>The <see cref="BinaryOperation"/> operation returned.</returns>
+        public BinaryOperation Get(NPTypeCode argl, NPTypeCode argr, NPTypeCode ret)
         {
-            return _operations.GetOrAdd((argl, argr, ret), CreateCaller);
+            return _operations.GetOrAdd((argl, argr, ret), Create);
         }
     }
 }

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperationIndex.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperationIndex.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+
+namespace NumSharp.Utilities.Maths
+{
+    using OperationCallerIndex = ConcurrentDictionary<(NPTypeCode argl, NPTypeCode argr, NPTypeCode ret), BinaryOperation>;
+
+    /// <summary>
+    /// Encapsulates the binary operation metadata index for the specified static container type and operaton method name.
+    /// </summary>
+    /// <remarks>This class uses reflection, but only at first operation call. This index that should be a static by design, otherwise,
+    /// it's used improperly. Therefore it's going to have the performance hit only on first invocation of an operation index.</remarks>
+    public class BinaryOperationIndex : OperationMetadataIndex
+    {
+        private readonly MethodInfo _method;
+        private readonly OperationCallerIndex _operations = new OperationCallerIndex();
+        private readonly Type _parameter1;
+        private readonly Type _parameter2;
+        private readonly Type _caller;
+        private readonly Type _return;
+
+        /// <summary>
+        /// Initializes the new instance of a binary operation metadata index and sets the static operation method.
+        /// </summary>
+        /// <param name="type">The containing <see cref="Type"/> that holds the operation method.</param>
+        /// <param name="methodName">The operation method info name to create the lambda functions for.</param>
+        public BinaryOperationIndex(Type type, string methodName)
+        {
+            if (type is null)
+                throw new ArgumentNullException(nameof(type));
+
+            if (type.GetMethod(methodName, Filter) is MethodInfo method)
+            {
+                _method = method;
+                var parameters = _method.GetParameters().Select(x => x.ParameterType).ToList();
+                if (parameters.Count == 3)
+                    if (parameters[2].GetGenericTypeDefinition() is var caller && caller == typeof(BinaryOperator<,,>))
+                        if (_method.ReturnType != typeof(void))
+                        {
+                            _parameter1 = parameters[0];
+                            _parameter2 = parameters[1];
+                            _caller = caller;
+                            _return = _method.ReturnType;
+                        }
+                        else
+                            throw new ArgumentException($"The operation {method} is supposed to have return value.", nameof(methodName));
+                    else
+                        throw new ArgumentException($"The operation {method} last argument should be a gneric operator caller.", nameof(methodName));
+                else
+                    throw new ArgumentException($"The operation {method} is supposed to have {3} arguments.", nameof(methodName));
+            }
+            else
+                throw new ArgumentException($"The operation method does not exist on type {type}: {methodName}.");
+        }
+
+        /// <summary>
+        /// Creates the <see cref="BinaryOperation"/> operation caller helper based on the argument type codes.
+        /// </summary>
+        /// <param name="key">The tuple encapsulating the type codes for arguments.</param>
+        /// <returns>The <see cref="BinaryOperation"/> operation caller created.</returns>
+        private BinaryOperation CreateCaller((NPTypeCode argl, NPTypeCode argr, NPTypeCode ret) key)
+        {
+            var (argl, argr, ret) = (Translate(key.argl), Translate(key.argr), Translate(key.ret));
+            var caller = typeof(BinaryOperation<,,>);
+            switch ((l: _parameter1, r: _parameter2))
+            {
+                case var p when p.l.IsGenericParameter && p.r.IsGenericParameter:
+                    throw new InvalidOperationException($"The operation {_method} does not support scalar arguments.");
+                case var p when p.l.IsGenericParameter:
+                    caller = typeof(BinaryROperation<,,>);
+                    break;
+                case var p when p.r.IsGenericParameter:
+                    caller = typeof(BinaryLOperation<,,>);
+                    break;
+            };
+            var parameters = new[] {
+                _parameter1.IsGenericParameter ? argl : _parameter1,
+                _parameter2.IsGenericParameter ? argr : _parameter1,
+                _caller.MakeGenericType(argl, argr, ret),
+                _return
+            };
+            var signature = typeof(Func<,,,>).MakeGenericType(parameters.ToArray());
+            var operation = Delegate.CreateDelegate(signature, _method.MakeGenericMethod(argl, argr, ret));
+            return Activator.CreateInstance(caller.MakeGenericType(argl, argr, ret), operation) as BinaryOperation;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="BinaryOperation"/> operation caller for the requested argument type codes.
+        /// </summary>
+        /// <param name="argl">The left operation argument type code.</param>
+        /// <param name="argr">The right operation argument type code.</param>
+        /// <param name="ret">The return type code.</param>
+        /// <returns>The <see cref="BinaryOperation"/> operation caller returned.</returns>
+        public BinaryOperation GetCaller(NPTypeCode argl, NPTypeCode argr, NPTypeCode ret)
+        {
+            return _operations.GetOrAdd((argl, argr, ret), CreateCaller);
+        }
+    }
+}

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperator.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperator.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace NumSharp.Utilities.Maths
+{
+    /// <summary>
+    /// Encapsulates the <see cref="BinaryOperator"/> operator caller data necessary to call the operator based on argument type codes.
+    /// </summary>
+    public abstract class BinaryOperator
+    {
+        /// <summary>
+        /// Gets the <see cref="BinaryOperator"/> operator caller type code signature key.
+        /// </summary>
+        public abstract (NPTypeCode, NPTypeCode) Key { get; }
+
+        /// <summary>
+        /// Gets the <see cref="BinaryOperator"/> operator caller return type code.
+        /// </summary>
+        public abstract NPTypeCode ReturnCode { get; }
+    }
+
+    /// <summary>
+    /// Encapsulates the <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller data necessary to call the operator based on argument type codes.
+    /// </summary>
+    /// <typeparam name="TLElement">The type of a left operator operand.</typeparam>
+    /// <typeparam name="TRElement">The type of a right operator operand.</typeparam>
+    /// <typeparam name="TResult">THe type of an operator result.</typeparam>
+    public class BinaryOperator<TLElement, TRElement, TResult> : BinaryOperator
+        where TLElement : unmanaged
+        where TRElement : unmanaged
+        where TResult : unmanaged
+    {
+        private readonly Func<TLElement, TRElement, TResult> _operator;
+
+        /// <summary>
+        /// Creates the new instance of an  <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller.
+        /// </summary>
+        /// <param name="operator">The operator delegate to invoke when operator is executed.</param>
+        public BinaryOperator(Func<TLElement, TRElement, TResult> @operator)
+        {
+            _operator = @operator ?? throw new ArgumentNullException(nameof(@operator));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="BinaryOperator"/> operator caller type code signature key.
+        /// </summary>
+        public override (NPTypeCode, NPTypeCode) Key => (typeof(TLElement).GetTypeCode(), typeof(TRElement).GetTypeCode());
+
+        /// <summary>
+        /// Gets the <see cref="BinaryOperator"/> operator caller return type code.
+        /// </summary>
+        public override NPTypeCode ReturnCode => typeof(TResult).GetTypeCode();
+
+        /// <summary>
+        /// Runs the <see cref="Parallel.For(int, int, Action{int})"/> operation for every array element and a scalar element.
+        /// </summary>
+        /// <param name="index">The starting index for an array operation.</param>
+        /// <param name="length">The sequence length for an array operation.</param>
+        /// <param name="result">The operator result pointer to place the value to.</param>
+        /// <param name="lhs">The left operator argument pointer to get the value from.</param>
+        /// <param name="rhs">The right operator argument to get the value from.</param>
+        public unsafe void ParallelFor(int index, int length, TResult* result, TLElement* lhs, TRElement rhs)
+        {
+            Parallel.For(index, length, i => *(result + i) = _operator(*(lhs + i), rhs));
+        }
+
+        /// <summary>
+        /// Runs the <see cref="Parallel.For(int, int, Action{int})"/> operation for a scalar element and every array element.
+        /// </summary>
+        /// <param name="index">The starting index for an array operation.</param>
+        /// <param name="length">The sequence length for an array operation.</param>
+        /// <param name="result">The operator result pointer to place the value to.</param>
+        /// <param name="lhs">The left operator argument to get the value from.</param>
+        /// <param name="rhs">The right operator argument pointer to get the value from.</param>
+        public unsafe void ParallelFor(int index, int length, TResult* result, TLElement lhs, TRElement* rhs)
+        {
+            Parallel.For(index, length, i => *(result + i) = _operator(lhs, *(rhs + i)));
+        }
+
+        /// <summary>
+        /// Runs the <see cref="Parallel.For(int, int, Action{int})"/> operation for every array element in both sides.
+        /// </summary>
+        /// <param name="index">The starting index for an array operation.</param>
+        /// <param name="length">The sequence length for an array operation.</param>
+        /// <param name="result">The operator result pointer to place the value to.</param>
+        /// <param name="lhs">The left operator argument pointer to get the value from.</param>
+        /// <param name="rhs">The right operator argument pointer to get the value from.</param>
+        public unsafe void ParallelFor(int index, int length, TResult* result, TLElement* lhs, TRElement* rhs)
+        {
+            Parallel.For(index, length, i => *(result + i) = _operator(*(lhs + i), *(rhs + i)));
+        }
+
+        /// <summary>
+        /// Runs the coordinate incrementor in linear and non-linear arrays.
+        /// </summary>
+        /// <param name="result">The operator result pointer to place the value to.</param>
+        /// <param name="lhs">The left operator argument pointer to get the value from.</param>
+        /// <param name="rhs">The right operator argument pointer to get the value from.</param>
+        /// <param name="rs">The shape of a right array argument.</param>
+        public unsafe void IncrementFor(TResult* result, TLElement* lhs, TRElement* rhs, ref Shape rs)
+        {
+            var incrementor = new NDCoordinatesIncrementor(ref rs);
+            var current = incrementor.Index;
+            Func<int[], int> rsOffset = rs.GetOffset;
+            do
+                *result++ = _operator(*lhs++, *(rhs + rsOffset(current)));
+            while (incrementor.Next() != null);
+        }
+
+        /// <summary>
+        /// Runs the coordinate incrementor in non-linear and linear arrays.
+        /// </summary>
+        /// <param name="result">The operator result pointer to place the value to.</param>
+        /// <param name="lhs">The left operator argument pointer to get the value from.</param>
+        /// <param name="ls">The shape of a left array argument.</param>
+        /// <param name="rhs">The right operator argument pointer to get the value from.</param>
+        public unsafe void IncrementFor(TResult* result, TLElement* lhs, ref Shape ls, TRElement* rhs)
+        {
+            var incrementor = new NDCoordinatesIncrementor(ref ls);
+            var current = incrementor.Index;
+            Func<int[], int> lsOffset = ls.GetOffset;
+            do
+                *result++ = _operator(*(lhs + lsOffset(current)), *rhs++);
+            while (incrementor.Next() != null);
+        }
+
+        /// <summary>
+        /// Runs the coordinate incrementor in non-linear and non-linear arrays.
+        /// </summary>
+        /// <param name="result">The operator result pointer to place the value to.</param>
+        /// <param name="lhs">The left operator argument pointer to get the value from.</param>
+        /// <param name="ls">The shape of a left array argument.</param>
+        /// <param name="rhs">The right operator argument pointer to get the value from.</param>
+        /// <param name="rs">The shape of a right array argument.</param>
+        public unsafe void IncrementFor(TResult* result, TLElement* lhs, ref Shape ls, TRElement* rhs, ref Shape rs)
+        {
+            var incrementor = new NDCoordinatesIncrementor(ref ls);
+            var current = incrementor.Index;
+            Func<int[], int> rsOffset = rs.GetOffset;
+            Func<int[], int> lsOffset = ls.GetOffset;
+            do
+                *result++ = _operator(*(lhs + lsOffset(current)), *(rhs + rsOffset(current)));
+            while (incrementor.Next() != null);
+        }
+    }
+}

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperator.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperator.cs
@@ -4,23 +4,23 @@ using System.Threading.Tasks;
 namespace NumSharp.Utilities.Maths
 {
     /// <summary>
-    /// Encapsulates the <see cref="BinaryOperator"/> operator caller data necessary to call the operator based on argument type codes.
+    /// Encapsulates the <see cref="BinaryOperator"/> operator data necessary to call the operator based on argument type codes.
     /// </summary>
     public abstract class BinaryOperator
     {
         /// <summary>
-        /// Gets the <see cref="BinaryOperator"/> operator caller type code signature key.
+        /// Gets the <see cref="BinaryOperator"/> operator type code signature key.
         /// </summary>
         public abstract (NPTypeCode, NPTypeCode) Key { get; }
 
         /// <summary>
-        /// Gets the <see cref="BinaryOperator"/> operator caller return type code.
+        /// Gets the <see cref="BinaryOperator"/> operator return type code.
         /// </summary>
         public abstract NPTypeCode ReturnCode { get; }
     }
 
     /// <summary>
-    /// Encapsulates the <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller data necessary to call the operator based on argument type codes.
+    /// Encapsulates the <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator data necessary to call the operator based on argument type codes.
     /// </summary>
     /// <typeparam name="TLElement">The type of a left operator operand.</typeparam>
     /// <typeparam name="TRElement">The type of a right operator operand.</typeparam>
@@ -33,7 +33,7 @@ namespace NumSharp.Utilities.Maths
         private readonly Func<TLElement, TRElement, TResult> _operator;
 
         /// <summary>
-        /// Creates the new instance of an  <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller.
+        /// Creates the new instance of an  <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator.
         /// </summary>
         /// <param name="operator">The operator delegate to invoke when operator is executed.</param>
         public BinaryOperator(Func<TLElement, TRElement, TResult> @operator)
@@ -42,12 +42,12 @@ namespace NumSharp.Utilities.Maths
         }
 
         /// <summary>
-        /// Gets the <see cref="BinaryOperator"/> operator caller type code signature key.
+        /// Gets the <see cref="BinaryOperator"/> operator type code signature key.
         /// </summary>
         public override (NPTypeCode, NPTypeCode) Key => (typeof(TLElement).GetTypeCode(), typeof(TRElement).GetTypeCode());
 
         /// <summary>
-        /// Gets the <see cref="BinaryOperator"/> operator caller return type code.
+        /// Gets the <see cref="BinaryOperator"/> operator return type code.
         /// </summary>
         public override NPTypeCode ReturnCode => typeof(TResult).GetTypeCode();
 

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperatorIndex.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperatorIndex.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace NumSharp.Utilities.Maths
 {
-    using OperatorCallerIndex = ConcurrentDictionary<(NPTypeCode argl, NPTypeCode argr), BinaryOperator>;
+    using OperatorIndex = ConcurrentDictionary<(NPTypeCode argl, NPTypeCode argr), BinaryOperator>;
 
     /// <summary>
     /// Encapsulates the binary operator metadata index for the specified static container type and operaton method name.
@@ -15,7 +15,7 @@ namespace NumSharp.Utilities.Maths
     public class BinaryOperatorIndex : OperationMetadataIndex
     {
         private readonly string _operatorName;
-        private readonly OperatorCallerIndex _operators = new OperatorCallerIndex();
+        private readonly OperatorIndex _operators = new OperatorIndex();
 
         /// <summary>
         /// Creates the new instance of a binary operator metadata index and scans the static container type for operators.
@@ -39,7 +39,7 @@ namespace NumSharp.Utilities.Maths
                     if (method.ReturnType is var ret && !IsValid(ret))
                         throw new InvalidOperationException($"The left operator argument type is not supported: {argr.GetTypeCode()}.");
                     var key = (argl.GetTypeCode(), argr.GetTypeCode());
-                    _operators.TryAdd((argl.GetTypeCode(), argr.GetTypeCode()), CreateCaller(key, method));
+                    _operators.TryAdd((argl.GetTypeCode(), argr.GetTypeCode()), Create(key, method));
                 }
                 else
                     throw new InvalidOperationException($"The method {method} does not match the required parameter signature.");
@@ -47,41 +47,41 @@ namespace NumSharp.Utilities.Maths
         }
 
         /// <summary>
-        /// Creates the <see cref="BinaryOperator"/> operator caller helper based on the argument type codes.
+        /// Creates the <see cref="BinaryOperator"/> operator helper based on the argument type codes.
         /// </summary>
         /// <param name="key">The tuple encapsulating the type codes for arguments.</param>
         /// <param name="method">The <see cref="MethodInfo"/> reflection method that should be used as a delegate.</param>
-        /// <returns>The <see cref="BinaryOperator"/> operation caller created.</returns>
-        private BinaryOperator CreateCaller((NPTypeCode argl, NPTypeCode argr) key, MethodInfo method)
+        /// <returns>The <see cref="BinaryOperator"/> operation created.</returns>
+        private BinaryOperator Create((NPTypeCode argl, NPTypeCode argr) key, MethodInfo method)
         {
             if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
             //var (argl, argr, ret) = (Translate(key.argl), Translate(key.argr), Translate(key.ret));
             //var method = _method.MakeGenericMethod(argl, argr);
-            //var caller = typeof(OperationCaller<,,>).MakeGenericType(argl, argr, ret);
+            //var caller = typeof(Operation<,,>).MakeGenericType(argl, argr, ret);
             //var ls = Expression.Parameter(typeof(NDArray), "ls");
             //var rs = Expression.Parameter(typeof(NDArray), "rs");
-            //var @operator = Expression.Parameter(typeof(OperatorCaller), "operator");
+            //var @operator = Expression.Parameter(typeof(Operator), "operator");
             //var lambda = Expression.Lambda(Expression.Call(method, ls, rs, @operator), true, ls, rs, @operator);
-            //return Activator.CreateInstance(caller, lambda.Compile()) as OperationCaller;
+            //return Activator.CreateInstance(caller, lambda.Compile()) as Operation;
 
             var (argl, argr, ret) = (Translate(key.argl), Translate(key.argr), Translate(method.ReturnType.GetTypeCode()));
-            var caller = typeof(BinaryOperator<,,>).MakeGenericType(argl, argr, ret);
+            var @operator = typeof(BinaryOperator<,,>).MakeGenericType(argl, argr, ret);
             var signature = typeof(Func<,,>).MakeGenericType(argl, argr, ret);
-            return Activator.CreateInstance(caller, Delegate.CreateDelegate(signature, method)) as BinaryOperator;
+            return Activator.CreateInstance(@operator, Delegate.CreateDelegate(signature, method)) as BinaryOperator;
         }
 
         /// <summary>
-        /// Gets the <see cref="BinaryOperator"/> operator caller for the requested argument type codes.
+        /// Gets the <see cref="BinaryOperator"/> operator for the requested argument type codes.
         /// </summary>
         /// <param name="argl">The left operation argument type code.</param>
         /// <param name="argr">The right operation argument type code.</param>
-        /// <returns>The <see cref="BinaryOperator"/> operation caller returned.</returns>
-        public BinaryOperator GetCaller(NPTypeCode argl, NPTypeCode argr)
+        /// <returns>The <see cref="BinaryOperator"/> operation returned.</returns>
+        public BinaryOperator Get(NPTypeCode argl, NPTypeCode argr)
         {
-            if (_operators.TryGetValue((argl, argr), out var caller))
-                return caller;
+            if (_operators.TryGetValue((argl, argr), out var @operator))
+                return @operator;
             else
                 throw new ArgumentException($"The operator {_operatorName} is not supported for arguments: {argl}, {argr}.");
         }

--- a/src/NumSharp.Core/Utilities/Maths/BinaryOperatorIndex.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryOperatorIndex.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+
+namespace NumSharp.Utilities.Maths
+{
+    using OperatorCallerIndex = ConcurrentDictionary<(NPTypeCode argl, NPTypeCode argr), BinaryOperator>;
+
+    /// <summary>
+    /// Encapsulates the binary operator metadata index for the specified static container type and operaton method name.
+    /// </summary>
+    /// <remarks>This class uses reflection, but it takes time only at instance initialization that should be a static by design, otherwise, it's used improperly.
+    /// Therefore it's going to have the performance hit only on first invocation of an operator index.</remarks>
+    public class BinaryOperatorIndex : OperationMetadataIndex
+    {
+        private readonly string _operatorName;
+        private readonly OperatorCallerIndex _operators = new OperatorCallerIndex();
+
+        /// <summary>
+        /// Creates the new instance of a binary operator metadata index and scans the static container type for operators.
+        /// </summary>
+        /// <param name="type">The static container <see cref="Type"/> thet contains the operator delegates.</param>
+        /// <param name="methodName">The operator delegates method info name to create the index for.</param>
+        public BinaryOperatorIndex(Type type, string methodName)
+        {
+            if (type is null)
+                throw new ArgumentNullException(nameof(type));
+
+            _operatorName = methodName;
+            foreach (var method in type.GetMethods().Where(x => x.Name == methodName))
+            {
+                if (method.GetParameters() is ParameterInfo[] args && args.Length == 2)
+                {
+                    if (args[0].ParameterType is var argl && !IsValid(argl))
+                        throw new InvalidOperationException($"The left operator argument type is not supported: {argl.GetTypeCode()}.");
+                    if (args[1].ParameterType is var argr && !IsValid(argr))
+                        throw new InvalidOperationException($"The left operator argument type is not supported: {argr.GetTypeCode()}.");
+                    if (method.ReturnType is var ret && !IsValid(ret))
+                        throw new InvalidOperationException($"The left operator argument type is not supported: {argr.GetTypeCode()}.");
+                    var key = (argl.GetTypeCode(), argr.GetTypeCode());
+                    _operators.TryAdd((argl.GetTypeCode(), argr.GetTypeCode()), CreateCaller(key, method));
+                }
+                else
+                    throw new InvalidOperationException($"The method {method} does not match the required parameter signature.");
+            }
+        }
+
+        /// <summary>
+        /// Creates the <see cref="BinaryOperator"/> operator caller helper based on the argument type codes.
+        /// </summary>
+        /// <param name="key">The tuple encapsulating the type codes for arguments.</param>
+        /// <param name="method">The <see cref="MethodInfo"/> reflection method that should be used as a delegate.</param>
+        /// <returns>The <see cref="BinaryOperator"/> operation caller created.</returns>
+        private BinaryOperator CreateCaller((NPTypeCode argl, NPTypeCode argr) key, MethodInfo method)
+        {
+            if (method is null)
+                throw new ArgumentNullException(nameof(method));
+
+            //var (argl, argr, ret) = (Translate(key.argl), Translate(key.argr), Translate(key.ret));
+            //var method = _method.MakeGenericMethod(argl, argr);
+            //var caller = typeof(OperationCaller<,,>).MakeGenericType(argl, argr, ret);
+            //var ls = Expression.Parameter(typeof(NDArray), "ls");
+            //var rs = Expression.Parameter(typeof(NDArray), "rs");
+            //var @operator = Expression.Parameter(typeof(OperatorCaller), "operator");
+            //var lambda = Expression.Lambda(Expression.Call(method, ls, rs, @operator), true, ls, rs, @operator);
+            //return Activator.CreateInstance(caller, lambda.Compile()) as OperationCaller;
+
+            var (argl, argr, ret) = (Translate(key.argl), Translate(key.argr), Translate(method.ReturnType.GetTypeCode()));
+            var caller = typeof(BinaryOperator<,,>).MakeGenericType(argl, argr, ret);
+            var signature = typeof(Func<,,>).MakeGenericType(argl, argr, ret);
+            return Activator.CreateInstance(caller, Delegate.CreateDelegate(signature, method)) as BinaryOperator;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="BinaryOperator"/> operator caller for the requested argument type codes.
+        /// </summary>
+        /// <param name="argl">The left operation argument type code.</param>
+        /// <param name="argr">The right operation argument type code.</param>
+        /// <returns>The <see cref="BinaryOperator"/> operation caller returned.</returns>
+        public BinaryOperator GetCaller(NPTypeCode argl, NPTypeCode argr)
+        {
+            if (_operators.TryGetValue((argl, argr), out var caller))
+                return caller;
+            else
+                throw new ArgumentException($"The operator {_operatorName} is not supported for arguments: {argl}, {argr}.");
+        }
+    }
+}

--- a/src/NumSharp.Core/Utilities/Maths/BinaryROperation.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryROperation.cs
@@ -3,7 +3,7 @@
 namespace NumSharp.Utilities.Maths
 {
     /// <summary>
-    /// Encapsulates the <see cref="BinaryROperation{TLElement, TRElement, TResult}"/> operation caller data necessary to call the operation based on argument type codes.
+    /// Encapsulates the <see cref="BinaryROperation{TLElement, TRElement, TResult}"/> operation data necessary to call the operation based on argument type codes.
     /// </summary>
     /// <typeparam name="TLElement">The type of a left operation operand.</typeparam>
     /// <typeparam name="TRElement">The type of a right operation operand.</typeparam>
@@ -16,7 +16,7 @@ namespace NumSharp.Utilities.Maths
         private readonly Func<TLElement, NDArray, BinaryOperator<TLElement, TRElement, TResult>, NDArray> _operation;
 
         /// <summary>
-        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation caller.
+        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation.
         /// </summary>
         /// <param name="operation">The operation delegate to invoke when operation is executed.</param>
         public BinaryROperation(Func<TLElement, NDArray, BinaryOperator<TLElement, TRElement, TResult>, NDArray> operation)
@@ -25,7 +25,7 @@ namespace NumSharp.Utilities.Maths
         }
 
         /// <summary>
-        /// Gets the <see cref="BinaryOperation"/> operation caller type signature key.
+        /// Gets the <see cref="BinaryOperation"/> operation type signature key.
         /// </summary>
         public override (NPTypeCode, NPTypeCode) GetTypeKey => (typeof(TLElement).GetTypeCode(), typeof(TRElement).GetTypeCode());
 
@@ -34,14 +34,14 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left scalar operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator caller)
+        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator @operator)
         {
-            if (caller is null)
-                throw new ArgumentNullException(nameof(caller));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
 
-            if (caller is BinaryOperator<TLElement, TRElement, TResult> generic)
+            if (@operator is BinaryOperator<TLElement, TRElement, TResult> generic)
                 return _operation((TLElement)lhs, rhs, generic);
             else
                 throw new ArgumentException($"The operator signature is not compatible with operation.");
@@ -52,9 +52,9 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right scalar operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator caller)
+        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator @operator)
         {
             throw new NotSupportedException($"The binary operation on an array and a scalar is not supported.");
         }
@@ -64,9 +64,9 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator caller)
+        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator @operator)
         {
             throw new NotSupportedException($"The binary operation on two arrays is not supported.");
         }
@@ -76,14 +76,14 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
         /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
-        /// <param name="caller">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller that maps the operator signature.</param>
+        /// <param name="operator">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator that maps the operator signature.</param>
         /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
-        public NDArray Invoke(TLElement lhs, NDArray rhs, BinaryOperator<TLElement, TRElement, TResult> caller)
+        public NDArray Invoke(TLElement lhs, NDArray rhs, BinaryOperator<TLElement, TRElement, TResult> @operator)
         {
-            if (caller is null)
-                throw new ArgumentNullException(nameof(caller));
+            if (@operator is null)
+                throw new ArgumentNullException(nameof(@operator));
 
-            return _operation(lhs, rhs, caller);
+            return _operation(lhs, rhs, @operator);
         }
     }
 }

--- a/src/NumSharp.Core/Utilities/Maths/BinaryROperation.cs
+++ b/src/NumSharp.Core/Utilities/Maths/BinaryROperation.cs
@@ -1,0 +1,89 @@
+﻿using System;
+
+namespace NumSharp.Utilities.Maths
+{
+    /// <summary>
+    /// Encapsulates the <see cref="BinaryROperation{TLElement, TRElement, TResult}"/> operation caller data necessary to call the operation based on argument type codes.
+    /// </summary>
+    /// <typeparam name="TLElement">The type of a left operation operand.</typeparam>
+    /// <typeparam name="TRElement">The type of a right operation operand.</typeparam>
+    /// <typeparam name="TResult">THe type of an operation result.</typeparam>
+    public class BinaryROperation<TLElement, TRElement, TResult> : BinaryOperation
+        where TLElement : unmanaged
+        where TRElement : unmanaged
+        where TResult : unmanaged
+    {
+        private readonly Func<TLElement, NDArray, BinaryOperator<TLElement, TRElement, TResult>, NDArray> _operation;
+
+        /// <summary>
+        /// Creates the new instance of an  <see cref="BinaryOperation{TLElement, TRElement, TResult}"/> operation caller.
+        /// </summary>
+        /// <param name="operation">The operation delegate to invoke when operation is executed.</param>
+        public BinaryROperation(Func<TLElement, NDArray, BinaryOperator<TLElement, TRElement, TResult>, NDArray> operation)
+        {
+            _operation = operation ?? throw new ArgumentNullException(nameof(operation));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="BinaryOperation"/> operation caller type signature key.
+        /// </summary>
+        public override (NPTypeCode, NPTypeCode) GetTypeKey => (typeof(TLElement).GetTypeCode(), typeof(TRElement).GetTypeCode());
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left scalar operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(ValueType lhs, NDArray rhs, BinaryOperator caller)
+        {
+            if (caller is null)
+                throw new ArgumentNullException(nameof(caller));
+
+            if (caller is BinaryOperator<TLElement, TRElement, TResult> generic)
+                return _operation((TLElement)lhs, rhs, generic);
+            else
+                throw new ArgumentException($"The operator signature is not compatible with operation.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right scalar operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(NDArray lhs, ValueType rhs, BinaryOperator caller)
+        {
+            throw new NotSupportedException($"The binary operation on an array and a scalar is not supported.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public override NDArray Invoke(NDArray lhs, NDArray rhs, BinaryOperator caller)
+        {
+            throw new NotSupportedException($"The binary operation on two arrays is not supported.");
+        }
+
+        /// <summary>
+        /// Invokes the operator on <see cref="NDArray"/> by matching an <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> with the requested operator signature.
+        /// </summary>
+        /// <param name="lhs">The left <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="rhs">The right <see cref="NDArray"/> operand to call the operator for.</param>
+        /// <param name="caller">The <see cref="BinaryOperator{TLElement, TRElement, TResult}"/> operator caller that maps the operator signature.</param>
+        /// <returns>The resulting <see cref="NDArray"/> returned.</returns>
+        public NDArray Invoke(TLElement lhs, NDArray rhs, BinaryOperator<TLElement, TRElement, TResult> caller)
+        {
+            if (caller is null)
+                throw new ArgumentNullException(nameof(caller));
+
+            return _operation(lhs, rhs, caller);
+        }
+    }
+}

--- a/src/NumSharp.Core/Utilities/Maths/OperationMetadataIndex.cs
+++ b/src/NumSharp.Core/Utilities/Maths/OperationMetadataIndex.cs
@@ -22,8 +22,8 @@ namespace NumSharp.Utilities.Maths
         /// </summary>
         private static readonly OperationTypeIndex s_types = new Type[]
         {
-            typeof(bool),
-            typeof(char), typeof(byte), typeof(short), typeof(ushort),
+            typeof(bool), typeof(char),
+            typeof(sbyte), typeof(byte), typeof(short), typeof(ushort),
             typeof(int), typeof(uint), typeof(long), typeof(ulong),
             typeof(float), typeof(double), typeof(decimal), typeof(Complex)
         }.ToDictionary(x => x.GetTypeCode());

--- a/src/NumSharp.Core/Utilities/Maths/OperationMetadataIndex.cs
+++ b/src/NumSharp.Core/Utilities/Maths/OperationMetadataIndex.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
+
+namespace NumSharp.Utilities.Maths
+{
+    using OperationTypeIndex = Dictionary<NPTypeCode, Type>;
+
+    /// <summary>
+    /// Encapsulates the base operation metadata index functionality that supports dynamic <see cref="NDArray"/> operation inference.
+    /// </summary>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable
+    public class OperationMetadataIndex
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
+    {
+        protected const BindingFlags Filter = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+        /// <summary>
+        /// The index of types supported by <see cref="NDArray"/> operations.
+        /// </summary>
+        private static readonly OperationTypeIndex s_types = new Type[]
+        {
+            typeof(bool),
+            typeof(char), typeof(byte), typeof(short), typeof(ushort),
+            typeof(int), typeof(uint), typeof(long), typeof(ulong),
+            typeof(float), typeof(double), typeof(decimal), typeof(Complex)
+        }.ToDictionary(x => x.GetTypeCode());
+
+        /// <summary>
+        /// Translates the <see cref="NPTypeCode"/> type code in to the actual reflecton type.
+        /// </summary>
+        /// <param name="code">The type code to translate into the type.</param>
+        /// <returns>The <see cref="NDArray"/> element <see cref="Type"/>translated.</returns>
+        public static Type Translate(NPTypeCode code)
+        {
+            if (s_types.TryGetValue(code, out var type))
+                return type;
+            else
+                throw new ArgumentException($"The operation index does not support requested type code: {code}.");
+        }
+
+        /// <summary>
+        /// Validates the <see cref="NDArray"/> element <see cref="Type"/> against the index of supported type.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to validate agains the operation metadata index.</param>
+        /// <returns>True if the <see cref="Type"/> is supported; otherwise, false.</returns>
+        public static bool IsValid(Type type)
+        {
+            if (type is null)
+                throw new ArgumentNullException(nameof(type));
+
+            return s_types.ContainsKey(type.GetTypeCode());
+        }
+    }
+}

--- a/src/NumSharp.Core/Utilities/Maths/Operator.Bitwise.cs
+++ b/src/NumSharp.Core/Utilities/Maths/Operator.Bitwise.cs
@@ -5,32 +5,61 @@ namespace NumSharp.Utilities.Maths
 {
     internal partial class Operator
     {
+
         #region Bitwise AND
         // Boolean
+        // The type inference is based on Python output for the following type combinations:
+        // print((np.array([True], dtype=np.bool) & np.array([True])).dtype)               -> bool   : bool
+        // print((np.array([True], dtype=np.bool) & np.array([1], dtype=np.int8)).dtype)   -> int8   : sbyte
+        // print((np.array([True], dtype=np.bool) & np.array([1], dtype=np.uint8)).dtype)  -> uint8  : byte
+        // print((np.array([True], dtype=np.bool) & np.array([1], dtype=np.int16)).dtype)  -> int16  : short
+        // print((np.array([True], dtype=np.bool) & np.array([1], dtype=np.uint16)).dtype) -> uint16 : ushort
+        // print((np.array([True], dtype=np.bool) & np.array([1], dtype=np.int32)).dtype)  -> int32  : int
+        // print((np.array([True], dtype=np.bool) & np.array([1], dtype=np.uint32)).dtype) -> uint32 : uint
+        // print((np.array([True], dtype=np.bool) & np.array([1], dtype=np.int64)).dtype)  -> int64  : long
+        // print((np.array([True], dtype=np.bool) & np.array([1], dtype=np.uint64)).dtype) -> uint64 : ulong
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool BitwiseAnd(bool lhs, bool rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(bool lhs, char rhs) => (char)(Convert.ToInt32(lhs) & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(bool lhs, byte rhs) => (byte)(Convert.ToUInt32(lhs) & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(bool lhs, short rhs) => (short)(Convert.ToInt32(lhs) & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(bool lhs, ushort rhs) => (ushort)(Convert.ToUInt32(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static sbyte BitwiseAnd(bool lhs, sbyte rhs) => (sbyte)(Convert.ToSByte(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(bool lhs, byte rhs) => (byte)(Convert.ToByte(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(bool lhs, short rhs) => (short)(Convert.ToInt16(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(bool lhs, ushort rhs) => (ushort)(Convert.ToUInt16(lhs) & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(bool lhs, int rhs) => Convert.ToInt32(lhs) & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(bool lhs, uint rhs) => Convert.ToUInt32(lhs) & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(bool lhs, long rhs) => Convert.ToInt64(lhs) & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(bool lhs, ulong rhs) => Convert.ToUInt64(lhs) & rhs;
 
-        // Int8
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(char lhs, bool rhs) => (char)(lhs & Convert.ToInt32(rhs));
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(char lhs, char rhs) => (char)(lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(char lhs, byte rhs) => (byte)(lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(char lhs, short rhs) => (short)(lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(char lhs, ushort rhs) => (ushort)(lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(char lhs, int rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(char lhs, uint rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(char lhs, long rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(char lhs, ulong rhs) => lhs & rhs;
+        // SByte
+        // print((np.array([1], dtype=np.int8) & np.array([True])).dtype)                # -> int8  : sbyte 
+        // print((np.array([1], dtype=np.int8) & np.array([1], dtype=np.int8)).dtype)    # -> int8  : sbyte 
+        // print((np.array([1], dtype=np.int8) & np.array([1], dtype=np.uint8)).dtype)   # -> int16 : short 
+        // print((np.array([1], dtype=np.int8) & np.array([1], dtype=np.int16)).dtype)   # -> int16 : short  
+        // print((np.array([1], dtype=np.int8) & np.array([1], dtype=np.uint16)).dtype)  # -> int32 : int
+        // print((np.array([1], dtype=np.int8) & np.array([1], dtype=np.int32)).dtype)   # -> int32 : int  
+        // print((np.array([1], dtype=np.int8) & np.array([1], dtype=np.uint32)).dtype)  # -> int64 : long
+        // print((np.array([1], dtype=np.int8) & np.array([1], dtype=np.int64)).dtype)   # -> int64 : long  
+        // print((np.array([1], dtype=np.int8) & np.array([1], dtype=np.uint64)).dtype)  # -> 'bitwise_and' not supported for the input type
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static sbyte BitwiseAnd(sbyte lhs, bool rhs) => (sbyte)(lhs & Convert.ToSByte(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static sbyte BitwiseAnd(sbyte lhs, sbyte rhs) => (sbyte)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(sbyte lhs, byte rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(sbyte lhs, short rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(sbyte lhs, ushort rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(sbyte lhs, int rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(sbyte lhs, uint rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(sbyte lhs, long rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(sbyte lhs, ulong rhs) => throw new NotSupportedException("The operator is 'bitwise_and' not supported for the input types.");
 
-        // Char
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, bool rhs) => (byte)(lhs & Convert.ToUInt32(rhs));
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, char rhs) => (byte)(lhs & rhs);
+        // Byte
+        // print((np.array([1], dtype=np.uint8) & np.array([True])).dtype)                # -> uint8  : byte
+        // print((np.array([1], dtype=np.uint8) & np.array([1], dtype=np.int8)).dtype)    # -> int16  : short
+        // print((np.array([1], dtype=np.uint8) & np.array([1], dtype=np.uint8)).dtype)   # -> uint8  : byte
+        // print((np.array([1], dtype=np.uint8) & np.array([1], dtype=np.int16)).dtype)   # -> int16  : short
+        // print((np.array([1], dtype=np.uint8) & np.array([1], dtype=np.uint16)).dtype)  # -> uint16 : ushort
+        // print((np.array([1], dtype=np.uint8) & np.array([1], dtype=np.int32)).dtype)   # -> int32  : int
+        // print((np.array([1], dtype=np.uint8) & np.array([1], dtype=np.uint32)).dtype)  # -> uint32 : uint
+        // print((np.array([1], dtype=np.uint8) & np.array([1], dtype=np.int64)).dtype)   # -> int64  : long
+        // print((np.array([1], dtype=np.uint8) & np.array([1], dtype=np.uint64)).dtype)  # -> uint64 : ulong
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, bool rhs) => (byte)(lhs & Convert.ToByte(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(byte lhs, sbyte rhs) => (byte)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, byte rhs) => (byte)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(byte lhs, short rhs) => (short)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(byte lhs, ushort rhs) => (ushort)(lhs & rhs);
@@ -39,22 +68,40 @@ namespace NumSharp.Utilities.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(byte lhs, long rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(byte lhs, ulong rhs) => lhs & rhs;
 
-        // Byte
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, bool rhs) => (short)(lhs & Convert.ToInt32(rhs));
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, char rhs) => (short)(lhs & rhs);
+        // Int16
+        // print((np.array([1], dtype=np.int16) & np.array([True])).dtype)                # -> int16 : short
+        // print((np.array([1], dtype=np.int16) & np.array([1], dtype=np.int8)).dtype)    # -> int16 : short
+        // print((np.array([1], dtype=np.int16) & np.array([1], dtype=np.uint8)).dtype)   # -> int16 : short
+        // print((np.array([1], dtype=np.int16) & np.array([1], dtype=np.int16)).dtype)   # -> int16 : short
+        // print((np.array([1], dtype=np.int16) & np.array([1], dtype=np.uint16)).dtype)  # -> int32 : int
+        // print((np.array([1], dtype=np.int16) & np.array([1], dtype=np.int32)).dtype)   # -> int32 : int
+        // print((np.array([1], dtype=np.int16) & np.array([1], dtype=np.uint32)).dtype)  # -> int64 : long
+        // print((np.array([1], dtype=np.int16) & np.array([1], dtype=np.int64)).dtype)   # -> int64 : long
+        // print((np.array([1], dtype=np.int16) & np.array([1], dtype=np.uint64)).dtype)  # -> 'bitwise_and' not supported for the input type
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, bool rhs) => (short)(lhs & Convert.ToInt16(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, sbyte rhs) => (short)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, byte rhs) => (short)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, short rhs) => (short)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(short lhs, ushort rhs) => (lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(short lhs, int rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(short lhs, uint rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(short lhs, long rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(short lhs, ulong rhs) => (ulong)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(short lhs, ulong rhs) => throw new NotSupportedException("The operator is 'bitwise_and' not supported for the input types.");
 
         // UInt16
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, bool rhs) => (ushort)(lhs & Convert.ToUInt32(rhs));
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, char rhs) => (ushort)(lhs & rhs);
+        // print((np.array([1], dtype=np.uint16) & np.array([True])).dtype)                # -> uint16 : ushort
+        // print((np.array([1], dtype=np.uint16) & np.array([1], dtype=np.int8)).dtype)    # -> int32 : int
+        // print((np.array([1], dtype=np.uint16) & np.array([1], dtype=np.uint8)).dtype)   # -> uint16 : ushort
+        // print((np.array([1], dtype=np.uint16) & np.array([1], dtype=np.int16)).dtype)   # -> int32 : int
+        // print((np.array([1], dtype=np.uint16) & np.array([1], dtype=np.uint16)).dtype)  # -> uint16 : ushort
+        // print((np.array([1], dtype=np.uint16) & np.array([1], dtype=np.int32)).dtype)   # -> int32 : int
+        // print((np.array([1], dtype=np.uint16) & np.array([1], dtype=np.uint32)).dtype)  # -> uint32 : uint
+        // print((np.array([1], dtype=np.uint16) & np.array([1], dtype=np.int64)).dtype)   # -> int64 : long
+        // print((np.array([1], dtype=np.uint16) & np.array([1], dtype=np.uint64)).dtype)  # -> uint64 : ulong
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, bool rhs) => (ushort)(lhs & Convert.ToUInt16(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(ushort lhs, sbyte rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, byte rhs) => (ushort)(lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(ushort lhs, short rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(ushort lhs, short rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, ushort rhs) => (ushort)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(ushort lhs, int rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(ushort lhs, uint rhs) => lhs & rhs;
@@ -62,19 +109,36 @@ namespace NumSharp.Utilities.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ushort lhs, ulong rhs) => lhs & rhs;
 
         // Int32
+        // print((np.array([1], dtype=np.int32) & np.array([True])).dtype)                # -> int32 : int
+        // print((np.array([1], dtype=np.int32) & np.array([1], dtype=np.int8)).dtype)    # -> int32 : int
+        // print((np.array([1], dtype=np.int32) & np.array([1], dtype=np.uint8)).dtype)   # -> int32 : int
+        // print((np.array([1], dtype=np.int32) & np.array([1], dtype=np.int16)).dtype)   # -> int32 : int
+        // print((np.array([1], dtype=np.int32) & np.array([1], dtype=np.uint16)).dtype)  # -> int32 : int
+        // print((np.array([1], dtype=np.int32) & np.array([1], dtype=np.int32)).dtype)   # -> int32 : int
+        // print((np.array([1], dtype=np.int32) & np.array([1], dtype=np.uint32)).dtype)  # -> int64 : long
+        // print((np.array([1], dtype=np.int32) & np.array([1], dtype=np.int64)).dtype)   # -> int64 : long
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, bool rhs) => lhs & Convert.ToInt32(rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, char rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, sbyte rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, byte rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, short rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, ushort rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, int rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(int lhs, uint rhs) => lhs & (int)rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(int lhs, long rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(int lhs, ulong rhs) => (ulong)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(int lhs, ulong rhs) => throw new NotSupportedException("The operator is 'bitwise_and' not supported for the input types.");
 
         // UInt32
+        // print((np.array([1], dtype=np.uint32) & np.array([True])).dtype)                # -> uint32 : uint
+        // print((np.array([1], dtype=np.uint32) & np.array([1], dtype=np.int8)).dtype)    # -> int64  : long
+        // print((np.array([1], dtype=np.uint32) & np.array([1], dtype=np.uint8)).dtype)   # -> uint32 : uint
+        // print((np.array([1], dtype=np.uint32) & np.array([1], dtype=np.int16)).dtype)   # -> int64  : long
+        // print((np.array([1], dtype=np.uint32) & np.array([1], dtype=np.uint16)).dtype)  # -> uint32 : uint
+        // print((np.array([1], dtype=np.uint32) & np.array([1], dtype=np.int32)).dtype)   # -> int64  : long
+        // print((np.array([1], dtype=np.uint32) & np.array([1], dtype=np.uint32)).dtype)  # -> uint32 : uint
+        // print((np.array([1], dtype=np.uint32) & np.array([1], dtype=np.int64)).dtype)   # -> int64  : long
+        // print((np.array([1], dtype=np.uint32) & np.array([1], dtype=np.uint64)).dtype)  # -> uint64 : ulong
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, bool rhs) => lhs & Convert.ToUInt32(rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, char rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(uint lhs, sbyte rhs) => lhs & (uint)rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, byte rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(uint lhs, short rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, ushort rhs) => lhs & rhs;
@@ -84,25 +148,38 @@ namespace NumSharp.Utilities.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(uint lhs, ulong rhs) => lhs & rhs;
 
         // Int64
+        // print((np.array([1], dtype=np.int64) & np.array([True])).dtype)                # -> int64 : long
+        // print((np.array([1], dtype=np.int64) & np.array([1], dtype=np.int8)).dtype)    # -> int64 : long
+        // print((np.array([1], dtype=np.int64) & np.array([1], dtype=np.uint8)).dtype)   # -> int64 : long
+        // print((np.array([1], dtype=np.int64) & np.array([1], dtype=np.int16)).dtype)   # -> int64 : long
+        // print((np.array([1], dtype=np.int64) & np.array([1], dtype=np.uint16)).dtype)  # -> int64 : long
+        // print((np.array([1], dtype=np.int64) & np.array([1], dtype=np.int32)).dtype)   # -> int64 : long
+        // print((np.array([1], dtype=np.int64) & np.array([1], dtype=np.uint32)).dtype)  # -> int64 : long
+        // print((np.array([1], dtype=np.int64) & np.array([1], dtype=np.int64)).dtype)   # -> int64 : long
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, bool rhs) => lhs & Convert.ToInt64(rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, char rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, sbyte rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, byte rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, short rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, ushort rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, int rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, uint rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, long rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(long lhs, ulong rhs) => lhs & (long)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, ulong rhs) => throw new NotSupportedException("The operator is 'bitwise_and' not supported for the input types.");
 
         // UInt64
+        // print((np.array([1], dtype=np.uint64) & np.array([True])).dtype)                # -> uint64 : ulong
+        // print((np.array([1], dtype=np.uint64) & np.array([1], dtype=np.uint8)).dtype)   # -> uint64 : ulong
+        // print((np.array([1], dtype=np.uint64) & np.array([1], dtype=np.uint16)).dtype)  # -> uint64 : ulong
+        // print((np.array([1], dtype=np.uint64) & np.array([1], dtype=np.uint32)).dtype)  # -> uint64 : ulong
+        // print((np.array([1], dtype=np.uint64) & np.array([1], dtype=np.uint64)).dtype)  # -> uint64 : ulong
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, bool rhs) => lhs & Convert.ToUInt64(rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, char rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, sbyte rhs) => throw new NotSupportedException("The operator is 'bitwise_and' not supported for the input types.");
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, byte rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(ulong lhs, short rhs) => lhs & (ulong)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(ulong lhs, short rhs) => throw new NotSupportedException("The operator is 'bitwise_and' not supported for the input types.");
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, ushort rhs) => (lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(ulong lhs, int rhs) => lhs & (ulong)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(ulong lhs, int rhs) => throw new NotSupportedException("The operator is 'bitwise_and' not supported for the input types.");
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, uint rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(ulong lhs, long rhs) => (long)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, long rhs) => throw new NotSupportedException("The operator is 'bitwise_and' not supported for the input types.");
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, ulong rhs) => lhs & rhs;
         #endregion
 

--- a/src/NumSharp.Core/Utilities/Maths/Operator.Bitwise.cs
+++ b/src/NumSharp.Core/Utilities/Maths/Operator.Bitwise.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace NumSharp.Utilities.Maths
+{
+    internal partial class Operator
+    {
+        #region Bitwise AND
+        // Boolean
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool BitwiseAnd(bool lhs, bool rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(bool lhs, char rhs) => (char)(Convert.ToChar(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(bool lhs, byte rhs) => (byte)(Convert.ToByte(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(bool lhs, short rhs) => (short)(Convert.ToInt16(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(bool lhs, ushort rhs) => (ushort)(Convert.ToUInt16(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(bool lhs, int rhs) => Convert.ToInt32(lhs) & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(bool lhs, uint rhs) => Convert.ToUInt32(lhs) & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(bool lhs, long rhs) => Convert.ToInt64(lhs) & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(bool lhs, ulong rhs) => Convert.ToUInt64(lhs) & rhs;
+
+        // Int8
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(char lhs, bool rhs) => (char)(lhs & Convert.ToChar(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(char lhs, char rhs) => (char)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(char lhs, byte rhs) => (byte)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(char lhs, short rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(char lhs, ushort rhs) => (ushort)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(char lhs, int rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(char lhs, uint rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(char lhs, long rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(char lhs, ulong rhs) => lhs & rhs;
+
+        // UInt8
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, bool rhs) => (byte)(lhs & Convert.ToChar(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(byte lhs, char rhs) => (char)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, byte rhs) => (byte)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(byte lhs, short rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(byte lhs, ushort rhs) => (ushort)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(byte lhs, int rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(byte lhs, uint rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(byte lhs, long rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(byte lhs, ulong rhs) => lhs & rhs;
+
+        // Int16
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, bool rhs) => (short)(lhs & Convert.ToInt16(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, char rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, byte rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, short rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, ushort rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(short lhs, int rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(short lhs, uint rhs) => (uint)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(short lhs, long rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(short lhs, ulong rhs) => (ulong)lhs & rhs;
+
+        // UInt16
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, bool rhs) => (ushort)(lhs & Convert.ToUInt16(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, char rhs) => (ushort)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, byte rhs) => (ushort)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(ushort lhs, short rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, ushort rhs) => (ushort)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(ushort lhs, int rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(ushort lhs, uint rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(ushort lhs, long rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ushort lhs, ulong rhs) => lhs & rhs;
+
+        // Int32
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, bool rhs) => lhs & Convert.ToInt32(rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, char rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, byte rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, short rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, ushort rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, int rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, uint rhs) => lhs & (int)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(int lhs, long rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(int lhs, ulong rhs) => (ulong)lhs & rhs;
+
+        // UInt32
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, bool rhs) => lhs & Convert.ToUInt32(rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, char rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, byte rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, short rhs) => lhs & (uint)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, ushort rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(uint lhs, int rhs) => (int)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, uint rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(uint lhs, long rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(uint lhs, ulong rhs) => lhs & rhs;
+
+        // Int64
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, bool rhs) => lhs & Convert.ToInt64(rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, char rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, byte rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, short rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, ushort rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, int rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, uint rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, long rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, ulong rhs) => lhs & (long)rhs;
+
+        // UInt64
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, bool rhs) => lhs & Convert.ToUInt64(rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, char rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, byte rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, short rhs) => lhs & (ulong)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, ushort rhs) => (lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, int rhs) => lhs & (ulong)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, uint rhs) => lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(ulong lhs, long rhs) => (long)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, ulong rhs) => lhs & rhs;
+        #endregion
+
+        public static BinaryOperatorIndex OpBitwiseAnd = new BinaryOperatorIndex(typeof(Operator), nameof(BitwiseAnd));
+    }
+}

--- a/src/NumSharp.Core/Utilities/Maths/Operator.Bitwise.cs
+++ b/src/NumSharp.Core/Utilities/Maths/Operator.Bitwise.cs
@@ -8,17 +8,17 @@ namespace NumSharp.Utilities.Maths
         #region Bitwise AND
         // Boolean
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static bool BitwiseAnd(bool lhs, bool rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(bool lhs, char rhs) => (char)(Convert.ToChar(lhs) & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(bool lhs, byte rhs) => (byte)(Convert.ToByte(lhs) & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(bool lhs, short rhs) => (short)(Convert.ToInt16(lhs) & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(bool lhs, ushort rhs) => (ushort)(Convert.ToUInt16(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(bool lhs, char rhs) => (char)(Convert.ToInt32(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(bool lhs, byte rhs) => (byte)(Convert.ToUInt32(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(bool lhs, short rhs) => (short)(Convert.ToInt32(lhs) & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(bool lhs, ushort rhs) => (ushort)(Convert.ToUInt32(lhs) & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(bool lhs, int rhs) => Convert.ToInt32(lhs) & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(bool lhs, uint rhs) => Convert.ToUInt32(lhs) & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(bool lhs, long rhs) => Convert.ToInt64(lhs) & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(bool lhs, ulong rhs) => Convert.ToUInt64(lhs) & rhs;
 
         // Int8
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(char lhs, bool rhs) => (char)(lhs & Convert.ToChar(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(char lhs, bool rhs) => (char)(lhs & Convert.ToInt32(rhs));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(char lhs, char rhs) => (char)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(char lhs, byte rhs) => (byte)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(char lhs, short rhs) => (short)(lhs & rhs);
@@ -28,9 +28,9 @@ namespace NumSharp.Utilities.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(char lhs, long rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(char lhs, ulong rhs) => lhs & rhs;
 
-        // UInt8
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, bool rhs) => (byte)(lhs & Convert.ToChar(rhs));
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static char BitwiseAnd(byte lhs, char rhs) => (char)(lhs & rhs);
+        // Char
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, bool rhs) => (byte)(lhs & Convert.ToUInt32(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, char rhs) => (byte)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static byte BitwiseAnd(byte lhs, byte rhs) => (byte)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(byte lhs, short rhs) => (short)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(byte lhs, ushort rhs) => (ushort)(lhs & rhs);
@@ -39,22 +39,22 @@ namespace NumSharp.Utilities.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(byte lhs, long rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(byte lhs, ulong rhs) => lhs & rhs;
 
-        // Int16
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, bool rhs) => (short)(lhs & Convert.ToInt16(rhs));
+        // Byte
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, bool rhs) => (short)(lhs & Convert.ToInt32(rhs));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, char rhs) => (short)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, byte rhs) => (short)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, short rhs) => (short)(lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(short lhs, ushort rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(short lhs, ushort rhs) => (lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(short lhs, int rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(short lhs, uint rhs) => (uint)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(short lhs, uint rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(short lhs, long rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(short lhs, ulong rhs) => (ulong)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(short lhs, ulong rhs) => (ulong)lhs & rhs;
 
         // UInt16
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, bool rhs) => (ushort)(lhs & Convert.ToUInt16(rhs));
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, bool rhs) => (ushort)(lhs & Convert.ToUInt32(rhs));
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, char rhs) => (ushort)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, byte rhs) => (ushort)(lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static short BitwiseAnd(ushort lhs, short rhs) => (short)(lhs & rhs);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(ushort lhs, short rhs) => (short)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ushort BitwiseAnd(ushort lhs, ushort rhs) => (ushort)(lhs & rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(ushort lhs, int rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(ushort lhs, uint rhs) => lhs & rhs;
@@ -68,17 +68,17 @@ namespace NumSharp.Utilities.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, short rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, ushort rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, int rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(int lhs, uint rhs) => lhs & (int)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(int lhs, uint rhs) => lhs & (int)rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(int lhs, long rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(int lhs, ulong rhs) => (ulong)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(int lhs, ulong rhs) => (ulong)lhs & rhs;
 
         // UInt32
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, bool rhs) => lhs & Convert.ToUInt32(rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, char rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, byte rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, short rhs) => lhs & (uint)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(uint lhs, short rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, ushort rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static int BitwiseAnd(uint lhs, int rhs) => (int)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(uint lhs, int rhs) => (int)lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static uint BitwiseAnd(uint lhs, uint rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(uint lhs, long rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(uint lhs, ulong rhs) => lhs & rhs;
@@ -92,17 +92,17 @@ namespace NumSharp.Utilities.Maths
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, int rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, uint rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, long rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(long lhs, ulong rhs) => lhs & (long)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(long lhs, ulong rhs) => lhs & (long)rhs;
 
         // UInt64
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, bool rhs) => lhs & Convert.ToUInt64(rhs);
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, char rhs) => lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, byte rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, short rhs) => lhs & (ulong)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(ulong lhs, short rhs) => lhs & (ulong)rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, ushort rhs) => (lhs & rhs);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, int rhs) => lhs & (ulong)rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(ulong lhs, int rhs) => lhs & (ulong)rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, uint rhs) => lhs & rhs;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static long BitwiseAnd(ulong lhs, long rhs) => (long)lhs & rhs;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] public static double BitwiseAnd(ulong lhs, long rhs) => (long)lhs & rhs;
         [MethodImpl(MethodImplOptions.AggressiveInlining)] public static ulong BitwiseAnd(ulong lhs, ulong rhs) => lhs & rhs;
         #endregion
 

--- a/src/NumSharp.Core/Utilities/Maths/Operator.cs
+++ b/src/NumSharp.Core/Utilities/Maths/Operator.cs
@@ -8,7 +8,7 @@ namespace NumSharp.Utilities.Maths
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Local")]
     [SuppressMessage("ReSharper", "ArrangeTypeMemberModifiers")]
-    internal class Operator
+    internal partial class Operator
     {
         //all other gen
 #if _REGEN //We manually fixed types that naturally do not match with casting.

--- a/src/NumSharp.Core/Utilities/NumberInfo.cs
+++ b/src/NumSharp.Core/Utilities/NumberInfo.cs
@@ -23,6 +23,8 @@ namespace NumSharp.Utilities
                     return #1.MaxValue;
                 %
 #else
+                case NPTypeCode.SByte:
+                    return SByte.MaxValue;
                 case NPTypeCode.Byte:
                     return Byte.MaxValue;
                 case NPTypeCode.Int16:
@@ -68,6 +70,8 @@ namespace NumSharp.Utilities
                     return #1.MinValue;
                 %
 #else
+                case NPTypeCode.SByte:
+                    return SByte.MinValue;
                 case NPTypeCode.Byte:
                     return Byte.MinValue;
                 case NPTypeCode.Int16:

--- a/src/NumSharp.Core/View/Shape.cs
+++ b/src/NumSharp.Core/View/Shape.cs
@@ -72,6 +72,11 @@ namespace NumSharp
         public bool IsScalar;
 
         /// <summary>
+        ///     Is this shape a linear? (<see cref="IsBroadcasted"/>==false && <see cref="IsSliced"/>==false)
+        /// </summary>
+        public bool IsLinear => !IsBroadcasted && !IsSliced;
+
+        /// <summary>
         /// True if the shape is not initialized.
         /// Note: A scalar shape is not empty.
         /// </summary>

--- a/test/NumSharp.Benchmark/Unmanaged/NestingCalls.cs
+++ b/test/NumSharp.Benchmark/Unmanaged/NestingCalls.cs
@@ -145,6 +145,8 @@ namespace NumSharp.Benchmark.Unmanaged
                         break;
                     case NPTypeCode.Char:
                         break;
+                    case NPTypeCode.SByte:
+                        break;
                     case NPTypeCode.Byte:
                         break;
                     case NPTypeCode.Int16:

--- a/test/NumSharp.UnitTest/Operations/NDArray.AND.Test.cs
+++ b/test/NumSharp.UnitTest/Operations/NDArray.AND.Test.cs
@@ -174,13 +174,114 @@ namespace NumSharp.UnitTest.Operations
             Assert.IsTrue(Enumerable.SequenceEqual(expected, np3.Data<bool>()));
         }
 
-        public static readonly Type[] Types = new[]
+        [DataTestMethod]
+        // Boolean
+        [DataRow(new[] { true }, new[] { true }, new[] { true })]
+        [DataRow(new[] { true }, new[] { (char)1 }, new[] { (char)1 })]
+        [DataRow(new[] { true }, new[] { (byte)1 }, new[] { (byte)1 })]
+        [DataRow(new[] { true }, new[] { (short)1 }, new[] { (short)1 })]
+        [DataRow(new[] { true }, new[] { (ushort)1 }, new[] { (ushort)1 })]
+        [DataRow(new[] { true }, new[] { (int)1 }, new[] { (int)1 })]
+        [DataRow(new[] { true }, new[] { (uint)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { true }, new[] { (long)1 }, new[] { (long)1 })]
+        [DataRow(new[] { true }, new[] { (ulong)1 }, new[] { (ulong)1 })]
+
+        // Char
+        [DataRow(new[] { (char)1 }, new[] { true }, new[] { (char)1 })]
+        [DataRow(new[] { (char)1 }, new[] { (char)1 }, new[] { (char)1 })]
+        [DataRow(new[] { (char)1 }, new[] { (byte)1 }, new[] { (byte)1 })]
+        [DataRow(new[] { (char)1 }, new[] { (short)1 }, new[] { (short)1 })]
+        [DataRow(new[] { (char)1 }, new[] { (ushort)1 }, new[] { (ushort)1 })]
+        [DataRow(new[] { (char)1 }, new[] { (int)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (char)1 }, new[] { (uint)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { (char)1 }, new[] { (long)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (char)1 }, new[] { (ulong)1 }, new[] { (ulong)1 })]
+
+        // Byte
+        [DataRow(new[] { (byte)1 }, new[] { true }, new[] { (byte)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (char)1 }, new[] { (byte)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (byte)1 }, new[] { (byte)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (short)1 }, new[] { (short)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (ushort)1 }, new[] { (ushort)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (int)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (uint)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (long)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (ulong)1 }, new[] { (ulong)1 })]
+
+        // Int16
+        [DataRow(new[] { (short)1 }, new[] { true }, new[] { (short)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (char)1 }, new[] { (short)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (byte)1 }, new[] { (short)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (short)1 }, new[] { (short)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (ushort)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (int)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (uint)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (long)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (ulong)1 }, new[] { (double)1 })]
+
+        // UInt16
+        [DataRow(new[] { (ushort)1 }, new[] { true }, new[] { (ushort)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (char)1 }, new[] { (ushort)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (byte)1 }, new[] { (ushort)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (short)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (ushort)1 }, new[] { (ushort)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (int)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (uint)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (long)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (ulong)1 }, new[] { (ulong)1 })]
+
+        // Int32
+        [DataRow(new[] { (int)1 }, new[] { true }, new[] { (int)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (char)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (byte)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (short)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (ushort)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (int)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (uint)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (long)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (ulong)1 }, new[] { (double)1 })]
+
+        // Int32
+        [DataRow(new[] { (uint)1 }, new[] { true }, new[] { (uint)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (char)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (byte)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (short)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (ushort)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (int)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (uint)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (long)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (ulong)1 }, new[] { (ulong)1 })]
+
+        // Int64
+        [DataRow(new[] { (long)1 }, new[] { true }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (char)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (byte)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (short)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (ushort)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (int)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (uint)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (long)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (ulong)1 }, new[] { (double)1 })]
+
+        // Int64
+        [DataRow(new[] { (ulong)1 }, new[] { true }, new[] { (ulong)1 })]
+        [DataRow(new[] { (ulong)1 }, new[] { (char)1 }, new[] { (ulong)1 })]
+        [DataRow(new[] { (ulong)1 }, new[] { (byte)1 }, new[] { (ulong)1 })]
+        [DataRow(new[] { (ulong)1 }, new[] { (short)1 }, new[] { (double)1 })]
+        [DataRow(new[] { (ulong)1 }, new[] { (ushort)1 }, new[] { (ulong)1 })]
+        [DataRow(new[] { (ulong)1 }, new[] { (int)1 }, new[] { (double)1 })]
+        [DataRow(new[] { (ulong)1 }, new[] { (uint)1 }, new[] { (ulong)1 })]
+        [DataRow(new[] { (ulong)1 }, new[] { (long)1 }, new[] { (double)1 })]
+        [DataRow(new[] { (ulong)1 }, new[] { (ulong)1 }, new[] { (ulong)1 })]
+        public void NDArray_InputTypesAND(Array lhs, Array rhs, Array result)
         {
-            typeof(bool),
-            typeof(char), typeof(byte), typeof(short), typeof(ushort),
-            typeof(int), typeof(uint), typeof(long), typeof(ulong),
-            typeof(float), typeof(double),
-        };
+            var np1 = new NDArray(lhs, new Shape(1));
+            var np2 = new NDArray(rhs, new Shape(1));
+
+            var np3 = np1 & np2;
+
+            Assert.AreEqual(result.GetType().GetTypeCode(), np3.typecode);
+        }
 
         [TestMethod]
         public void Byte1D_NDArrayAND()

--- a/test/NumSharp.UnitTest/Operations/NDArray.AND.Test.cs
+++ b/test/NumSharp.UnitTest/Operations/NDArray.AND.Test.cs
@@ -13,7 +13,6 @@ namespace NumSharp.UnitTest.Operations
     public class NDArrayAndTest
     {
 
-        [Ignore("TODO: fix this test")]
         [TestMethod]
         public void BoolTwo1D_NDArrayAND()
         {
@@ -25,7 +24,6 @@ namespace NumSharp.UnitTest.Operations
             Assert.IsTrue(Enumerable.SequenceEqual(new[] {true, false, false, false}, np3.Data<bool>()));
         }
 
-        [Ignore("TODO: fix this test")]
         [TestMethod]
         public void BoolTwo2D_NDArrayAND()
         {
@@ -43,15 +41,164 @@ namespace NumSharp.UnitTest.Operations
             Assert.IsTrue(Enumerable.SequenceEqual(np3.Data<bool>(), np4));
         }
 
-        [Ignore("TODO: fix this test")]
         [TestMethod]
         public void Byte1D_NDArrayAND()
         {
             var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
 
-            var np3 = np1 & 2;
+            var np3 = np1 & (byte)2;
 
             Assert.IsTrue(Enumerable.SequenceEqual(new byte[] {0, 2, 2, 0}, np3.Data<byte>()));
+        }
+
+        [TestMethod]
+        public void Byte2D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+
+            var np3 = np1 & (byte)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new byte[] {0, 2, 2, 0, 0, 2}, np3.Data<byte>()));
+        }
+
+        [TestMethod]
+        public void UShort1D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+
+            var np3 = np1 & (ushort)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new ushort[] {0, 2, 2, 0}, np3.Data<ushort>()));
+        }
+
+        [TestMethod]
+        public void UShort2D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+
+            var np3 = np1 & (ushort)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new ushort[] {0, 2, 2, 0, 0, 2}, np3.Data<ushort>()));
+        }
+
+        [TestMethod]
+        public void UInt1D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+
+            var np3 = np1 & (uint)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new uint[] {0, 2, 2, 0}, np3.Data<uint>()));
+        }
+
+        [TestMethod]
+        public void UInt2D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+
+            var np3 = np1 & (uint)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new uint[] {0, 2, 2, 0, 0, 2}, np3.Data<uint>()));
+        }
+
+        [TestMethod]
+        public void ULong1D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+
+            var np3 = np1 & (ulong)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new ulong[] {0, 2, 2, 0}, np3.Data<ulong>()));
+        }
+
+        [TestMethod]
+        public void ULong2D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+
+            var np3 = np1 & (ulong)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new ulong[] {0, 2, 2, 0, 0, 2}, np3.Data<ulong>()));
+        }
+
+        [TestMethod]
+        public void Char1D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+
+            var np3 = np1 & (char)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new char[] {(char)0, (char)2, (char)2, (char)0 }, np3.Data<char>()));
+        }
+
+        [TestMethod]
+        public void Char2D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+
+            var np3 = np1 & (char)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new char[] { (char)0, (char)2, (char)2, (char)0, (char)0, (char)2 }, np3.Data<char>()));
+        }
+
+        [TestMethod]
+        public void Short1D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+
+            var np3 = np1 & (short)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new short[] {0, 2, 2, 0}, np3.Data<short>()));
+        }
+
+        [TestMethod]
+        public void Short2D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+
+            var np3 = np1 & (short)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new short[] {0, 2, 2, 0, 0, 2}, np3.Data<short>()));
+        }
+
+        [TestMethod]
+        public void Int1D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+
+            var np3 = np1 & 2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new int[] {0, 2, 2, 0}, np3.Data<int>()));
+        }
+
+        [TestMethod]
+        public void Int2D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+
+            var np3 = np1 & 2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new int[] {0, 2, 2, 0, 0, 2}, np3.Data<int>()));
+        }
+
+        [TestMethod]
+        public void Long1D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+
+            var np3 = np1 & (long)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new long[] {0, 2, 2, 0}, np3.Data<long>()));
+        }
+
+        [TestMethod]
+        public void Long2D_NDArrayAND()
+        {
+            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+
+            var np3 = np1 & (long)2;
+
+            Assert.IsTrue(Enumerable.SequenceEqual(new long[] {0, 2, 2, 0, 0, 2}, np3.Data<long>()));
         }
     }
 }

--- a/test/NumSharp.UnitTest/Operations/NDArray.AND.Test.cs
+++ b/test/NumSharp.UnitTest/Operations/NDArray.AND.Test.cs
@@ -1,140 +1,281 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Numerics;
+﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Linq;
-using NumSharp;
-using NumSharp.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace NumSharp.UnitTest.Operations
 {
     [TestClass]
     public class NDArrayAndTest
     {
-
-        [TestMethod]
-        public void BoolTwo1D_NDArrayAND()
+#pragma warning disable CA1034, CA1815, CA1819
+        public struct DataEntry<T>
         {
-            var np1 = new NDArray(new[] {true, true, false, false}, new Shape(4));
-            var np2 = new NDArray(new[] {true, false, true, false}, new Shape(4));
+            public string Name { get; }
+            public T[] Data { get; }
+            public Shape Shape { get; }
+
+            public DataEntry(string name, T[] data, params int[] dims)
+            {
+                Name = name;
+                Data = data;
+                Shape = dims;
+            }
+
+            public override string ToString() => $"{Name}{Shape}";
+        }
+#pragma warning restore CA1815, CA1034, CA1819
+
+        public static List<(string name, string data, int[] dims)> EntryMappings = new List<(string name, string data, int[] dims)>
+        {
+            ("1D1False", "1False", new [] { 1 }),
+            ("1D1True", "1True", new [] { 1 }),
+            ("1D4False", "4False", new [] { 4 }),
+            ("1D4True", "4True", new [] { 4 }),
+            ("10D1False", "10False", new [] { 10 }),
+            ("10D1True", "10True", new [] { 10 }),
+            ("2D11False", "1False", new [] { 1, 1 }),
+            ("2D11True", "1True", new [] { 1, 1 }),
+            ("2D14False", "4False", new [] { 1, 4 }),
+            ("2D14True", "4True", new [] { 1, 4 }),
+            ("2D41False", "4False", new [] { 4, 1 }),
+            ("2D41True", "4True", new [] { 4, 1 }),
+            ("2D44False", "16False", new [] { 4, 4 }),
+            ("2D44True", "16True", new [] { 4, 4 }),
+            ("3D111False", "1False", new [] { 1, 1, 1 }),
+            ("3D111True", "1True", new [] { 1, 1, 1 }),
+            ("3D122False", "4False", new [] { 1, 2, 2 }),
+            ("3D122True", "4True", new [] { 1, 2, 2 }),
+        };
+
+
+        public static Dictionary<string, bool[]> BoolArrayData = new Dictionary<string, bool[]>
+        {
+            { "1False", Enumerable.Repeat(false, 1).ToArray() },
+            { "1True", Enumerable.Repeat(true, 1).ToArray() },
+            { "4False", Enumerable.Repeat(false, 4).ToArray() },
+            { "4True", Enumerable.Repeat(true, 4).ToArray() },
+            { "10False", Enumerable.Repeat(false, 10).ToArray() },
+            { "10True", Enumerable.Repeat(true, 10).ToArray() },
+            { "16False", Enumerable.Repeat(false, 16).ToArray() },
+            { "16True", Enumerable.Repeat(true, 16).ToArray() },
+        };
+
+        public static Dictionary<string, DataEntry<bool>> BoolEntryData = EntryMappings.ToDictionary(
+            x => x.name,
+            x => new DataEntry<bool>(x.name, BoolArrayData[x.data], x.dims));
+
+        [DataTestMethod]
+        // [1] & [1]
+        [DataRow("1D1True", "1D1True", "1True")]
+        [DataRow("1D1True", "1D1False", "1False")]
+        [DataRow("1D1False", "1D1True", "1False")]
+        [DataRow("1D1False", "1D1False", "1False")]
+
+        // [1] & [10]
+        [DataRow("1D1True", "10D1True", "10True")]
+        [DataRow("1D1True", "10D1False", "10False")]
+        [DataRow("1D1False", "10D1True", "10False")]
+        [DataRow("1D1False", "10D1False", "10False")]
+
+        // [10] & [1]
+        [DataRow("10D1True", "1D1True", "10True")]
+        [DataRow("10D1True", "1D1False", "10False")]
+        [DataRow("10D1False", "1D1True", "10False")]
+        [DataRow("10D1False", "1D1False", "10False")]
+
+        // [10] & [10]
+        [DataRow("10D1True", "10D1True", "10True")]
+        [DataRow("10D1True", "10D1False", "10False")]
+        [DataRow("10D1False", "10D1True", "10False")]
+        [DataRow("10D1False", "10D1False", "10False")]
+
+        // [1, 1] & [1, 1]
+        [DataRow("2D11True", "2D11True", "1True")]
+        [DataRow("2D11True", "2D11False", "1False")]
+        [DataRow("2D11False", "2D11True", "1False")]
+        [DataRow("2D11False", "2D11False", "1False")]
+
+        // [1, 1] & [1, 4]
+        [DataRow("2D11True", "2D14True", "4True")]
+        [DataRow("2D11True", "2D14False", "4False")]
+        [DataRow("2D11False", "2D14True", "4False")]
+        [DataRow("2D11False", "2D14False", "4False")]
+
+        // [1, 4] & [1, 1]
+        [DataRow("2D14True", "2D11True", "4True")]
+        [DataRow("2D14True", "2D11False", "4False")]
+        [DataRow("2D14False", "2D11True", "4False")]
+        [DataRow("2D14False", "2D11False", "4False")]
+
+        // [1, 4] & [4, 1]
+        [DataRow("2D14True", "2D41True", "16True")]
+        [DataRow("2D14True", "2D41False", "16False")]
+        [DataRow("2D14False", "2D41True", "16False")]
+        [DataRow("2D14False", "2D41False", "16False")]
+
+        // [4, 1] & [1, 4]
+        [DataRow("2D41True", "2D14True", "16True")]
+        [DataRow("2D41True", "2D14False", "16False")]
+        [DataRow("2D41False", "2D14True", "16False")]
+        [DataRow("2D41False", "2D14False", "16False")]
+
+        // [4, 4] & [4, 4]
+        [DataRow("2D44True", "2D44True", "16True")]
+        [DataRow("2D44True", "2D44False", "16False")]
+        [DataRow("2D44False", "2D44True", "16False")]
+        [DataRow("2D44False", "2D44False", "16False")]
+
+        // [1, 1, 1] & [1, 2, 2]
+        [DataRow("3D111True", "3D122True", "4True")]
+        [DataRow("3D111True", "3D122False", "4False")]
+        [DataRow("3D111False", "3D122True", "4False")]
+        [DataRow("3D111False", "3D122False", "4False")]
+
+        // [1, 2, 2] & [1, 2, 2]
+        [DataRow("3D122True", "3D111True", "4True")]
+        [DataRow("3D122True", "3D111False", "4False")]
+        [DataRow("3D122False", "3D111True", "4False")]
+        [DataRow("3D122False", "3D111False", "4False")]
+
+        // [1] & [1, 4]
+        [DataRow("1D1True", "2D14True", "4True")]
+        [DataRow("1D1True", "2D14False", "4False")]
+        [DataRow("1D1False", "2D14True", "4False")]
+        [DataRow("1D1False", "2D14False", "4False")]
+
+        // [1, 4] & [1]
+        [DataRow("2D14True", "1D1True", "4True")]
+        [DataRow("2D14True", "1D1False", "4False")]
+        [DataRow("2D14False", "1D1True", "4False")]
+        [DataRow("2D14False", "1D1False", "4False")]
+
+        // [4] & [1, 4]
+        [DataRow("1D4True", "2D14True", "4True")]
+        [DataRow("1D4True", "2D14False", "4False")]
+        [DataRow("1D4False", "2D14True", "4False")]
+        [DataRow("1D4False", "2D14False", "4False")]
+
+        // [1, 4] & [4]
+        [DataRow("2D14True", "1D4True", "4True")]
+        [DataRow("2D14True", "1D4False", "4False")]
+        [DataRow("2D14False", "1D4True", "4False")]
+        [DataRow("2D14False", "1D4False", "4False")]
+        public void NDArray_ABoolANDABool(string lname, string rname, string ename)
+        {
+            var ldata = BoolEntryData[lname];
+            var rdata = BoolEntryData[rname];
+            var expected = BoolArrayData[ename];
+            var np1 = new NDArray(ldata.Data, ldata.Shape);
+            var np2 = new NDArray(rdata.Data, rdata.Shape);
 
             var np3 = np1 & np2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new[] {true, false, false, false}, np3.Data<bool>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(expected, np3.Data<bool>()));
         }
 
-        [TestMethod]
-        public void BoolTwo2D_NDArrayAND()
+        public static readonly Type[] Types = new[]
         {
-            var np1 = new NDArray(typeof(bool), new Shape(2, 3));
-            np1.ReplaceData(new bool[] {true, true, false, false, true, false});
-
-            var np2 = new NDArray(typeof(bool), new Shape(2, 3));
-            np2.ReplaceData(new bool[] {true, false, true, false, true, true});
-
-            var np3 = np1 & np2;
-
-            // expected
-            var np4 = new bool[] {true, false, false, false, true, false};
-
-            Assert.IsTrue(Enumerable.SequenceEqual(np3.Data<bool>(), np4));
-        }
+            typeof(bool),
+            typeof(char), typeof(byte), typeof(short), typeof(ushort),
+            typeof(int), typeof(uint), typeof(long), typeof(ulong),
+            typeof(float), typeof(double),
+        };
 
         [TestMethod]
         public void Byte1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (byte)x).ToArray(), new Shape(4));
 
             var np3 = np1 & (byte)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new byte[] {0, 2, 2, 0}, np3.Data<byte>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new byte[] { 0, 2, 2, 0 }, np3.Data<byte>()));
         }
 
         [TestMethod]
         public void Byte2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (byte)x).ToArray(), new Shape(2, 3));
 
             var np3 = np1 & (byte)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new byte[] {0, 2, 2, 0, 0, 2}, np3.Data<byte>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new byte[] { 0, 2, 2, 0, 0, 2 }, np3.Data<byte>()));
         }
 
         [TestMethod]
         public void UShort1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (ushort)x).ToArray(), new Shape(4));
 
             var np3 = np1 & (ushort)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new ushort[] {0, 2, 2, 0}, np3.Data<ushort>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new ushort[] { 0, 2, 2, 0 }, np3.Data<ushort>()));
         }
 
         [TestMethod]
         public void UShort2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (ushort)x).ToArray(), new Shape(2, 3));
 
             var np3 = np1 & (ushort)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new ushort[] {0, 2, 2, 0, 0, 2}, np3.Data<ushort>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new ushort[] { 0, 2, 2, 0, 0, 2 }, np3.Data<ushort>()));
         }
 
         [TestMethod]
         public void UInt1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (uint)x).ToArray(), new Shape(4));
 
             var np3 = np1 & (uint)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new uint[] {0, 2, 2, 0}, np3.Data<uint>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new uint[] { 0, 2, 2, 0 }, np3.Data<uint>()));
         }
 
         [TestMethod]
         public void UInt2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (uint)x).ToArray(), new Shape(2, 3));
 
             var np3 = np1 & (uint)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new uint[] {0, 2, 2, 0, 0, 2}, np3.Data<uint>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new uint[] { 0, 2, 2, 0, 0, 2 }, np3.Data<uint>()));
         }
 
         [TestMethod]
         public void ULong1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (ulong)x).ToArray(), new Shape(4));
 
             var np3 = np1 & (ulong)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new ulong[] {0, 2, 2, 0}, np3.Data<ulong>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new ulong[] { 0, 2, 2, 0 }, np3.Data<ulong>()));
         }
 
         [TestMethod]
         public void ULong2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (ulong)x).ToArray(), new Shape(2, 3));
 
             var np3 = np1 & (ulong)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new ulong[] {0, 2, 2, 0, 0, 2}, np3.Data<ulong>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new ulong[] { 0, 2, 2, 0, 0, 2 }, np3.Data<ulong>()));
         }
 
         [TestMethod]
         public void Char1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (char)x).ToArray(), new Shape(4));
 
             var np3 = np1 & (char)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new char[] {(char)0, (char)2, (char)2, (char)0 }, np3.Data<char>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new char[] { (char)0, (char)2, (char)2, (char)0 }, np3.Data<char>()));
         }
 
         [TestMethod]
         public void Char2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (char)x).ToArray(), new Shape(2, 3));
 
             var np3 = np1 & (char)2;
 
@@ -144,61 +285,61 @@ namespace NumSharp.UnitTest.Operations
         [TestMethod]
         public void Short1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (short)x).ToArray(), new Shape(4));
 
             var np3 = np1 & (short)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new short[] {0, 2, 2, 0}, np3.Data<short>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new short[] { 0, 2, 2, 0 }, np3.Data<short>()));
         }
 
         [TestMethod]
         public void Short2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (short)x).ToArray(), new Shape(2, 3));
 
             var np3 = np1 & (short)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new short[] {0, 2, 2, 0, 0, 2}, np3.Data<short>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new short[] { 0, 2, 2, 0, 0, 2 }, np3.Data<short>()));
         }
 
         [TestMethod]
         public void Int1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (int)x).ToArray(), new Shape(4));
 
             var np3 = np1 & 2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new int[] {0, 2, 2, 0}, np3.Data<int>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new int[] { 0, 2, 2, 0 }, np3.Data<int>()));
         }
 
         [TestMethod]
         public void Int2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (int)x).ToArray(), new Shape(2, 3));
 
             var np3 = np1 & 2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new int[] {0, 2, 2, 0, 0, 2}, np3.Data<int>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new int[] { 0, 2, 2, 0, 0, 2 }, np3.Data<int>()));
         }
 
         [TestMethod]
         public void Long1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4}, new Shape(4));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (long)x).ToArray(), new Shape(4));
 
             var np3 = np1 & (long)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new long[] {0, 2, 2, 0}, np3.Data<long>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new long[] { 0, 2, 2, 0 }, np3.Data<long>()));
         }
 
         [TestMethod]
         public void Long2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] {1, 2, 3, 4, 5, 6}, new Shape(2, 3));
+            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (long)x).ToArray(), new Shape(2, 3));
 
             var np3 = np1 & (long)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new long[] {0, 2, 2, 0, 0, 2}, np3.Data<long>()));
+            Assert.IsTrue(Enumerable.SequenceEqual(new long[] { 0, 2, 2, 0, 0, 2 }, np3.Data<long>()));
         }
     }
 }

--- a/test/NumSharp.UnitTest/Operations/NDArray.AND.Test.cs
+++ b/test/NumSharp.UnitTest/Operations/NDArray.AND.Test.cs
@@ -177,7 +177,7 @@ namespace NumSharp.UnitTest.Operations
         [DataTestMethod]
         // Boolean
         [DataRow(new[] { true }, new[] { true }, new[] { true })]
-        [DataRow(new[] { true }, new[] { (char)1 }, new[] { (char)1 })]
+        [DataRow(new[] { true }, new[] { (sbyte)1 }, new[] { (sbyte)1 })]
         [DataRow(new[] { true }, new[] { (byte)1 }, new[] { (byte)1 })]
         [DataRow(new[] { true }, new[] { (short)1 }, new[] { (short)1 })]
         [DataRow(new[] { true }, new[] { (ushort)1 }, new[] { (ushort)1 })]
@@ -186,20 +186,19 @@ namespace NumSharp.UnitTest.Operations
         [DataRow(new[] { true }, new[] { (long)1 }, new[] { (long)1 })]
         [DataRow(new[] { true }, new[] { (ulong)1 }, new[] { (ulong)1 })]
 
-        // Char
-        [DataRow(new[] { (char)1 }, new[] { true }, new[] { (char)1 })]
-        [DataRow(new[] { (char)1 }, new[] { (char)1 }, new[] { (char)1 })]
-        [DataRow(new[] { (char)1 }, new[] { (byte)1 }, new[] { (byte)1 })]
-        [DataRow(new[] { (char)1 }, new[] { (short)1 }, new[] { (short)1 })]
-        [DataRow(new[] { (char)1 }, new[] { (ushort)1 }, new[] { (ushort)1 })]
-        [DataRow(new[] { (char)1 }, new[] { (int)1 }, new[] { (int)1 })]
-        [DataRow(new[] { (char)1 }, new[] { (uint)1 }, new[] { (uint)1 })]
-        [DataRow(new[] { (char)1 }, new[] { (long)1 }, new[] { (long)1 })]
-        [DataRow(new[] { (char)1 }, new[] { (ulong)1 }, new[] { (ulong)1 })]
+        // SByte
+        [DataRow(new[] { (sbyte)1 }, new[] { true }, new[] { (sbyte)1 })]
+        [DataRow(new[] { (sbyte)1 }, new[] { (sbyte)1 }, new[] { (sbyte)1 })]
+        [DataRow(new[] { (sbyte)1 }, new[] { (byte)1 }, new[] { (short)1 })]
+        [DataRow(new[] { (sbyte)1 }, new[] { (short)1 }, new[] { (short)1 })]
+        [DataRow(new[] { (sbyte)1 }, new[] { (ushort)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (sbyte)1 }, new[] { (int)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (sbyte)1 }, new[] { (uint)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (sbyte)1 }, new[] { (long)1 }, new[] { (long)1 })]
 
         // Byte
         [DataRow(new[] { (byte)1 }, new[] { true }, new[] { (byte)1 })]
-        [DataRow(new[] { (byte)1 }, new[] { (char)1 }, new[] { (byte)1 })]
+        [DataRow(new[] { (byte)1 }, new[] { (sbyte)1 }, new[] { (short)1 })]
         [DataRow(new[] { (byte)1 }, new[] { (byte)1 }, new[] { (byte)1 })]
         [DataRow(new[] { (byte)1 }, new[] { (short)1 }, new[] { (short)1 })]
         [DataRow(new[] { (byte)1 }, new[] { (ushort)1 }, new[] { (ushort)1 })]
@@ -210,18 +209,17 @@ namespace NumSharp.UnitTest.Operations
 
         // Int16
         [DataRow(new[] { (short)1 }, new[] { true }, new[] { (short)1 })]
-        [DataRow(new[] { (short)1 }, new[] { (char)1 }, new[] { (short)1 })]
+        [DataRow(new[] { (short)1 }, new[] { (sbyte)1 }, new[] { (short)1 })]
         [DataRow(new[] { (short)1 }, new[] { (byte)1 }, new[] { (short)1 })]
         [DataRow(new[] { (short)1 }, new[] { (short)1 }, new[] { (short)1 })]
         [DataRow(new[] { (short)1 }, new[] { (ushort)1 }, new[] { (int)1 })]
         [DataRow(new[] { (short)1 }, new[] { (int)1 }, new[] { (int)1 })]
         [DataRow(new[] { (short)1 }, new[] { (uint)1 }, new[] { (long)1 })]
         [DataRow(new[] { (short)1 }, new[] { (long)1 }, new[] { (long)1 })]
-        [DataRow(new[] { (short)1 }, new[] { (ulong)1 }, new[] { (double)1 })]
 
         // UInt16
         [DataRow(new[] { (ushort)1 }, new[] { true }, new[] { (ushort)1 })]
-        [DataRow(new[] { (ushort)1 }, new[] { (char)1 }, new[] { (ushort)1 })]
+        [DataRow(new[] { (ushort)1 }, new[] { (sbyte)1 }, new[] { (int)1 })]
         [DataRow(new[] { (ushort)1 }, new[] { (byte)1 }, new[] { (ushort)1 })]
         [DataRow(new[] { (ushort)1 }, new[] { (short)1 }, new[] { (int)1 })]
         [DataRow(new[] { (ushort)1 }, new[] { (ushort)1 }, new[] { (ushort)1 })]
@@ -232,18 +230,17 @@ namespace NumSharp.UnitTest.Operations
 
         // Int32
         [DataRow(new[] { (int)1 }, new[] { true }, new[] { (int)1 })]
-        [DataRow(new[] { (int)1 }, new[] { (char)1 }, new[] { (int)1 })]
+        [DataRow(new[] { (int)1 }, new[] { (sbyte)1 }, new[] { (int)1 })]
         [DataRow(new[] { (int)1 }, new[] { (byte)1 }, new[] { (int)1 })]
         [DataRow(new[] { (int)1 }, new[] { (short)1 }, new[] { (int)1 })]
         [DataRow(new[] { (int)1 }, new[] { (ushort)1 }, new[] { (int)1 })]
         [DataRow(new[] { (int)1 }, new[] { (int)1 }, new[] { (int)1 })]
         [DataRow(new[] { (int)1 }, new[] { (uint)1 }, new[] { (long)1 })]
         [DataRow(new[] { (int)1 }, new[] { (long)1 }, new[] { (long)1 })]
-        [DataRow(new[] { (int)1 }, new[] { (ulong)1 }, new[] { (double)1 })]
 
-        // Int32
+        // UInt32
         [DataRow(new[] { (uint)1 }, new[] { true }, new[] { (uint)1 })]
-        [DataRow(new[] { (uint)1 }, new[] { (char)1 }, new[] { (uint)1 })]
+        [DataRow(new[] { (uint)1 }, new[] { (sbyte)1 }, new[] { (long)1 })]
         [DataRow(new[] { (uint)1 }, new[] { (byte)1 }, new[] { (uint)1 })]
         [DataRow(new[] { (uint)1 }, new[] { (short)1 }, new[] { (long)1 })]
         [DataRow(new[] { (uint)1 }, new[] { (ushort)1 }, new[] { (uint)1 })]
@@ -252,26 +249,21 @@ namespace NumSharp.UnitTest.Operations
         [DataRow(new[] { (uint)1 }, new[] { (long)1 }, new[] { (long)1 })]
         [DataRow(new[] { (uint)1 }, new[] { (ulong)1 }, new[] { (ulong)1 })]
 
-        // Int64
+        //// Int64
         [DataRow(new[] { (long)1 }, new[] { true }, new[] { (long)1 })]
-        [DataRow(new[] { (long)1 }, new[] { (char)1 }, new[] { (long)1 })]
+        [DataRow(new[] { (long)1 }, new[] { (sbyte)1 }, new[] { (long)1 })]
         [DataRow(new[] { (long)1 }, new[] { (byte)1 }, new[] { (long)1 })]
         [DataRow(new[] { (long)1 }, new[] { (short)1 }, new[] { (long)1 })]
         [DataRow(new[] { (long)1 }, new[] { (ushort)1 }, new[] { (long)1 })]
         [DataRow(new[] { (long)1 }, new[] { (int)1 }, new[] { (long)1 })]
         [DataRow(new[] { (long)1 }, new[] { (uint)1 }, new[] { (long)1 })]
         [DataRow(new[] { (long)1 }, new[] { (long)1 }, new[] { (long)1 })]
-        [DataRow(new[] { (long)1 }, new[] { (ulong)1 }, new[] { (double)1 })]
 
-        // Int64
+        // UInt64
         [DataRow(new[] { (ulong)1 }, new[] { true }, new[] { (ulong)1 })]
-        [DataRow(new[] { (ulong)1 }, new[] { (char)1 }, new[] { (ulong)1 })]
         [DataRow(new[] { (ulong)1 }, new[] { (byte)1 }, new[] { (ulong)1 })]
-        [DataRow(new[] { (ulong)1 }, new[] { (short)1 }, new[] { (double)1 })]
         [DataRow(new[] { (ulong)1 }, new[] { (ushort)1 }, new[] { (ulong)1 })]
-        [DataRow(new[] { (ulong)1 }, new[] { (int)1 }, new[] { (double)1 })]
         [DataRow(new[] { (ulong)1 }, new[] { (uint)1 }, new[] { (ulong)1 })]
-        [DataRow(new[] { (ulong)1 }, new[] { (long)1 }, new[] { (double)1 })]
         [DataRow(new[] { (ulong)1 }, new[] { (ulong)1 }, new[] { (ulong)1 })]
         public void NDArray_InputTypesAND(Array lhs, Array rhs, Array result)
         {
@@ -364,23 +356,23 @@ namespace NumSharp.UnitTest.Operations
         }
 
         [TestMethod]
-        public void Char1D_NDArrayAND()
+        public void SByte1D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (char)x).ToArray(), new Shape(4));
+            //var np1 = new NDArray(new[] { 1, 2, 3, 4 }.Select(x => (sbyte)x).ToArray(), new Shape(4));
 
-            var np3 = np1 & (char)2;
+            //var np3 = np1 & (sbyte)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new char[] { (char)0, (char)2, (char)2, (char)0 }, np3.Data<char>()));
+            //Assert.IsTrue(Enumerable.SequenceEqual(new sbyte[] { (sbyte)0, (sbyte)2, (sbyte)2, (sbyte)0 }, np3.Data<sbyte>()));
         }
 
         [TestMethod]
-        public void Char2D_NDArrayAND()
+        public void SByte2D_NDArrayAND()
         {
-            var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (char)x).ToArray(), new Shape(2, 3));
+            //var np1 = new NDArray(new[] { 1, 2, 3, 4, 5, 6 }.Select(x => (sbyte)x).ToArray(), new Shape(2, 3));
 
-            var np3 = np1 & (char)2;
+            //var np3 = np1 & (sbyte)2;
 
-            Assert.IsTrue(Enumerable.SequenceEqual(new char[] { (char)0, (char)2, (char)2, (char)0, (char)0, (char)2 }, np3.Data<char>()));
+            //Assert.IsTrue(Enumerable.SequenceEqual(new sbyte[] { (sbyte)0, (sbyte)2, (sbyte)2, (sbyte)0, (sbyte)0, (sbyte)2 }, np3.Data<sbyte>()));
         }
 
         [TestMethod]

--- a/test/NumSharp.UnitTest/Utilities/FluentExtension.cs
+++ b/test/NumSharp.UnitTest/Utilities/FluentExtension.cs
@@ -363,6 +363,26 @@ namespace NumSharp.UnitTest.Utilities
                     }
                     break;
                 }
+			    case NPTypeCode.SByte: 
+                {
+                    var iter = Subject.AsIterator<sbyte>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+                        
+                        var expected = Convert.ToSByte(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Byte).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+                    break;
+                }
 			    case NPTypeCode.Byte: 
                 {
                     var iter = Subject.AsIterator<byte>();
@@ -643,6 +663,22 @@ namespace NumSharp.UnitTest.Utilities
                     }
                     break;
                 }
+			    case NPTypeCode.SByte: 
+                {
+                    var iter = Subject.AsIterator<sbyte>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    var expected = Convert.ToSByte(val);
+                    for (int i = 0; hasnext(); i++)
+                    {
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(expected == nextval)
+                            .FailWith($"Expected NDArray's {2}th value to be {0}, but found {1} (dtype: Byte).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n{val}", expected, nextval, i);
+                    }
+                    break;
+                }
 			    case NPTypeCode.Byte: 
                 {
                     var iter = Subject.AsIterator<byte>();
@@ -887,6 +923,26 @@ namespace NumSharp.UnitTest.Utilities
 
                         Execute.Assertion
                             .ForCondition(expected==nextval)
+                            .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
+                    }
+                    break;
+                }
+			    case NPTypeCode.SByte: 
+                {
+                    var iter = Subject.AsIterator<sbyte>();
+                    var next = iter.MoveNext;
+                    var hasnext = iter.HasNext;
+                    for (int i = 0; i < values.Length; i++)
+                    {
+                        Execute.Assertion
+                            .ForCondition(hasnext())
+                            .FailWith($"Expected the NDArray to have atleast {values.Length} but in fact it has size of {i}.");
+                        
+                        var expected = Convert.ToSByte(values[i]);
+                        var nextval = next();
+
+                        Execute.Assertion
+                            .ForCondition(Math.Abs(expected - nextval) <= sensitivity)
                             .FailWith($"Expected NDArray's {{2}}th value to be {{0}}, but found {{1}} (dtype: Boolean).\n------- Subject -------\n{Subject.ToString(false)}\n------- Expected -------\n[{string.Join(", ", values.Select(v => v.ToString()))}]", expected, nextval, i);
                     }
                     break;


### PR DESCRIPTION
1. TensorFlow.NET constant_op method refers to the byte type conversion on NumSharp.Lite and it's going to break when migrating to the NumSharp.Core, so I decided to add missing type conversions there
![image](https://user-images.githubusercontent.com/485120/88214279-92348c00-cc62-11ea-9ab9-fc5285386128.png)

2. I've found the broken tests in NDArray.AND and decided to rewrite and extend the operator set, so it would cover all integral scalars. I've made 2 private generic utilities that can run a projector delegate against array elements, so you'll have uniform and maintainable code across all operations. You can use them pretty much everywhere to apply element-size operators on arrays. The code is documented, validated and unit tested. I'd also add the Shape validation, but I didn't figure out what's the best strategy there.

Offtop:
I've found *a lot* of copy-pasted code that could be pretty much solved with generics. It would be more compact and reusable and reduce the maintenance hell for you.. So.. The good idea is to put the refactoring in the roadmap, this would make the work on a project a lot easier..