### PR TITLE
Added data types in np.frombuffer.

### DIFF
--- a/src/NumSharp.Core/Creation/np.frombuffer.cs
+++ b/src/NumSharp.Core/Creation/np.frombuffer.cs
@@ -7,9 +7,19 @@ namespace NumSharp
     {
         public static NDArray frombuffer(byte[] bytes, Type dtype)
         {
-
             //TODO! all types
-            if (dtype.Name == "Int32")
+            if (dtype.Name == nameof(Int16))
+            {
+                var size = bytes.Length / InfoOf<short>.Size;
+                var ints = new short[size];
+                for (var index = 0; index < size; index++)
+                {
+                    ints[index] = BitConverter.ToInt16(bytes, index * InfoOf<short>.Size);
+                }
+
+                return new NDArray(ints);
+            }
+            else if (dtype.Name == nameof(Int32))
             {
                 var size = bytes.Length / InfoOf<int>.Size;
                 var ints = new int[size];
@@ -20,7 +30,73 @@ namespace NumSharp
 
                 return new NDArray(ints);
             }
-            else if (dtype.Name == "Byte")
+            else if (dtype.Name == nameof(Int64))
+            {
+                var size = bytes.Length / InfoOf<long>.Size;
+                var ints = new long[size];
+                for (var index = 0; index < size; index++)
+                {
+                    ints[index] = BitConverter.ToInt64(bytes, index * InfoOf<long>.Size);
+                }
+
+                return new NDArray(ints);
+            }
+            else if (dtype.Name == nameof(UInt16))
+            {
+                var size = bytes.Length / InfoOf<ushort>.Size;
+                var ints = new ushort[size];
+                for (var index = 0; index < size; index++)
+                {
+                    ints[index] = BitConverter.ToUInt16(bytes, index * InfoOf<ushort>.Size);
+                }
+
+                return new NDArray(ints);
+            }
+            else if (dtype.Name == nameof(UInt32))
+            {
+                var size = bytes.Length / InfoOf<uint>.Size;
+                var ints = new uint[size];
+                for (var index = 0; index < size; index++)
+                {
+                    ints[index] = BitConverter.ToUInt32(bytes, index * InfoOf<uint>.Size);
+                }
+
+                return new NDArray(ints);
+            }
+            else if (dtype.Name == nameof(UInt64))
+            {
+                var size = bytes.Length / InfoOf<ulong>.Size;
+                var ints = new ulong[size];
+                for (var index = 0; index < size; index++)
+                {
+                    ints[index] = BitConverter.ToUInt64(bytes, index * InfoOf<ulong>.Size);
+                }
+
+                return new NDArray(ints);
+            }
+            else if (dtype.Name == nameof(Single))
+            {
+                var size = bytes.Length / InfoOf<float>.Size;
+                var floats = new float[size];
+                for (var index = 0; index < size; index++)
+                {
+                    floats[index] = BitConverter.ToSingle(bytes, index * InfoOf<float>.Size);
+                }
+
+                return new NDArray(floats);
+            }
+            else if (dtype.Name == nameof(Double))
+            {
+                var size = bytes.Length / InfoOf<double>.Size;
+                var floats = new double[size];
+                for (var index = 0; index < size; index++)
+                {
+                    floats[index] = BitConverter.ToDouble(bytes, index * InfoOf<double>.Size);
+                }
+
+                return new NDArray(floats);
+            }
+            else if (dtype.Name == nameof(Byte))
             {
                 var size = bytes.Length / InfoOf<byte>.Size;
                 var ints = bytes;

--- a/test/NumSharp.UnitTest/Creation/np.frombuffer.Test.cs
+++ b/test/NumSharp.UnitTest/Creation/np.frombuffer.Test.cs
@@ -12,15 +12,100 @@ namespace NumSharp.UnitTest.Creation
     public class NpFromBufferTest
     {
         [TestMethod]
+        public void ToInt16()
+        {
+            short[] ints = { -100, 200, 300, 400, 500 };
+            var bytes = new byte[ints.Length * sizeof(short)];
+            Buffer.BlockCopy(ints, 0, bytes, 0, bytes.Length);
+
+            var nd = np.frombuffer(bytes, np.int16);
+            Assert.AreEqual(nd.GetInt16(0), -100);
+            Assert.AreEqual(nd.GetInt16(4), 500);
+        }
+
+        [TestMethod]
         public void ToInt32()
         {
-            int[] ints = {100, 200, 300, 400, 500};
-            byte[] bytes = new byte[ints.Length * sizeof(int)];
+            int[] ints = {-100, 200, 300, 400, 500};
+            var bytes = new byte[ints.Length * sizeof(int)];
             Buffer.BlockCopy(ints, 0, bytes, 0, bytes.Length);
 
             var nd = np.frombuffer(bytes, np.int32);
-            Assert.AreEqual(nd.GetInt32(0), 100);
+            Assert.AreEqual(nd.GetInt32(0), -100);
             Assert.AreEqual(nd.GetInt32(4), 500);
         }
+
+        [TestMethod]
+        public void ToInt64()
+        {
+            long[] ints = { -100, 200, 300, 400, 500 };
+            var bytes = new byte[ints.Length * sizeof(long)];
+            Buffer.BlockCopy(ints, 0, bytes, 0, bytes.Length);
+
+            var nd = np.frombuffer(bytes, np.int64);
+            Assert.AreEqual(nd.GetInt64(0), -100);
+            Assert.AreEqual(nd.GetInt64(4), 500);
+        }
+
+        [TestMethod]
+        public void ToUInt16()
+        {
+            ushort[] ints = { 100, 200, 300, 400, 500 };
+            var bytes = new byte[ints.Length * sizeof(ushort)];
+            Buffer.BlockCopy(ints, 0, bytes, 0, bytes.Length);
+
+            var nd = np.frombuffer(bytes, np.uint16);
+            Assert.AreEqual(nd.GetUInt16(0), (ushort)100);
+            Assert.AreEqual(nd.GetUInt16(4), (ushort)500);
+        }
+
+        [TestMethod]
+        public void ToUInt32()
+        {
+            uint[] ints = { 100, 200, 300, 400, 500 };
+            var bytes = new byte[ints.Length * sizeof(uint)];
+            Buffer.BlockCopy(ints, 0, bytes, 0, bytes.Length);
+
+            var nd = np.frombuffer(bytes, np.uint32);
+            Assert.AreEqual(nd.GetUInt32(0), (uint)100);
+            Assert.AreEqual(nd.GetUInt32(4), (uint)500);
+        }
+
+        [TestMethod]
+        public void ToUInt64()
+        {
+            ulong[] ints = { 100, 200, 300, 400, 500 };
+            var bytes = new byte[ints.Length * sizeof(ulong)];
+            Buffer.BlockCopy(ints, 0, bytes, 0, bytes.Length);
+
+            var nd = np.frombuffer(bytes, np.uint64);
+            Assert.AreEqual(nd.GetUInt64(0), (ulong)100);
+            Assert.AreEqual(nd.GetUInt64(4), (ulong)500);
+        }
+        
+        [TestMethod]
+        public void ToSingle()
+        {
+            float[] floats = { 100.5F, 200.0F, 300.0F, 400.0F, 500.0F };
+            var bytes = new byte[floats.Length * sizeof(float)];
+            Buffer.BlockCopy(floats, 0, bytes, 0, bytes.Length);
+
+            var nd = np.frombuffer(bytes, np.float32);
+            Assert.AreEqual(nd.GetSingle(0), 100.5F);
+            Assert.AreEqual(nd.GetSingle(4), 500.0F);
+        }
+
+        [TestMethod]
+        public void ToDouble()
+        {
+            double[] floats = { 100.5, 200.0, 300.0, 400.0, 500.0 };
+            var bytes = new byte[floats.Length * sizeof(double)];
+            Buffer.BlockCopy(floats, 0, bytes, 0, bytes.Length);
+
+            var nd = np.frombuffer(bytes, np.@double);
+            Assert.AreEqual(nd.GetDouble(0), 100.5);
+            Assert.AreEqual(nd.GetDouble(4), 500.0);
+        }
+       
     }
 }


### PR DESCRIPTION
In response to issue #423,

I added data types ( int16, int64, uint16, uint32, uint64, single and double) in method `np.frombuffer(byte[] bytes, Type dtype)` and also their corresponding unit tests.


