### PR TITLE
Added support for user defined decimal precision for np.around() and TensorEngine.Round()

### DIFF
--- a/src/NumSharp.Core/Backends/Default/Math/Default.Round.cs
+++ b/src/NumSharp.Core/Backends/Default/Math/Default.Round.cs
@@ -9,6 +9,8 @@ namespace NumSharp.Backends
     {
         public override NDArray Round(in NDArray nd, Type dtype) => Round(nd, dtype?.GetTypeCode());
 
+        public override NDArray Round(in NDArray nd, int decimals, Type dtype) => Round(nd, decimals, dtype?.GetTypeCode());
+
         public override NDArray Round(in NDArray nd, NPTypeCode? typeCode = null)
         {
             if (nd.size == 0)
@@ -59,6 +61,61 @@ namespace NumSharp.Backends
 	                }
 	                default:
 		                throw new NotSupportedException();
+#endif
+                }
+            }
+        }
+
+        public override NDArray Round(in NDArray nd, int decimals, NPTypeCode? typeCode = null)
+        {
+            if (nd.size == 0)
+                return nd.Clone();
+
+            var @out = Cast(nd, ResolveUnaryReturnType(nd, typeCode), copy: true);
+            var len = @out.size;
+
+            unsafe
+            {
+                switch (@out.GetTypeCode)
+                {
+#if _REGEN
+                    %foreach except(supported_numericals, "Decimal"),except(supported_numericals_lowercase, "decimal")%
+	                case NPTypeCode.#1:
+	                {
+                        var out_addr = (#2*)@out.Address;
+                        for (int i = 0; i < len; i++) out_addr[i] = Converts.To#1(Math.Round(out_addr[i], decimals));
+                        return @out;
+	                }
+	                %
+                    case NPTypeCode.Decimal:
+	                {
+                        var out_addr = (decimal*)@out.Address;
+                        for (int i = 0; i < len; i++) out_addr[i] = (DecimalEx.Round(out_addr[i], decimals));
+                        return @out;
+	                }
+	                default:
+		                throw new NotSupportedException();
+#else
+                    case NPTypeCode.Double:
+                        {
+                            var out_addr = (double*)@out.Address;
+                            for (int i = 0; i < len; i++) out_addr[i] = Converts.ToDouble(Math.Round(out_addr[i], decimals));
+                            return @out;
+                        }
+                    case NPTypeCode.Single:
+                        {
+                            var out_addr = (float*)@out.Address;
+                            for (int i = 0; i < len; i++) out_addr[i] = Converts.ToSingle(Math.Round(out_addr[i], decimals));
+                            return @out;
+                        }
+                    case NPTypeCode.Decimal:
+                        {
+                            var out_addr = (decimal*)@out.Address;
+                            for (int i = 0; i < len; i++) out_addr[i] = (decimal.Round(out_addr[i], decimals));
+                            return @out;
+                        }
+                    default:
+                        throw new NotSupportedException();
 #endif
                 }
             }

--- a/src/NumSharp.Core/Backends/TensorEngine.cs
+++ b/src/NumSharp.Core/Backends/TensorEngine.cs
@@ -79,7 +79,9 @@ namespace NumSharp
         public abstract NDArray Ceil(in NDArray nd, Type dtype);
         public abstract NDArray Ceil(in NDArray nd, NPTypeCode? typeCode = null);
         public abstract NDArray Round(in NDArray nd, Type dtype);
+        public abstract NDArray Round(in NDArray nd, int decimals, Type dtype);
         public abstract NDArray Round(in NDArray nd, NPTypeCode? typeCode = null);
+        public abstract NDArray Round(in NDArray nd, int decimals, NPTypeCode? typeCode = null);
         public abstract (NDArray Fractional, NDArray Intergral) ModF(in NDArray nd, Type dtype);
         public abstract (NDArray Fractional, NDArray Intergral) ModF(in NDArray nd, NPTypeCode? typeCode = null);
        

--- a/src/NumSharp.Core/Math/np.round.cs
+++ b/src/NumSharp.Core/Math/np.round.cs
@@ -20,12 +20,36 @@ namespace NumSharp
         ///     Evenly round to the given number of decimals.
         /// </summary>
         /// <param name="x">Input array</param>
+        /// <param name="decimals">Number of decimal places to round to</param>
+        /// <param name="outType">The dtype the returned ndarray should be of, only non integer values are supported.</param>
+        /// <returns>An array of the same type as a, containing the rounded values. Unless out was specified, a new array is created. A reference to the result is returned.
+        ///  The real and imaginary parts of complex numbers are rounded separately.The result of rounding a float is a float.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.around.html</remarks>
+        public static NDArray round_(in NDArray x, int decimals, NPTypeCode? outType = null)
+            => x.TensorEngine.Round(x, decimals, outType);
+
+        /// <summary>
+        ///     Evenly round to the given number of decimals.
+        /// </summary>
+        /// <param name="x">Input array</param>
         /// <param name="outType">The dtype the returned ndarray should be of, only non integer values are supported.</param>
         /// <returns>An array of the same type as a, containing the rounded values. Unless out was specified, a new array is created. A reference to the result is returned.
         ///  The real and imaginary parts of complex numbers are rounded separately.The result of rounding a float is a float.</returns>
         /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.around.html</remarks>
         public static NDArray round_(in NDArray x, Type outType) 
             => x.TensorEngine.Round(x, outType);
+
+        /// <summary>
+        ///     Evenly round to the given number of decimals.
+        /// </summary>
+        /// <param name="x">Input array</param>
+        /// <param name="decimals">Number of decimal places to round to</param>
+        /// <param name="outType">The dtype the returned ndarray should be of, only non integer values are supported.</param>
+        /// <returns>An array of the same type as a, containing the rounded values. Unless out was specified, a new array is created. A reference to the result is returned.
+        ///  The real and imaginary parts of complex numbers are rounded separately.The result of rounding a float is a float.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.around.html</remarks>
+        public static NDArray round_(in NDArray x, int decimals, Type outType)
+            => x.TensorEngine.Round(x, decimals, outType);
 
         /// <summary>
         ///     Evenly round to the given number of decimals.
@@ -42,11 +66,35 @@ namespace NumSharp
         ///     Evenly round to the given number of decimals.
         /// </summary>
         /// <param name="x">Input array</param>
+        /// <param name="decimals">Number of decimal places to round to</param>
+        /// <param name="outType">The dtype the returned ndarray should be of, only non integer values are supported.</param>
+        /// <returns>An array of the same type as a, containing the rounded values. Unless out was specified, a new array is created. A reference to the result is returned.
+        ///  The real and imaginary parts of complex numbers are rounded separately.The result of rounding a float is a float.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.around.html</remarks>
+        public static NDArray around(in NDArray x, int decimals, NPTypeCode? outType = null)
+            => x.TensorEngine.Round(x, decimals, outType);
+
+        /// <summary>
+        ///     Evenly round to the given number of decimals.
+        /// </summary>
+        /// <param name="x">Input array</param>
         /// <param name="outType">The dtype the returned ndarray should be of, only non integer values are supported.</param>
         /// <returns>An array of the same type as a, containing the rounded values. Unless out was specified, a new array is created. A reference to the result is returned.
         ///  The real and imaginary parts of complex numbers are rounded separately.The result of rounding a float is a float.</returns>
         /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.around.html</remarks>
         public static NDArray around(in NDArray x, Type outType)
             => x.TensorEngine.Round(x, outType);
+
+        /// <summary>
+        ///     Evenly round to the given number of decimals.
+        /// </summary>
+        /// <param name="x">Input array</param>
+        /// <param name="decimals">Number of decimal places to round to</param>
+        /// <param name="outType">The dtype the returned ndarray should be of, only non integer values are supported.</param>
+        /// <returns>An array of the same type as a, containing the rounded values. Unless out was specified, a new array is created. A reference to the result is returned.
+        ///  The real and imaginary parts of complex numbers are rounded separately.The result of rounding a float is a float.</returns>
+        /// <remarks>https://docs.scipy.org/doc/numpy/reference/generated/numpy.around.html</remarks>
+        public static NDArray around(in NDArray x, int decimals, Type outType)
+            => x.TensorEngine.Round(x, decimals, outType);
     }
 }


### PR DESCRIPTION
In response to issue #452,

I added new overloads for np.around(), np.round_() and TensorEngine.Round() methods with argument decimals (int) to round the values of NDArray to user specified precision