### PR TITLE
Add GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,6 +11,13 @@ on:
 permissions: write-all
 
 env:
+  # Suppress noisy build warnings that clutter CI annotations.
+  # Uses %3B (URL-encoded semicolon) because MSBuild CLI treats raw ; and , as property separators.
+  # XML doc warnings (CS15xx, CS17xx): ~7,200 of ~8,700 total — malformed/missing doc comments
+  # CS8981: 'np' only contains lowercase chars — intentional for NumPy API compat
+  # NU5048: PackageIconUrl deprecated — cosmetic NuGet warning
+  DOTNET_NOWARN: CS1570%3BCS1571%3BCS1572%3BCS1573%3BCS1574%3BCS1587%3BCS1591%3BCS1711%3BCS1734%3BCS8981%3BNU5048
+
   # Exclude known-failing test classes and specific test methods from CI.
   # These are pre-existing bugs tracked in OpenBugs.cs and related test files.
   # When a bug is fixed, remove its exclusion here so CI catches regressions.
@@ -60,7 +67,7 @@ jobs:
         dotnet-quality: 'preview'
 
     - name: Build
-      run: dotnet build test/NumSharp.UnitTest/NumSharp.UnitTest.csproj --configuration Release
+      run: dotnet build test/NumSharp.UnitTest/NumSharp.UnitTest.csproj --configuration Release -p:NoWarn=${{ env.DOTNET_NOWARN }}
 
     - name: Test
       run: dotnet test test/NumSharp.UnitTest/NumSharp.UnitTest.csproj --configuration Release --no-build --verbosity normal --logger trx --filter "${{ env.TEST_FILTER }} ${{ matrix.extra_filter }}"
@@ -105,6 +112,7 @@ jobs:
       run: |
         dotnet build src/NumSharp.Core/NumSharp.Core.csproj \
           --configuration Release \
+          -p:NoWarn=${{ env.DOTNET_NOWARN }} \
           -p:Version=${{ steps.version.outputs.VERSION }} \
           -p:AssemblyVersion=${{ steps.version.outputs.ASSEMBLY_VERSION }} \
           -p:FileVersion=${{ steps.version.outputs.ASSEMBLY_VERSION }} \
@@ -113,6 +121,7 @@ jobs:
 
         dotnet build src/NumSharp.Bitmap/NumSharp.Bitmap.csproj \
           --configuration Release \
+          -p:NoWarn=${{ env.DOTNET_NOWARN }} \
           -p:Version=${{ steps.version.outputs.VERSION }} \
           -p:AssemblyVersion=${{ steps.version.outputs.ASSEMBLY_VERSION }} \
           -p:FileVersion=${{ steps.version.outputs.ASSEMBLY_VERSION }} \
@@ -127,6 +136,7 @@ jobs:
           --configuration Release \
           --no-build \
           --output artifacts/nuget \
+          -p:NoWarn=${{ env.DOTNET_NOWARN }} \
           -p:Version=${{ steps.version.outputs.VERSION }} \
           -p:AssemblyVersion=${{ steps.version.outputs.ASSEMBLY_VERSION }} \
           -p:FileVersion=${{ steps.version.outputs.ASSEMBLY_VERSION }} \
@@ -136,6 +146,7 @@ jobs:
           --configuration Release \
           --no-build \
           --output artifacts/nuget \
+          -p:NoWarn=${{ env.DOTNET_NOWARN }} \
           -p:Version=${{ steps.version.outputs.VERSION }} \
           -p:AssemblyVersion=${{ steps.version.outputs.ASSEMBLY_VERSION }} \
           -p:FileVersion=${{ steps.version.outputs.ASSEMBLY_VERSION }} \


### PR DESCRIPTION
## Summary

- Add `.github/workflows/build-and-release.yml` — full CI/CD pipeline with 4 jobs: **test** (3 OSes), **build-nuget**, **create-release**, **publish-nuget**
- Suppress ~7,600 cosmetic build warnings (XML doc comments, lowercase `np` class name) to keep annotations clean
- Exclude known-failing tests via `TEST_FILTER` so the pipeline starts green (bugs tracked in `OpenBugs.cs`)

## Details

**Triggers:** push to master, PR to master, tag `v*`, manual `workflow_dispatch`

**Tag releases:** Pushing a `v*` tag runs the full pipeline — tests on all 3 OSes, builds NuGet packages for `NumSharp` + `NumSharp.Bitmap`, creates a GitHub Release with `.nupkg` + `.sha256` assets, and publishes to nuget.org (requires `NUGETAPIKEY` secret).

**Prerelease detection:** Tags with hyphens (e.g., `v1.0.0-rc1`) → `prerelease: true`. Without → `prerelease: false`.

**Warning suppression:** Uses `-p:NoWarn` with `%3B`-encoded semicolons (MSBuild CLI quoting) to suppress XML doc warnings (`CS1570-CS1591`, `CS1711`, `CS1734`), `CS8981` (lowercase type name `np`), and `NU5048` (PackageIconUrl deprecated). Real code warnings preserved.

## Test plan

Exhaustively verified on [`Nucs/NumSharp-dev`](https://github.com/Nucs/NumSharp-dev) test repository:

- [x] `workflow_dispatch` — 3 OSes green, publish jobs skipped
- [x] Regression detection — deliberate failing test → all 3 OSes fail red
- [x] PR trigger — 3 OSes green, publish jobs skipped
- [x] Stable release tag (`v0.50.0`) — full pipeline with release assets
- [x] Prerelease flag correct (`prerelease: false` for non-hyphenated tag)
- [x] Missing `NUGETAPIKEY` — clear error, doesn't crash parallel jobs
- [x] Warning suppression — annotations reduced from ~120 to ~30 per run
- [x] All test artifacts cleaned up after verification

Closes #533