### PR TITLE
Fix: skip Bitmap tests on non-Windows CI

### DIFF
--- a/test/NumSharp.UnitTest/NumSharp.Bitmap/BitmapExtensionsTests.cs
+++ b/test/NumSharp.UnitTest/NumSharp.Bitmap/BitmapExtensionsTests.cs
@@ -10,6 +10,13 @@ namespace NumSharp.UnitTest
     [TestClass]
     public class BitmapExtensionsTests : TestClass
     {
+        [ClassInitialize]
+        public static void RequireWindows(TestContext _)
+        {
+            if (!OperatingSystem.IsWindows())
+                Assert.Inconclusive("System.Drawing.Common requires Windows (GDI+).");
+        }
+
         // ================================================================
         // Bugs discovered during test coverage expansion:
         //

--- a/test/NumSharp.UnitTest/NumSharp.Bitmap/BitmapWithAlphaTests.cs
+++ b/test/NumSharp.UnitTest/NumSharp.Bitmap/BitmapWithAlphaTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing.Imaging;
+﻿using System;
+using System.Drawing.Imaging;
 using System.Resources;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -9,6 +10,13 @@ namespace NumSharp.UnitTest
     [TestClass]
     public class BitmapWithAlphaTests : TestClass
     {
+        [ClassInitialize]
+        public static void RequireWindows(TestContext _)
+        {
+            if (!OperatingSystem.IsWindows())
+                Assert.Inconclusive("System.Drawing.Common requires Windows (GDI+).");
+        }
+
         [TestMethod]
         public void ToNDArray_Case1()
         {

--- a/test/NumSharp.UnitTest/OpenBugs.Bitmap.cs
+++ b/test/NumSharp.UnitTest/OpenBugs.Bitmap.cs
@@ -57,6 +57,13 @@ namespace NumSharp.UnitTest
     [TestClass]
     public class OpenBugsBitmap : TestClass
     {
+        [ClassInitialize]
+        public static void RequireWindows(TestContext _)
+        {
+            if (!OperatingSystem.IsWindows())
+                Assert.Inconclusive("System.Drawing.Common requires Windows (GDI+).");
+        }
+
         // ================================================================
         //
         //  BUG 1: ToNDArray(copy:true) on odd-width 24bpp images produces


### PR DESCRIPTION
## Summary

- Add `[ClassInitialize]` with `OperatingSystem.IsWindows()` check to all 3 Bitmap test classes
- Tests report as **Inconclusive** (skipped) on Linux/macOS instead of failing with `PlatformNotSupportedException`

Fixes the CI failure introduced by #532 — `System.Drawing.Common` requires GDI+ which is Windows-only since .NET 6.

Affected classes: `BitmapWithAlphaTests`, `BitmapExtensionsTests`, `OpenBugsBitmap`