### PR TITLE
[API] Support np.where via ILKernelGenerator

### DIFF
--- a/src/NumSharp.Core/APIs/np.where.cs
+++ b/src/NumSharp.Core/APIs/np.where.cs
@@ -27,11 +27,7 @@ namespace NumSharp
         /// <remarks>https://numpy.org/doc/stable/reference/generated/numpy.where.html</remarks>
         public static NDArray where(NDArray condition, NDArray x, NDArray y)
         {
-            // Detect scalar NDArrays (from implicit primitive conversion or explicit NDArray.Scalar)
-            // Scalar NDArrays use NEP50 weak scalar type promotion rules
-            bool xIsScalar = x.Shape.IsScalar;
-            bool yIsScalar = y.Shape.IsScalar;
-            return where_internal(condition, x, y, xIsScalar, yIsScalar);
+            return where_internal(condition, x, y);
         }
 
         /// <summary>
@@ -40,8 +36,7 @@ namespace NumSharp
         /// </summary>
         public static NDArray where(NDArray condition, object x, NDArray y)
         {
-            var xArr = asanyarray(x);
-            return where_internal(condition, xArr, y, xArr.Shape.IsScalar, y.Shape.IsScalar);
+            return where_internal(condition, asanyarray(x), y);
         }
 
         /// <summary>
@@ -50,8 +45,7 @@ namespace NumSharp
         /// </summary>
         public static NDArray where(NDArray condition, NDArray x, object y)
         {
-            var yArr = asanyarray(y);
-            return where_internal(condition, x, yArr, x.Shape.IsScalar, yArr.Shape.IsScalar);
+            return where_internal(condition, x, asanyarray(y));
         }
 
         /// <summary>
@@ -60,20 +54,13 @@ namespace NumSharp
         /// </summary>
         public static NDArray where(NDArray condition, object x, object y)
         {
-            var xArr = asanyarray(x);
-            var yArr = asanyarray(y);
-            return where_internal(condition, xArr, yArr, xArr.Shape.IsScalar, yArr.Shape.IsScalar);
+            return where_internal(condition, asanyarray(x), asanyarray(y));
         }
 
         /// <summary>
-        /// Internal implementation of np.where with scalar tracking for NEP50 type promotion.
+        /// Internal implementation of np.where.
         /// </summary>
-        /// <param name="condition">Condition array</param>
-        /// <param name="x">X values (already converted to NDArray)</param>
-        /// <param name="y">Y values (already converted to NDArray)</param>
-        /// <param name="xIsScalar">True if x is a scalar NDArray</param>
-        /// <param name="yIsScalar">True if y is a scalar NDArray</param>
-        private static NDArray where_internal(NDArray condition, NDArray x, NDArray y, bool xIsScalar, bool yIsScalar)
+        private static NDArray where_internal(NDArray condition, NDArray x, NDArray y)
         {
             // Broadcast all three arrays to common shape
             var broadcasted = broadcast_arrays(condition, x, y);
@@ -81,8 +68,9 @@ namespace NumSharp
             var xArr = broadcasted[1];
             var yArr = broadcasted[2];
 
-            // Determine output dtype from x and y using NEP50-aware type promotion
-            var outType = _FindCommonTypeForWhere(x.GetTypeCode, y.GetTypeCode, xIsScalar, yIsScalar);
+            // Determine output dtype using existing type promotion system
+            // _FindCommonType already handles NEP50: scalar+array → array wins
+            var outType = _FindCommonType(x, y);
 
             // Convert x and y to output type if needed (required for kernel and iterator paths)
             if (xArr.GetTypeCode != outType)
@@ -155,94 +143,6 @@ namespace NumSharp
             }
 
             return result;
-        }
-
-        /// <summary>
-        /// Determines the output dtype for np.where following NumPy 2.x NEP50 rules.
-        ///
-        /// Rules:
-        /// 1. Both arrays (non-scalar): use array-array promotion table
-        /// 2. Both were scalars: use Python-like defaults (int32→int64)
-        /// 3. One array, one scalar: use NEP50 weak scalar rules (array dtype wins for same-kind)
-        /// </summary>
-        private static NPTypeCode _FindCommonTypeForWhere(NPTypeCode xType, NPTypeCode yType, bool xIsScalar, bool yIsScalar)
-        {
-            // Case 1: Both are scalars - use Python-like default type widening
-            if (xIsScalar && yIsScalar)
-            {
-                return _GetPythonLikeScalarType(xType, yType);
-            }
-
-            // Case 2: One is scalar, one is array - use NEP50 weak scalar rules
-            if (xIsScalar)
-            {
-                // y is array, x is scalar - array wins for same-kind
-                return _FindCommonArrayScalarType(yType, xType);
-            }
-            if (yIsScalar)
-            {
-                // x is array, y is scalar - array wins for same-kind
-                return _FindCommonArrayScalarType(xType, yType);
-            }
-
-            // Case 3: Both are arrays - use array-array promotion
-            return _FindCommonArrayType(xType, yType);
-        }
-
-        /// <summary>
-        /// Determines the result type when both operands are scalar NDArrays.
-        ///
-        /// C# limitation: We cannot distinguish between:
-        /// - `np.where(cond, 1, 0)` where 1,0 are C# int literals (implicit conversion)
-        /// - `np.where(cond, np.array(1), np.array(0))` where arrays are explicitly created
-        ///
-        /// Both cases create int32 scalar NDArrays. We preserve the type when both
-        /// scalars are the same type, and use NEP50 weak scalar rules otherwise.
-        /// This differs from NumPy where Python int literals widen to int64.
-        /// </summary>
-        private static NPTypeCode _GetPythonLikeScalarType(NPTypeCode xType, NPTypeCode yType)
-        {
-            // Same type: preserve it (no widening)
-            // This handles np.where(cond, 1, 0) → int32, np.where(cond, 1L, 0L) → int64
-            if (xType == yType)
-                return xType;
-
-            // Different types - apply promotion rules
-            var xKind = GetTypeKind(xType);
-            var yKind = GetTypeKind(yType);
-
-            // Cross-kind promotion: use standard array-array rules
-            if (xKind != yKind)
-            {
-                return _FindCommonArrayType(xType, yType);
-            }
-
-            // Same kind, different types - use array-array promotion
-            return _FindCommonArrayType(xType, yType);
-        }
-
-        /// <summary>
-        /// Returns the kind character for a type (matching NumPy's dtype.kind).
-        /// </summary>
-        private static char GetTypeKind(NPTypeCode type)
-        {
-            return type switch
-            {
-                NPTypeCode.Boolean => 'b',
-                NPTypeCode.Byte => 'u',
-                NPTypeCode.UInt16 => 'u',
-                NPTypeCode.UInt32 => 'u',
-                NPTypeCode.UInt64 => 'u',
-                NPTypeCode.Int16 => 'i',
-                NPTypeCode.Int32 => 'i',
-                NPTypeCode.Int64 => 'i',
-                NPTypeCode.Char => 'u', // char is essentially uint16
-                NPTypeCode.Single => 'f',
-                NPTypeCode.Double => 'f',
-                NPTypeCode.Decimal => 'f', // treat decimal as float-like
-                NPTypeCode.Complex => 'c',
-                _ => '?'
-            };
         }
 
         private static void WhereImpl<T>(NDArray cond, NDArray x, NDArray y, NDArray result) where T : unmanaged

--- a/src/NumSharp.Core/APIs/np.where.cs
+++ b/src/NumSharp.Core/APIs/np.where.cs
@@ -209,6 +209,8 @@ namespace NumSharp
                 case NPTypeCode.Decimal:
                     ILKernelGenerator.WhereExecute(condPtr, (decimal*)x.Address, (decimal*)y.Address, (decimal*)result.Address, count);
                     break;
+                default:
+                    throw new NotSupportedException($"Type {outType} not supported for np.where");
             }
         }
     }

--- a/src/NumSharp.Core/APIs/np.where.cs
+++ b/src/NumSharp.Core/APIs/np.where.cs
@@ -7,10 +7,11 @@ namespace NumSharp
     public static partial class np
     {
         /// <summary>
-        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        ///     Equivalent to <see cref="nonzero(NDArray)"/>: returns the indices where
+        ///     <paramref name="condition"/> is non-zero.
         /// </summary>
-        /// <param name="condition">Where True, yield `x`, otherwise yield `y`.</param>
-        /// <returns>Tuple of arrays with indices where condition is non-zero (equivalent to np.nonzero).</returns>
+        /// <param name="condition">Input array. Non-zero entries yield their indices.</param>
+        /// <returns>Tuple of arrays with indices where condition is non-zero, one per dimension.</returns>
         /// <remarks>https://numpy.org/doc/stable/reference/generated/numpy.where.html</remarks>
         public static NDArray<long>[] where(NDArray condition)
         {
@@ -62,17 +63,29 @@ namespace NumSharp
         /// </summary>
         private static NDArray where_internal(NDArray condition, NDArray x, NDArray y)
         {
-            // Broadcast all three arrays to common shape
-            var broadcasted = broadcast_arrays(condition, x, y);
-            var cond = broadcasted[0];
-            var xArr = broadcasted[1];
-            var yArr = broadcasted[2];
+            // Skip broadcast_arrays (which allocates 3 NDArrays + helper arrays) when all three
+            // already share a shape — the frequent case of np.where(mask, arr, other_arr).
+            NDArray cond, xArr, yArr;
+            if (condition.Shape == x.Shape && x.Shape == y.Shape)
+            {
+                cond = condition;
+                xArr = x;
+                yArr = y;
+            }
+            else
+            {
+                var broadcasted = broadcast_arrays(condition, x, y);
+                cond = broadcasted[0];
+                xArr = broadcasted[1];
+                yArr = broadcasted[2];
+            }
 
-            // Determine output dtype using existing type promotion system
-            // _FindCommonType already handles NEP50: scalar+array → array wins
-            var outType = _FindCommonType(x, y);
+            // When x and y already agree, skip the NEP50 promotion lookup. Otherwise defer to
+            // _FindCommonType which handles the scalar+array NEP50 rules.
+            var outType = x.GetTypeCode == y.GetTypeCode
+                ? x.GetTypeCode
+                : _FindCommonType(x, y);
 
-            // Convert x and y to output type if needed (required for kernel and iterator paths)
             if (xArr.GetTypeCode != outType)
                 xArr = xArr.astype(outType, copy: false);
             if (yArr.GetTypeCode != outType)

--- a/src/NumSharp.Core/APIs/np.where.cs
+++ b/src/NumSharp.Core/APIs/np.where.cs
@@ -27,14 +27,69 @@ namespace NumSharp
         /// <remarks>https://numpy.org/doc/stable/reference/generated/numpy.where.html</remarks>
         public static NDArray where(NDArray condition, NDArray x, NDArray y)
         {
+            // Detect scalar NDArrays (from implicit primitive conversion or explicit NDArray.Scalar)
+            // Scalar NDArrays use NEP50 weak scalar type promotion rules
+            bool xIsScalar = x.Shape.IsScalar;
+            bool yIsScalar = y.Shape.IsScalar;
+            return where_internal(condition, x, y, xIsScalar, yIsScalar);
+        }
+
+        /// <summary>
+        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        ///     Scalar overload for x.
+        /// </summary>
+        public static NDArray where(NDArray condition, object x, NDArray y)
+        {
+            var xArr = asanyarray(x);
+            return where_internal(condition, xArr, y, xArr.Shape.IsScalar, y.Shape.IsScalar);
+        }
+
+        /// <summary>
+        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        ///     Scalar overload for y.
+        /// </summary>
+        public static NDArray where(NDArray condition, NDArray x, object y)
+        {
+            var yArr = asanyarray(y);
+            return where_internal(condition, x, yArr, x.Shape.IsScalar, yArr.Shape.IsScalar);
+        }
+
+        /// <summary>
+        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        ///     Scalar overload for both x and y.
+        /// </summary>
+        public static NDArray where(NDArray condition, object x, object y)
+        {
+            var xArr = asanyarray(x);
+            var yArr = asanyarray(y);
+            return where_internal(condition, xArr, yArr, xArr.Shape.IsScalar, yArr.Shape.IsScalar);
+        }
+
+        /// <summary>
+        /// Internal implementation of np.where with scalar tracking for NEP50 type promotion.
+        /// </summary>
+        /// <param name="condition">Condition array</param>
+        /// <param name="x">X values (already converted to NDArray)</param>
+        /// <param name="y">Y values (already converted to NDArray)</param>
+        /// <param name="xIsScalar">True if x is a scalar NDArray</param>
+        /// <param name="yIsScalar">True if y is a scalar NDArray</param>
+        private static NDArray where_internal(NDArray condition, NDArray x, NDArray y, bool xIsScalar, bool yIsScalar)
+        {
             // Broadcast all three arrays to common shape
             var broadcasted = broadcast_arrays(condition, x, y);
             var cond = broadcasted[0];
             var xArr = broadcasted[1];
             var yArr = broadcasted[2];
 
-            // Determine output dtype from x and y (type promotion)
-            var outType = _FindCommonType(xArr, yArr);
+            // Determine output dtype from x and y using NEP50-aware type promotion
+            var outType = _FindCommonTypeForWhere(x.GetTypeCode, y.GetTypeCode, xIsScalar, yIsScalar);
+
+            // Convert x and y to output type if needed (required for kernel and iterator paths)
+            if (xArr.GetTypeCode != outType)
+                xArr = xArr.astype(outType, copy: false);
+            if (yArr.GetTypeCode != outType)
+                yArr = yArr.astype(outType, copy: false);
+
             // Use cond.shape (dimensions only) not cond.Shape (which may have broadcast strides)
             var result = empty(cond.shape, outType);
 
@@ -103,30 +158,91 @@ namespace NumSharp
         }
 
         /// <summary>
-        ///     Return elements chosen from `x` or `y` depending on `condition`.
-        ///     Scalar overload for x.
+        /// Determines the output dtype for np.where following NumPy 2.x NEP50 rules.
+        ///
+        /// Rules:
+        /// 1. Both arrays (non-scalar): use array-array promotion table
+        /// 2. Both were scalars: use Python-like defaults (int32→int64)
+        /// 3. One array, one scalar: use NEP50 weak scalar rules (array dtype wins for same-kind)
         /// </summary>
-        public static NDArray where(NDArray condition, object x, NDArray y)
+        private static NPTypeCode _FindCommonTypeForWhere(NPTypeCode xType, NPTypeCode yType, bool xIsScalar, bool yIsScalar)
         {
-            return where(condition, asanyarray(x), y);
+            // Case 1: Both are scalars - use Python-like default type widening
+            if (xIsScalar && yIsScalar)
+            {
+                return _GetPythonLikeScalarType(xType, yType);
+            }
+
+            // Case 2: One is scalar, one is array - use NEP50 weak scalar rules
+            if (xIsScalar)
+            {
+                // y is array, x is scalar - array wins for same-kind
+                return _FindCommonArrayScalarType(yType, xType);
+            }
+            if (yIsScalar)
+            {
+                // x is array, y is scalar - array wins for same-kind
+                return _FindCommonArrayScalarType(xType, yType);
+            }
+
+            // Case 3: Both are arrays - use array-array promotion
+            return _FindCommonArrayType(xType, yType);
         }
 
         /// <summary>
-        ///     Return elements chosen from `x` or `y` depending on `condition`.
-        ///     Scalar overload for y.
+        /// Determines the result type when both operands are scalar NDArrays.
+        ///
+        /// C# limitation: We cannot distinguish between:
+        /// - `np.where(cond, 1, 0)` where 1,0 are C# int literals (implicit conversion)
+        /// - `np.where(cond, np.array(1), np.array(0))` where arrays are explicitly created
+        ///
+        /// Both cases create int32 scalar NDArrays. We preserve the type when both
+        /// scalars are the same type, and use NEP50 weak scalar rules otherwise.
+        /// This differs from NumPy where Python int literals widen to int64.
         /// </summary>
-        public static NDArray where(NDArray condition, NDArray x, object y)
+        private static NPTypeCode _GetPythonLikeScalarType(NPTypeCode xType, NPTypeCode yType)
         {
-            return where(condition, x, asanyarray(y));
+            // Same type: preserve it (no widening)
+            // This handles np.where(cond, 1, 0) → int32, np.where(cond, 1L, 0L) → int64
+            if (xType == yType)
+                return xType;
+
+            // Different types - apply promotion rules
+            var xKind = GetTypeKind(xType);
+            var yKind = GetTypeKind(yType);
+
+            // Cross-kind promotion: use standard array-array rules
+            if (xKind != yKind)
+            {
+                return _FindCommonArrayType(xType, yType);
+            }
+
+            // Same kind, different types - use array-array promotion
+            return _FindCommonArrayType(xType, yType);
         }
 
         /// <summary>
-        ///     Return elements chosen from `x` or `y` depending on `condition`.
-        ///     Scalar overload for both x and y.
+        /// Returns the kind character for a type (matching NumPy's dtype.kind).
         /// </summary>
-        public static NDArray where(NDArray condition, object x, object y)
+        private static char GetTypeKind(NPTypeCode type)
         {
-            return where(condition, asanyarray(x), asanyarray(y));
+            return type switch
+            {
+                NPTypeCode.Boolean => 'b',
+                NPTypeCode.Byte => 'u',
+                NPTypeCode.UInt16 => 'u',
+                NPTypeCode.UInt32 => 'u',
+                NPTypeCode.UInt64 => 'u',
+                NPTypeCode.Int16 => 'i',
+                NPTypeCode.Int32 => 'i',
+                NPTypeCode.Int64 => 'i',
+                NPTypeCode.Char => 'u', // char is essentially uint16
+                NPTypeCode.Single => 'f',
+                NPTypeCode.Double => 'f',
+                NPTypeCode.Decimal => 'f', // treat decimal as float-like
+                NPTypeCode.Complex => 'c',
+                _ => '?'
+            };
         }
 
         private static void WhereImpl<T>(NDArray cond, NDArray x, NDArray y, NDArray result) where T : unmanaged

--- a/src/NumSharp.Core/APIs/np.where.cs
+++ b/src/NumSharp.Core/APIs/np.where.cs
@@ -1,0 +1,199 @@
+using System;
+using NumSharp.Backends.Kernels;
+using NumSharp.Generic;
+
+namespace NumSharp
+{
+    public static partial class np
+    {
+        /// <summary>
+        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        /// </summary>
+        /// <param name="condition">Where True, yield `x`, otherwise yield `y`.</param>
+        /// <returns>Tuple of arrays with indices where condition is non-zero (equivalent to np.nonzero).</returns>
+        /// <remarks>https://numpy.org/doc/stable/reference/generated/numpy.where.html</remarks>
+        public static NDArray<long>[] where(NDArray condition)
+        {
+            return nonzero(condition);
+        }
+
+        /// <summary>
+        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        /// </summary>
+        /// <param name="condition">Where True, yield `x`, otherwise yield `y`.</param>
+        /// <param name="x">Values from which to choose where condition is True.</param>
+        /// <param name="y">Values from which to choose where condition is False.</param>
+        /// <returns>An array with elements from `x` where `condition` is True, and elements from `y` elsewhere.</returns>
+        /// <remarks>https://numpy.org/doc/stable/reference/generated/numpy.where.html</remarks>
+        public static NDArray where(NDArray condition, NDArray x, NDArray y)
+        {
+            // Broadcast all three arrays to common shape
+            var broadcasted = broadcast_arrays(condition, x, y);
+            var cond = broadcasted[0];
+            var xArr = broadcasted[1];
+            var yArr = broadcasted[2];
+
+            // Determine output dtype from x and y (type promotion)
+            var outType = _FindCommonType(xArr, yArr);
+            // Use cond.shape (dimensions only) not cond.Shape (which may have broadcast strides)
+            var result = empty(cond.shape, outType);
+
+            // Handle empty arrays - nothing to iterate
+            if (result.size == 0)
+                return result;
+
+            // IL Kernel fast path: all arrays contiguous, bool condition, SIMD enabled
+            // Broadcasted arrays (stride=0) are NOT contiguous, so they use iterator path.
+            bool canUseKernel = ILKernelGenerator.Enabled &&
+                                cond.typecode == NPTypeCode.Boolean &&
+                                cond.Shape.IsContiguous &&
+                                xArr.Shape.IsContiguous &&
+                                yArr.Shape.IsContiguous;
+
+            if (canUseKernel)
+            {
+                WhereKernelDispatch(cond, xArr, yArr, result, outType);
+                return result;
+            }
+
+            // Iterator fallback for non-contiguous/broadcasted arrays
+            switch (outType)
+            {
+                case NPTypeCode.Boolean:
+                    WhereImpl<bool>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.Byte:
+                    WhereImpl<byte>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.Int16:
+                    WhereImpl<short>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.UInt16:
+                    WhereImpl<ushort>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.Int32:
+                    WhereImpl<int>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.UInt32:
+                    WhereImpl<uint>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.Int64:
+                    WhereImpl<long>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.UInt64:
+                    WhereImpl<ulong>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.Char:
+                    WhereImpl<char>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.Single:
+                    WhereImpl<float>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.Double:
+                    WhereImpl<double>(cond, xArr, yArr, result);
+                    break;
+                case NPTypeCode.Decimal:
+                    WhereImpl<decimal>(cond, xArr, yArr, result);
+                    break;
+                default:
+                    throw new NotSupportedException($"Type {outType} not supported for np.where");
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        ///     Scalar overload for x.
+        /// </summary>
+        public static NDArray where(NDArray condition, object x, NDArray y)
+        {
+            return where(condition, asanyarray(x), y);
+        }
+
+        /// <summary>
+        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        ///     Scalar overload for y.
+        /// </summary>
+        public static NDArray where(NDArray condition, NDArray x, object y)
+        {
+            return where(condition, x, asanyarray(y));
+        }
+
+        /// <summary>
+        ///     Return elements chosen from `x` or `y` depending on `condition`.
+        ///     Scalar overload for both x and y.
+        /// </summary>
+        public static NDArray where(NDArray condition, object x, object y)
+        {
+            return where(condition, asanyarray(x), asanyarray(y));
+        }
+
+        private static void WhereImpl<T>(NDArray cond, NDArray x, NDArray y, NDArray result) where T : unmanaged
+        {
+            // Use iterators for proper handling of broadcasted/strided arrays
+            using var condIter = cond.AsIterator<bool>();
+            using var xIter = x.AsIterator<T>();
+            using var yIter = y.AsIterator<T>();
+            using var resultIter = result.AsIterator<T>();
+
+            while (condIter.HasNext())
+            {
+                var c = condIter.MoveNext();
+                var xVal = xIter.MoveNext();
+                var yVal = yIter.MoveNext();
+                resultIter.MoveNextReference() = c ? xVal : yVal;
+            }
+        }
+
+        /// <summary>
+        /// IL Kernel dispatch for contiguous arrays.
+        /// Uses IL-generated kernels with SIMD optimization.
+        /// </summary>
+        private static unsafe void WhereKernelDispatch(NDArray cond, NDArray x, NDArray y, NDArray result, NPTypeCode outType)
+        {
+            var condPtr = (bool*)cond.Address;
+            var count = result.size;
+
+            switch (outType)
+            {
+                case NPTypeCode.Boolean:
+                    ILKernelGenerator.WhereExecute(condPtr, (bool*)x.Address, (bool*)y.Address, (bool*)result.Address, count);
+                    break;
+                case NPTypeCode.Byte:
+                    ILKernelGenerator.WhereExecute(condPtr, (byte*)x.Address, (byte*)y.Address, (byte*)result.Address, count);
+                    break;
+                case NPTypeCode.Int16:
+                    ILKernelGenerator.WhereExecute(condPtr, (short*)x.Address, (short*)y.Address, (short*)result.Address, count);
+                    break;
+                case NPTypeCode.UInt16:
+                    ILKernelGenerator.WhereExecute(condPtr, (ushort*)x.Address, (ushort*)y.Address, (ushort*)result.Address, count);
+                    break;
+                case NPTypeCode.Int32:
+                    ILKernelGenerator.WhereExecute(condPtr, (int*)x.Address, (int*)y.Address, (int*)result.Address, count);
+                    break;
+                case NPTypeCode.UInt32:
+                    ILKernelGenerator.WhereExecute(condPtr, (uint*)x.Address, (uint*)y.Address, (uint*)result.Address, count);
+                    break;
+                case NPTypeCode.Int64:
+                    ILKernelGenerator.WhereExecute(condPtr, (long*)x.Address, (long*)y.Address, (long*)result.Address, count);
+                    break;
+                case NPTypeCode.UInt64:
+                    ILKernelGenerator.WhereExecute(condPtr, (ulong*)x.Address, (ulong*)y.Address, (ulong*)result.Address, count);
+                    break;
+                case NPTypeCode.Char:
+                    ILKernelGenerator.WhereExecute(condPtr, (char*)x.Address, (char*)y.Address, (char*)result.Address, count);
+                    break;
+                case NPTypeCode.Single:
+                    ILKernelGenerator.WhereExecute(condPtr, (float*)x.Address, (float*)y.Address, (float*)result.Address, count);
+                    break;
+                case NPTypeCode.Double:
+                    ILKernelGenerator.WhereExecute(condPtr, (double*)x.Address, (double*)y.Address, (double*)result.Address, count);
+                    break;
+                case NPTypeCode.Decimal:
+                    ILKernelGenerator.WhereExecute(condPtr, (decimal*)x.Address, (decimal*)y.Address, (decimal*)result.Address, count);
+                    break;
+            }
+        }
+    }
+}

--- a/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
+++ b/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
@@ -115,8 +115,17 @@ namespace NumSharp.Backends.Kernels
         {
             int elementSize = Unsafe.SizeOf<T>();
 
-            // Determine if we can use SIMD
-            bool canSimd = elementSize <= 8 && IsSimdSupported<T>();
+            // SIMD eligibility:
+            //  - 1-byte types (byte) only touch portable Vector128/Vector256 APIs, so they work
+            //    on any SIMD-capable platform (including ARM64/Neon).
+            //  - 2/4/8-byte types need Sse41.ConvertToVector128Int* (V128 path) or
+            //    Avx2.ConvertToVector256Int* (V256 path) to expand the bool-mask lanes.
+            //    These x86 intrinsics throw PlatformNotSupportedException on ARM64.
+            bool canSimdDtype = elementSize <= 8 && IsSimdSupported<T>();
+            bool needsX86 = elementSize > 1;
+            bool useV256 = VectorBits >= 256 && (!needsX86 || Avx2.IsSupported);
+            bool useV128 = !useV256 && VectorBits >= 128 && (!needsX86 || Sse41.IsSupported);
+            bool emitSimd = canSimdDtype && (useV256 || useV128);
 
             var dm = new DynamicMethod(
                 name: $"IL_Where_{typeof(T).Name}",
@@ -139,10 +148,9 @@ namespace NumSharp.Backends.Kernels
             il.Emit(OpCodes.Ldc_I8, 0L);
             il.Emit(OpCodes.Stloc, locI);
 
-            if (canSimd && VectorBits >= 128)
+            if (emitSimd)
             {
-                // Generate SIMD path
-                EmitWhereSIMDLoop<T>(il, locI);
+                EmitWhereSIMDLoop<T>(il, locI, useV256);
             }
 
             // Scalar loop for remainder
@@ -170,13 +178,12 @@ namespace NumSharp.Backends.Kernels
             return (WhereKernel<T>)dm.CreateDelegate(typeof(WhereKernel<T>));
         }
 
-        private static void EmitWhereSIMDLoop<T>(ILGenerator il, LocalBuilder locI) where T : unmanaged
+        private static void EmitWhereSIMDLoop<T>(ILGenerator il, LocalBuilder locI, bool useV256) where T : unmanaged
         {
             long elementSize = Unsafe.SizeOf<T>();
-            long vectorCount = VectorBits >= 256 ? (32 / elementSize) : (16 / elementSize);
+            long vectorCount = useV256 ? (32 / elementSize) : (16 / elementSize);
             long unrollFactor = 4;
             long unrollStep = vectorCount * unrollFactor;
-            bool useV256 = VectorBits >= 256;
 
             var locUnrollEnd = il.DeclareLocal(typeof(long));
             var locVectorEnd = il.DeclareLocal(typeof(long));

--- a/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
+++ b/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
@@ -252,9 +252,6 @@ namespace NumSharp.Backends.Kernels
 
         private static void EmitWhereV256BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
         {
-            // Get the appropriate mask creation method based on element size
-            var maskMethod = GetMaskCreationMethod256((int)elementSize);
-
             // Get Vector256 methods via reflection - need to find generic method definitions first
             var loadMethod = Array.Find(typeof(Vector256).GetMethods(),
                 m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!
@@ -277,8 +274,8 @@ namespace NumSharp.Backends.Kernels
             il.Emit(OpCodes.Conv_I);
             il.Emit(OpCodes.Add);
 
-            // Call mask creation: returns Vector256<T> on stack
-            il.Emit(OpCodes.Call, maskMethod);
+            // Inline mask creation - emit AVX2 instructions directly instead of calling helper
+            EmitInlineMaskCreationV256(il, (int)elementSize);
 
             // Load x vector: x + (i + offset) * elementSize
             il.Emit(OpCodes.Ldarg_1);  // x
@@ -329,8 +326,6 @@ namespace NumSharp.Backends.Kernels
 
         private static void EmitWhereV128BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
         {
-            var maskMethod = GetMaskCreationMethod128((int)elementSize);
-
             // Get Vector128 methods via reflection - need to find generic method definitions first
             var loadMethod = Array.Find(typeof(Vector128).GetMethods(),
                 m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!
@@ -352,7 +347,9 @@ namespace NumSharp.Backends.Kernels
             }
             il.Emit(OpCodes.Conv_I);
             il.Emit(OpCodes.Add);
-            il.Emit(OpCodes.Call, maskMethod);
+
+            // Inline mask creation - emit SSE4.1 instructions directly
+            EmitInlineMaskCreationV128(il, (int)elementSize);
 
             // Load x vector
             il.Emit(OpCodes.Ldarg_1);
@@ -496,6 +493,230 @@ namespace NumSharp.Backends.Kernels
                 _ => throw new NotSupportedException($"Element size {elementSize} not supported for SIMD where")
             };
         }
+
+        #endregion
+
+        #region Inline Mask IL Emission
+
+        // Cache reflection lookups for inline emission
+        private static readonly MethodInfo _v128LoadByte = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "Load" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
+        private static readonly MethodInfo _v256LoadByte = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "Load" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
+
+        private static readonly MethodInfo _v128CreateScalarUInt = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "CreateScalar" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(uint));
+        private static readonly MethodInfo _v128CreateScalarULong = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "CreateScalar" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ulong));
+        private static readonly MethodInfo _v128CreateScalarUShort = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "CreateScalar" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ushort));
+
+        // AsByte is an extension method on Vector128 static class, not instance method
+        private static readonly MethodInfo _v128UIntAsByte = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "AsByte" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(uint));
+        private static readonly MethodInfo _v128ULongAsByte = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "AsByte" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ulong));
+        private static readonly MethodInfo _v128UShortAsByte = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "AsByte" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ushort));
+
+        private static readonly MethodInfo _avx2ConvertToV256Int64 = typeof(Avx2).GetMethod("ConvertToVector256Int64", new[] { typeof(Vector128<byte>) })!;
+        private static readonly MethodInfo _avx2ConvertToV256Int32 = typeof(Avx2).GetMethod("ConvertToVector256Int32", new[] { typeof(Vector128<byte>) })!;
+        private static readonly MethodInfo _avx2ConvertToV256Int16 = typeof(Avx2).GetMethod("ConvertToVector256Int16", new[] { typeof(Vector128<byte>) })!;
+
+        private static readonly MethodInfo _sse41ConvertToV128Int64 = typeof(Sse41).GetMethod("ConvertToVector128Int64", new[] { typeof(Vector128<byte>) })!;
+        private static readonly MethodInfo _sse41ConvertToV128Int32 = typeof(Sse41).GetMethod("ConvertToVector128Int32", new[] { typeof(Vector128<byte>) })!;
+        private static readonly MethodInfo _sse41ConvertToV128Int16 = typeof(Sse41).GetMethod("ConvertToVector128Int16", new[] { typeof(Vector128<byte>) })!;
+
+        // As* methods are extension methods on Vector256/Vector128 static classes
+        private static readonly MethodInfo _v256LongAsULong = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "AsUInt64" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(long));
+        private static readonly MethodInfo _v256IntAsUInt = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "AsUInt32" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(int));
+        private static readonly MethodInfo _v256ShortAsUShort = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "AsUInt16" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(short));
+
+        private static readonly MethodInfo _v128LongAsULong = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "AsUInt64" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(long));
+        private static readonly MethodInfo _v128IntAsUInt = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "AsUInt32" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(int));
+        private static readonly MethodInfo _v128ShortAsUShort = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "AsUInt16" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(short));
+
+        private static readonly MethodInfo _v256GreaterThanULong = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ulong));
+        private static readonly MethodInfo _v256GreaterThanUInt = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(uint));
+        private static readonly MethodInfo _v256GreaterThanUShort = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ushort));
+        private static readonly MethodInfo _v256GreaterThanByte = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
+
+        private static readonly MethodInfo _v128GreaterThanULong = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ulong));
+        private static readonly MethodInfo _v128GreaterThanUInt = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(uint));
+        private static readonly MethodInfo _v128GreaterThanUShort = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ushort));
+        private static readonly MethodInfo _v128GreaterThanByte = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
+
+        private static readonly FieldInfo _v256ZeroULong = typeof(Vector256<ulong>).GetProperty("Zero")!.GetMethod!.IsStatic
+            ? null! : null!; // Use GetMethod call instead
+        private static readonly MethodInfo _v256GetZeroULong = typeof(Vector256<ulong>).GetProperty("Zero")!.GetMethod!;
+        private static readonly MethodInfo _v256GetZeroUInt = typeof(Vector256<uint>).GetProperty("Zero")!.GetMethod!;
+        private static readonly MethodInfo _v256GetZeroUShort = typeof(Vector256<ushort>).GetProperty("Zero")!.GetMethod!;
+        private static readonly MethodInfo _v256GetZeroByte = typeof(Vector256<byte>).GetProperty("Zero")!.GetMethod!;
+
+        private static readonly MethodInfo _v128GetZeroULong = typeof(Vector128<ulong>).GetProperty("Zero")!.GetMethod!;
+        private static readonly MethodInfo _v128GetZeroUInt = typeof(Vector128<uint>).GetProperty("Zero")!.GetMethod!;
+        private static readonly MethodInfo _v128GetZeroUShort = typeof(Vector128<ushort>).GetProperty("Zero")!.GetMethod!;
+        private static readonly MethodInfo _v128GetZeroByte = typeof(Vector128<byte>).GetProperty("Zero")!.GetMethod!;
+
+        /// <summary>
+        /// Emit inline V256 mask creation. Stack: byte* -> Vector256{T} (as mask)
+        /// </summary>
+        private static void EmitInlineMaskCreationV256(ILGenerator il, int elementSize)
+        {
+            // Stack has: byte* pointing to condition bools
+
+            switch (elementSize)
+            {
+                case 8: // double/long: load 4 bytes, expand to 4 qwords
+                    // *(uint*)ptr
+                    il.Emit(OpCodes.Ldind_U4);
+                    // Vector128.CreateScalar<uint>(value)
+                    il.Emit(OpCodes.Call, _v128CreateScalarUInt);
+                    // .AsByte()
+                    il.Emit(OpCodes.Call, _v128UIntAsByte);
+                    // Avx2.ConvertToVector256Int64(bytes)
+                    il.Emit(OpCodes.Call, _avx2ConvertToV256Int64);
+                    // .AsUInt64()
+                    il.Emit(OpCodes.Call, _v256LongAsULong);
+                    // Vector256<ulong>.Zero
+                    il.Emit(OpCodes.Call, _v256GetZeroULong);
+                    // Vector256.GreaterThan(expanded, zero)
+                    il.Emit(OpCodes.Call, _v256GreaterThanULong);
+                    break;
+
+                case 4: // float/int: load 8 bytes, expand to 8 dwords
+                    // *(ulong*)ptr
+                    il.Emit(OpCodes.Ldind_I8);
+                    // Vector128.CreateScalar<ulong>(value)
+                    il.Emit(OpCodes.Call, _v128CreateScalarULong);
+                    // .AsByte()
+                    il.Emit(OpCodes.Call, _v128ULongAsByte);
+                    // Avx2.ConvertToVector256Int32(bytes)
+                    il.Emit(OpCodes.Call, _avx2ConvertToV256Int32);
+                    // .AsUInt32()
+                    il.Emit(OpCodes.Call, _v256IntAsUInt);
+                    // Vector256<uint>.Zero
+                    il.Emit(OpCodes.Call, _v256GetZeroUInt);
+                    // Vector256.GreaterThan(expanded, zero)
+                    il.Emit(OpCodes.Call, _v256GreaterThanUInt);
+                    break;
+
+                case 2: // short/char: load 16 bytes, expand to 16 words
+                    // Vector128.Load<byte>(ptr)
+                    il.Emit(OpCodes.Call, _v128LoadByte);
+                    // Avx2.ConvertToVector256Int16(bytes)
+                    il.Emit(OpCodes.Call, _avx2ConvertToV256Int16);
+                    // .AsUInt16()
+                    il.Emit(OpCodes.Call, _v256ShortAsUShort);
+                    // Vector256<ushort>.Zero
+                    il.Emit(OpCodes.Call, _v256GetZeroUShort);
+                    // Vector256.GreaterThan(expanded, zero)
+                    il.Emit(OpCodes.Call, _v256GreaterThanUShort);
+                    break;
+
+                case 1: // byte/bool: load 32 bytes, compare directly
+                    // Vector256.Load<byte>(ptr)
+                    il.Emit(OpCodes.Call, _v256LoadByte);
+                    // Vector256<byte>.Zero
+                    il.Emit(OpCodes.Call, _v256GetZeroByte);
+                    // Vector256.GreaterThan(vec, zero)
+                    il.Emit(OpCodes.Call, _v256GreaterThanByte);
+                    break;
+
+                default:
+                    throw new NotSupportedException($"Element size {elementSize} not supported");
+            }
+        }
+
+        /// <summary>
+        /// Emit inline V128 mask creation. Stack: byte* -> Vector128{T} (as mask)
+        /// </summary>
+        private static void EmitInlineMaskCreationV128(ILGenerator il, int elementSize)
+        {
+            switch (elementSize)
+            {
+                case 8: // double/long: load 2 bytes, expand to 2 qwords
+                    // *(ushort*)ptr
+                    il.Emit(OpCodes.Ldind_U2);
+                    // Vector128.CreateScalar<ushort>(value)
+                    il.Emit(OpCodes.Call, _v128CreateScalarUShort);
+                    // .AsByte()
+                    il.Emit(OpCodes.Call, _v128UShortAsByte);
+                    // Sse41.ConvertToVector128Int64(bytes)
+                    il.Emit(OpCodes.Call, _sse41ConvertToV128Int64);
+                    // .AsUInt64()
+                    il.Emit(OpCodes.Call, _v128LongAsULong);
+                    // Vector128<ulong>.Zero
+                    il.Emit(OpCodes.Call, _v128GetZeroULong);
+                    // Vector128.GreaterThan(expanded, zero)
+                    il.Emit(OpCodes.Call, _v128GreaterThanULong);
+                    break;
+
+                case 4: // float/int: load 4 bytes, expand to 4 dwords
+                    // *(uint*)ptr
+                    il.Emit(OpCodes.Ldind_U4);
+                    // Vector128.CreateScalar<uint>(value)
+                    il.Emit(OpCodes.Call, _v128CreateScalarUInt);
+                    // .AsByte()
+                    il.Emit(OpCodes.Call, _v128UIntAsByte);
+                    // Sse41.ConvertToVector128Int32(bytes)
+                    il.Emit(OpCodes.Call, _sse41ConvertToV128Int32);
+                    // .AsUInt32()
+                    il.Emit(OpCodes.Call, _v128IntAsUInt);
+                    // Vector128<uint>.Zero
+                    il.Emit(OpCodes.Call, _v128GetZeroUInt);
+                    // Vector128.GreaterThan(expanded, zero)
+                    il.Emit(OpCodes.Call, _v128GreaterThanUInt);
+                    break;
+
+                case 2: // short/char: load 8 bytes, expand to 8 words
+                    // *(ulong*)ptr
+                    il.Emit(OpCodes.Ldind_I8);
+                    // Vector128.CreateScalar<ulong>(value)
+                    il.Emit(OpCodes.Call, _v128CreateScalarULong);
+                    // .AsByte()
+                    il.Emit(OpCodes.Call, _v128ULongAsByte);
+                    // Sse41.ConvertToVector128Int16(bytes)
+                    il.Emit(OpCodes.Call, _sse41ConvertToV128Int16);
+                    // .AsUInt16()
+                    il.Emit(OpCodes.Call, _v128ShortAsUShort);
+                    // Vector128<ushort>.Zero
+                    il.Emit(OpCodes.Call, _v128GetZeroUShort);
+                    // Vector128.GreaterThan(expanded, zero)
+                    il.Emit(OpCodes.Call, _v128GreaterThanUShort);
+                    break;
+
+                case 1: // byte/bool: load 16 bytes, compare directly
+                    // Vector128.Load<byte>(ptr)
+                    il.Emit(OpCodes.Call, _v128LoadByte);
+                    // Vector128<byte>.Zero
+                    il.Emit(OpCodes.Call, _v128GetZeroByte);
+                    // Vector128.GreaterThan(vec, zero)
+                    il.Emit(OpCodes.Call, _v128GreaterThanByte);
+                    break;
+
+                default:
+                    throw new NotSupportedException($"Element size {elementSize} not supported");
+            }
+        }
+
+        #endregion
+
+        #region Static Mask Creation Methods (fallback)
 
         /// <summary>
         /// Create V256 mask from 32 bools for 1-byte elements.

--- a/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
+++ b/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
@@ -251,27 +251,11 @@ namespace NumSharp.Backends.Kernels
             il.MarkLabel(lblVectorLoopEnd);
         }
 
-        // Generic method definitions are cached once at class init; MakeGenericMethod is the
-        // only per-T work needed during kernel generation.
-        private static readonly MethodInfo _v256LoadGeneric = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!;
-        private static readonly MethodInfo _v256StoreGeneric = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "Store" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2)!;
-        private static readonly MethodInfo _v256ConditionalSelectGeneric = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "ConditionalSelect" && m.IsGenericMethodDefinition)!;
-
-        private static readonly MethodInfo _v128LoadGeneric = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!;
-        private static readonly MethodInfo _v128StoreGeneric = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "Store" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2)!;
-        private static readonly MethodInfo _v128ConditionalSelectGeneric = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "ConditionalSelect" && m.IsGenericMethodDefinition)!;
-
         private static void EmitWhereV256BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
         {
-            var loadMethod = _v256LoadGeneric.MakeGenericMethod(typeof(T));
-            var storeMethod = _v256StoreGeneric.MakeGenericMethod(typeof(T));
-            var selectMethod = _v256ConditionalSelectGeneric.MakeGenericMethod(typeof(T));
+            var loadMethod = CachedMethods.V256LoadGeneric.MakeGenericMethod(typeof(T));
+            var storeMethod = CachedMethods.V256StoreGeneric.MakeGenericMethod(typeof(T));
+            var selectMethod = CachedMethods.V256ConditionalSelectGeneric.MakeGenericMethod(typeof(T));
 
             // Load address: cond + (i + offset)
             il.Emit(OpCodes.Ldarg_0);  // cond
@@ -336,9 +320,9 @@ namespace NumSharp.Backends.Kernels
 
         private static void EmitWhereV128BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
         {
-            var loadMethod = _v128LoadGeneric.MakeGenericMethod(typeof(T));
-            var storeMethod = _v128StoreGeneric.MakeGenericMethod(typeof(T));
-            var selectMethod = _v128ConditionalSelectGeneric.MakeGenericMethod(typeof(T));
+            var loadMethod = CachedMethods.V128LoadGeneric.MakeGenericMethod(typeof(T));
+            var storeMethod = CachedMethods.V128StoreGeneric.MakeGenericMethod(typeof(T));
+            var selectMethod = CachedMethods.V128ConditionalSelectGeneric.MakeGenericMethod(typeof(T));
 
             // Load address: cond + (i + offset)
             il.Emit(OpCodes.Ldarg_0);
@@ -456,77 +440,8 @@ namespace NumSharp.Backends.Kernels
 
         #region Inline Mask IL Emission
 
-        // Cache reflection lookups for inline emission
-        private static readonly MethodInfo _v128LoadByte = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "Load" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
-        private static readonly MethodInfo _v256LoadByte = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "Load" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
-
-        private static readonly MethodInfo _v128CreateScalarUInt = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "CreateScalar" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(uint));
-        private static readonly MethodInfo _v128CreateScalarULong = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "CreateScalar" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ulong));
-        private static readonly MethodInfo _v128CreateScalarUShort = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "CreateScalar" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ushort));
-
-        // AsByte is an extension method on Vector128 static class, not instance method
-        private static readonly MethodInfo _v128UIntAsByte = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "AsByte" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(uint));
-        private static readonly MethodInfo _v128ULongAsByte = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "AsByte" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ulong));
-        private static readonly MethodInfo _v128UShortAsByte = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "AsByte" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ushort));
-
-        private static readonly MethodInfo _avx2ConvertToV256Int64 = typeof(Avx2).GetMethod("ConvertToVector256Int64", new[] { typeof(Vector128<byte>) })!;
-        private static readonly MethodInfo _avx2ConvertToV256Int32 = typeof(Avx2).GetMethod("ConvertToVector256Int32", new[] { typeof(Vector128<byte>) })!;
-        private static readonly MethodInfo _avx2ConvertToV256Int16 = typeof(Avx2).GetMethod("ConvertToVector256Int16", new[] { typeof(Vector128<byte>) })!;
-
-        private static readonly MethodInfo _sse41ConvertToV128Int64 = typeof(Sse41).GetMethod("ConvertToVector128Int64", new[] { typeof(Vector128<byte>) })!;
-        private static readonly MethodInfo _sse41ConvertToV128Int32 = typeof(Sse41).GetMethod("ConvertToVector128Int32", new[] { typeof(Vector128<byte>) })!;
-        private static readonly MethodInfo _sse41ConvertToV128Int16 = typeof(Sse41).GetMethod("ConvertToVector128Int16", new[] { typeof(Vector128<byte>) })!;
-
-        // As* methods are extension methods on Vector256/Vector128 static classes
-        private static readonly MethodInfo _v256LongAsULong = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "AsUInt64" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(long));
-        private static readonly MethodInfo _v256IntAsUInt = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "AsUInt32" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(int));
-        private static readonly MethodInfo _v256ShortAsUShort = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "AsUInt16" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(short));
-
-        private static readonly MethodInfo _v128LongAsULong = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "AsUInt64" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(long));
-        private static readonly MethodInfo _v128IntAsUInt = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "AsUInt32" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(int));
-        private static readonly MethodInfo _v128ShortAsUShort = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "AsUInt16" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(short));
-
-        private static readonly MethodInfo _v256GreaterThanULong = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ulong));
-        private static readonly MethodInfo _v256GreaterThanUInt = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(uint));
-        private static readonly MethodInfo _v256GreaterThanUShort = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ushort));
-        private static readonly MethodInfo _v256GreaterThanByte = Array.Find(typeof(Vector256).GetMethods(),
-            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
-
-        private static readonly MethodInfo _v128GreaterThanULong = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ulong));
-        private static readonly MethodInfo _v128GreaterThanUInt = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(uint));
-        private static readonly MethodInfo _v128GreaterThanUShort = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(ushort));
-        private static readonly MethodInfo _v128GreaterThanByte = Array.Find(typeof(Vector128).GetMethods(),
-            m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
-
-        private static readonly MethodInfo _v256GetZeroULong = typeof(Vector256<ulong>).GetProperty("Zero")!.GetMethod!;
-        private static readonly MethodInfo _v256GetZeroUInt = typeof(Vector256<uint>).GetProperty("Zero")!.GetMethod!;
-        private static readonly MethodInfo _v256GetZeroUShort = typeof(Vector256<ushort>).GetProperty("Zero")!.GetMethod!;
-        private static readonly MethodInfo _v256GetZeroByte = typeof(Vector256<byte>).GetProperty("Zero")!.GetMethod!;
-
-        private static readonly MethodInfo _v128GetZeroULong = typeof(Vector128<ulong>).GetProperty("Zero")!.GetMethod!;
-        private static readonly MethodInfo _v128GetZeroUInt = typeof(Vector128<uint>).GetProperty("Zero")!.GetMethod!;
-        private static readonly MethodInfo _v128GetZeroUShort = typeof(Vector128<ushort>).GetProperty("Zero")!.GetMethod!;
-        private static readonly MethodInfo _v128GetZeroByte = typeof(Vector128<byte>).GetProperty("Zero")!.GetMethod!;
+        // Vector-related MethodInfos for np.where are cached in the partial CachedMethods class
+        // below (see "Where Kernel Methods" region at the end of this file).
 
         /// <summary>
         /// Emit inline V256 mask creation. Stack: byte* -> Vector256{T} (as mask)
@@ -541,56 +456,56 @@ namespace NumSharp.Backends.Kernels
                     // *(uint*)ptr
                     il.Emit(OpCodes.Ldind_U4);
                     // Vector128.CreateScalar<uint>(value)
-                    il.Emit(OpCodes.Call, _v128CreateScalarUInt);
+                    il.Emit(OpCodes.Call, CachedMethods.V128CreateScalarUInt);
                     // .AsByte()
-                    il.Emit(OpCodes.Call, _v128UIntAsByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128UIntAsByte);
                     // Avx2.ConvertToVector256Int64(bytes)
-                    il.Emit(OpCodes.Call, _avx2ConvertToV256Int64);
+                    il.Emit(OpCodes.Call, CachedMethods.Avx2ConvertToV256Int64);
                     // .AsUInt64()
-                    il.Emit(OpCodes.Call, _v256LongAsULong);
+                    il.Emit(OpCodes.Call, CachedMethods.V256LongAsULong);
                     // Vector256<ulong>.Zero
-                    il.Emit(OpCodes.Call, _v256GetZeroULong);
+                    il.Emit(OpCodes.Call, CachedMethods.V256GetZeroULong);
                     // Vector256.GreaterThan(expanded, zero)
-                    il.Emit(OpCodes.Call, _v256GreaterThanULong);
+                    il.Emit(OpCodes.Call, CachedMethods.V256GreaterThanULong);
                     break;
 
                 case 4: // float/int: load 8 bytes, expand to 8 dwords
                     // *(ulong*)ptr
                     il.Emit(OpCodes.Ldind_I8);
                     // Vector128.CreateScalar<ulong>(value)
-                    il.Emit(OpCodes.Call, _v128CreateScalarULong);
+                    il.Emit(OpCodes.Call, CachedMethods.V128CreateScalarULong);
                     // .AsByte()
-                    il.Emit(OpCodes.Call, _v128ULongAsByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128ULongAsByte);
                     // Avx2.ConvertToVector256Int32(bytes)
-                    il.Emit(OpCodes.Call, _avx2ConvertToV256Int32);
+                    il.Emit(OpCodes.Call, CachedMethods.Avx2ConvertToV256Int32);
                     // .AsUInt32()
-                    il.Emit(OpCodes.Call, _v256IntAsUInt);
+                    il.Emit(OpCodes.Call, CachedMethods.V256IntAsUInt);
                     // Vector256<uint>.Zero
-                    il.Emit(OpCodes.Call, _v256GetZeroUInt);
+                    il.Emit(OpCodes.Call, CachedMethods.V256GetZeroUInt);
                     // Vector256.GreaterThan(expanded, zero)
-                    il.Emit(OpCodes.Call, _v256GreaterThanUInt);
+                    il.Emit(OpCodes.Call, CachedMethods.V256GreaterThanUInt);
                     break;
 
                 case 2: // short/char: load 16 bytes, expand to 16 words
                     // Vector128.Load<byte>(ptr)
-                    il.Emit(OpCodes.Call, _v128LoadByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128LoadByte);
                     // Avx2.ConvertToVector256Int16(bytes)
-                    il.Emit(OpCodes.Call, _avx2ConvertToV256Int16);
+                    il.Emit(OpCodes.Call, CachedMethods.Avx2ConvertToV256Int16);
                     // .AsUInt16()
-                    il.Emit(OpCodes.Call, _v256ShortAsUShort);
+                    il.Emit(OpCodes.Call, CachedMethods.V256ShortAsUShort);
                     // Vector256<ushort>.Zero
-                    il.Emit(OpCodes.Call, _v256GetZeroUShort);
+                    il.Emit(OpCodes.Call, CachedMethods.V256GetZeroUShort);
                     // Vector256.GreaterThan(expanded, zero)
-                    il.Emit(OpCodes.Call, _v256GreaterThanUShort);
+                    il.Emit(OpCodes.Call, CachedMethods.V256GreaterThanUShort);
                     break;
 
                 case 1: // byte/bool: load 32 bytes, compare directly
                     // Vector256.Load<byte>(ptr)
-                    il.Emit(OpCodes.Call, _v256LoadByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V256LoadByte);
                     // Vector256<byte>.Zero
-                    il.Emit(OpCodes.Call, _v256GetZeroByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V256GetZeroByte);
                     // Vector256.GreaterThan(vec, zero)
-                    il.Emit(OpCodes.Call, _v256GreaterThanByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V256GreaterThanByte);
                     break;
 
                 default:
@@ -609,60 +524,60 @@ namespace NumSharp.Backends.Kernels
                     // *(ushort*)ptr
                     il.Emit(OpCodes.Ldind_U2);
                     // Vector128.CreateScalar<ushort>(value)
-                    il.Emit(OpCodes.Call, _v128CreateScalarUShort);
+                    il.Emit(OpCodes.Call, CachedMethods.V128CreateScalarUShort);
                     // .AsByte()
-                    il.Emit(OpCodes.Call, _v128UShortAsByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128UShortAsByte);
                     // Sse41.ConvertToVector128Int64(bytes)
-                    il.Emit(OpCodes.Call, _sse41ConvertToV128Int64);
+                    il.Emit(OpCodes.Call, CachedMethods.Sse41ConvertToV128Int64);
                     // .AsUInt64()
-                    il.Emit(OpCodes.Call, _v128LongAsULong);
+                    il.Emit(OpCodes.Call, CachedMethods.V128LongAsULong);
                     // Vector128<ulong>.Zero
-                    il.Emit(OpCodes.Call, _v128GetZeroULong);
+                    il.Emit(OpCodes.Call, CachedMethods.V128GetZeroULong);
                     // Vector128.GreaterThan(expanded, zero)
-                    il.Emit(OpCodes.Call, _v128GreaterThanULong);
+                    il.Emit(OpCodes.Call, CachedMethods.V128GreaterThanULong);
                     break;
 
                 case 4: // float/int: load 4 bytes, expand to 4 dwords
                     // *(uint*)ptr
                     il.Emit(OpCodes.Ldind_U4);
                     // Vector128.CreateScalar<uint>(value)
-                    il.Emit(OpCodes.Call, _v128CreateScalarUInt);
+                    il.Emit(OpCodes.Call, CachedMethods.V128CreateScalarUInt);
                     // .AsByte()
-                    il.Emit(OpCodes.Call, _v128UIntAsByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128UIntAsByte);
                     // Sse41.ConvertToVector128Int32(bytes)
-                    il.Emit(OpCodes.Call, _sse41ConvertToV128Int32);
+                    il.Emit(OpCodes.Call, CachedMethods.Sse41ConvertToV128Int32);
                     // .AsUInt32()
-                    il.Emit(OpCodes.Call, _v128IntAsUInt);
+                    il.Emit(OpCodes.Call, CachedMethods.V128IntAsUInt);
                     // Vector128<uint>.Zero
-                    il.Emit(OpCodes.Call, _v128GetZeroUInt);
+                    il.Emit(OpCodes.Call, CachedMethods.V128GetZeroUInt);
                     // Vector128.GreaterThan(expanded, zero)
-                    il.Emit(OpCodes.Call, _v128GreaterThanUInt);
+                    il.Emit(OpCodes.Call, CachedMethods.V128GreaterThanUInt);
                     break;
 
                 case 2: // short/char: load 8 bytes, expand to 8 words
                     // *(ulong*)ptr
                     il.Emit(OpCodes.Ldind_I8);
                     // Vector128.CreateScalar<ulong>(value)
-                    il.Emit(OpCodes.Call, _v128CreateScalarULong);
+                    il.Emit(OpCodes.Call, CachedMethods.V128CreateScalarULong);
                     // .AsByte()
-                    il.Emit(OpCodes.Call, _v128ULongAsByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128ULongAsByte);
                     // Sse41.ConvertToVector128Int16(bytes)
-                    il.Emit(OpCodes.Call, _sse41ConvertToV128Int16);
+                    il.Emit(OpCodes.Call, CachedMethods.Sse41ConvertToV128Int16);
                     // .AsUInt16()
-                    il.Emit(OpCodes.Call, _v128ShortAsUShort);
+                    il.Emit(OpCodes.Call, CachedMethods.V128ShortAsUShort);
                     // Vector128<ushort>.Zero
-                    il.Emit(OpCodes.Call, _v128GetZeroUShort);
+                    il.Emit(OpCodes.Call, CachedMethods.V128GetZeroUShort);
                     // Vector128.GreaterThan(expanded, zero)
-                    il.Emit(OpCodes.Call, _v128GreaterThanUShort);
+                    il.Emit(OpCodes.Call, CachedMethods.V128GreaterThanUShort);
                     break;
 
                 case 1: // byte/bool: load 16 bytes, compare directly
                     // Vector128.Load<byte>(ptr)
-                    il.Emit(OpCodes.Call, _v128LoadByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128LoadByte);
                     // Vector128<byte>.Zero
-                    il.Emit(OpCodes.Call, _v128GetZeroByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128GetZeroByte);
                     // Vector128.GreaterThan(vec, zero)
-                    il.Emit(OpCodes.Call, _v128GreaterThanByte);
+                    il.Emit(OpCodes.Call, CachedMethods.V128GreaterThanByte);
                     break;
 
                 default:
@@ -687,5 +602,91 @@ namespace NumSharp.Backends.Kernels
         }
 
         #endregion
+
+        // Per the CachedMethods pattern in ILKernelGenerator.cs, reflection lookups for np.where
+        // live alongside the other cached entries. Fail-fast at type init so a renamed API shows
+        // up immediately instead of NREs at first use.
+        private static partial class CachedMethods
+        {
+            #region Where Kernel Methods
+
+            private static MethodInfo FindGenericMethod(Type container, string name, int? paramCount = null)
+            {
+                foreach (var m in container.GetMethods())
+                {
+                    if (m.Name == name && m.IsGenericMethodDefinition &&
+                        (paramCount is null || m.GetParameters().Length == paramCount.Value))
+                        return m;
+                }
+                throw new MissingMethodException(container.FullName, name);
+            }
+
+            private static MethodInfo FindMethodExact(Type container, string name, Type[] argTypes)
+                => container.GetMethod(name, argTypes)
+                   ?? throw new MissingMethodException(container.FullName, name);
+
+            private static MethodInfo GetZeroGetter(Type vectorOfT)
+                => vectorOfT.GetProperty("Zero")?.GetMethod
+                   ?? throw new MissingMethodException(vectorOfT.FullName, "get_Zero");
+
+            // Generic definitions — caller must MakeGenericMethod(typeof(T)) before emitting.
+            public static readonly MethodInfo V256LoadGeneric = FindGenericMethod(typeof(Vector256), "Load", 1);
+            public static readonly MethodInfo V256StoreGeneric = FindGenericMethod(typeof(Vector256), "Store", 2);
+            public static readonly MethodInfo V256ConditionalSelectGeneric = FindGenericMethod(typeof(Vector256), "ConditionalSelect");
+
+            public static readonly MethodInfo V128LoadGeneric = FindGenericMethod(typeof(Vector128), "Load", 1);
+            public static readonly MethodInfo V128StoreGeneric = FindGenericMethod(typeof(Vector128), "Store", 2);
+            public static readonly MethodInfo V128ConditionalSelectGeneric = FindGenericMethod(typeof(Vector128), "ConditionalSelect");
+
+            // Already-specialised generic methods used during mask creation.
+            public static readonly MethodInfo V256LoadByte = FindGenericMethod(typeof(Vector256), "Load").MakeGenericMethod(typeof(byte));
+            public static readonly MethodInfo V128LoadByte = FindGenericMethod(typeof(Vector128), "Load").MakeGenericMethod(typeof(byte));
+
+            public static readonly MethodInfo V128CreateScalarUInt = FindGenericMethod(typeof(Vector128), "CreateScalar").MakeGenericMethod(typeof(uint));
+            public static readonly MethodInfo V128CreateScalarULong = FindGenericMethod(typeof(Vector128), "CreateScalar").MakeGenericMethod(typeof(ulong));
+            public static readonly MethodInfo V128CreateScalarUShort = FindGenericMethod(typeof(Vector128), "CreateScalar").MakeGenericMethod(typeof(ushort));
+
+            public static readonly MethodInfo V128UIntAsByte = FindGenericMethod(typeof(Vector128), "AsByte").MakeGenericMethod(typeof(uint));
+            public static readonly MethodInfo V128ULongAsByte = FindGenericMethod(typeof(Vector128), "AsByte").MakeGenericMethod(typeof(ulong));
+            public static readonly MethodInfo V128UShortAsByte = FindGenericMethod(typeof(Vector128), "AsByte").MakeGenericMethod(typeof(ushort));
+
+            public static readonly MethodInfo V256LongAsULong = FindGenericMethod(typeof(Vector256), "AsUInt64").MakeGenericMethod(typeof(long));
+            public static readonly MethodInfo V256IntAsUInt = FindGenericMethod(typeof(Vector256), "AsUInt32").MakeGenericMethod(typeof(int));
+            public static readonly MethodInfo V256ShortAsUShort = FindGenericMethod(typeof(Vector256), "AsUInt16").MakeGenericMethod(typeof(short));
+
+            public static readonly MethodInfo V128LongAsULong = FindGenericMethod(typeof(Vector128), "AsUInt64").MakeGenericMethod(typeof(long));
+            public static readonly MethodInfo V128IntAsUInt = FindGenericMethod(typeof(Vector128), "AsUInt32").MakeGenericMethod(typeof(int));
+            public static readonly MethodInfo V128ShortAsUShort = FindGenericMethod(typeof(Vector128), "AsUInt16").MakeGenericMethod(typeof(short));
+
+            public static readonly MethodInfo V256GreaterThanULong = FindGenericMethod(typeof(Vector256), "GreaterThan").MakeGenericMethod(typeof(ulong));
+            public static readonly MethodInfo V256GreaterThanUInt = FindGenericMethod(typeof(Vector256), "GreaterThan").MakeGenericMethod(typeof(uint));
+            public static readonly MethodInfo V256GreaterThanUShort = FindGenericMethod(typeof(Vector256), "GreaterThan").MakeGenericMethod(typeof(ushort));
+            public static readonly MethodInfo V256GreaterThanByte = FindGenericMethod(typeof(Vector256), "GreaterThan").MakeGenericMethod(typeof(byte));
+
+            public static readonly MethodInfo V128GreaterThanULong = FindGenericMethod(typeof(Vector128), "GreaterThan").MakeGenericMethod(typeof(ulong));
+            public static readonly MethodInfo V128GreaterThanUInt = FindGenericMethod(typeof(Vector128), "GreaterThan").MakeGenericMethod(typeof(uint));
+            public static readonly MethodInfo V128GreaterThanUShort = FindGenericMethod(typeof(Vector128), "GreaterThan").MakeGenericMethod(typeof(ushort));
+            public static readonly MethodInfo V128GreaterThanByte = FindGenericMethod(typeof(Vector128), "GreaterThan").MakeGenericMethod(typeof(byte));
+
+            // Non-generic exact overloads on Avx2/Sse41 for byte-lane sign-extend expansion.
+            public static readonly MethodInfo Avx2ConvertToV256Int64 = FindMethodExact(typeof(Avx2), "ConvertToVector256Int64", new[] { typeof(Vector128<byte>) });
+            public static readonly MethodInfo Avx2ConvertToV256Int32 = FindMethodExact(typeof(Avx2), "ConvertToVector256Int32", new[] { typeof(Vector128<byte>) });
+            public static readonly MethodInfo Avx2ConvertToV256Int16 = FindMethodExact(typeof(Avx2), "ConvertToVector256Int16", new[] { typeof(Vector128<byte>) });
+            public static readonly MethodInfo Sse41ConvertToV128Int64 = FindMethodExact(typeof(Sse41), "ConvertToVector128Int64", new[] { typeof(Vector128<byte>) });
+            public static readonly MethodInfo Sse41ConvertToV128Int32 = FindMethodExact(typeof(Sse41), "ConvertToVector128Int32", new[] { typeof(Vector128<byte>) });
+            public static readonly MethodInfo Sse41ConvertToV128Int16 = FindMethodExact(typeof(Sse41), "ConvertToVector128Int16", new[] { typeof(Vector128<byte>) });
+
+            // Vector*<T>.Zero property getters — emitted as a call, not a field load, so we cache the getter MethodInfo.
+            public static readonly MethodInfo V256GetZeroULong = GetZeroGetter(typeof(Vector256<ulong>));
+            public static readonly MethodInfo V256GetZeroUInt = GetZeroGetter(typeof(Vector256<uint>));
+            public static readonly MethodInfo V256GetZeroUShort = GetZeroGetter(typeof(Vector256<ushort>));
+            public static readonly MethodInfo V256GetZeroByte = GetZeroGetter(typeof(Vector256<byte>));
+            public static readonly MethodInfo V128GetZeroULong = GetZeroGetter(typeof(Vector128<ulong>));
+            public static readonly MethodInfo V128GetZeroUInt = GetZeroGetter(typeof(Vector128<uint>));
+            public static readonly MethodInfo V128GetZeroUShort = GetZeroGetter(typeof(Vector128<ushort>));
+            public static readonly MethodInfo V128GetZeroByte = GetZeroGetter(typeof(Vector128<byte>));
+
+            #endregion
+        }
     }
 }

--- a/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
+++ b/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
@@ -251,18 +251,27 @@ namespace NumSharp.Backends.Kernels
             il.MarkLabel(lblVectorLoopEnd);
         }
 
+        // Generic method definitions are cached once at class init; MakeGenericMethod is the
+        // only per-T work needed during kernel generation.
+        private static readonly MethodInfo _v256LoadGeneric = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!;
+        private static readonly MethodInfo _v256StoreGeneric = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "Store" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2)!;
+        private static readonly MethodInfo _v256ConditionalSelectGeneric = Array.Find(typeof(Vector256).GetMethods(),
+            m => m.Name == "ConditionalSelect" && m.IsGenericMethodDefinition)!;
+
+        private static readonly MethodInfo _v128LoadGeneric = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!;
+        private static readonly MethodInfo _v128StoreGeneric = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "Store" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2)!;
+        private static readonly MethodInfo _v128ConditionalSelectGeneric = Array.Find(typeof(Vector128).GetMethods(),
+            m => m.Name == "ConditionalSelect" && m.IsGenericMethodDefinition)!;
+
         private static void EmitWhereV256BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
         {
-            // Get Vector256 methods via reflection - need to find generic method definitions first
-            var loadMethod = Array.Find(typeof(Vector256).GetMethods(),
-                m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!
-                .MakeGenericMethod(typeof(T));
-            var storeMethod = Array.Find(typeof(Vector256).GetMethods(),
-                m => m.Name == "Store" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2)!
-                .MakeGenericMethod(typeof(T));
-            var selectMethod = Array.Find(typeof(Vector256).GetMethods(),
-                m => m.Name == "ConditionalSelect" && m.IsGenericMethodDefinition)!
-                .MakeGenericMethod(typeof(T));
+            var loadMethod = _v256LoadGeneric.MakeGenericMethod(typeof(T));
+            var storeMethod = _v256StoreGeneric.MakeGenericMethod(typeof(T));
+            var selectMethod = _v256ConditionalSelectGeneric.MakeGenericMethod(typeof(T));
 
             // Load address: cond + (i + offset)
             il.Emit(OpCodes.Ldarg_0);  // cond
@@ -327,16 +336,9 @@ namespace NumSharp.Backends.Kernels
 
         private static void EmitWhereV128BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
         {
-            // Get Vector128 methods via reflection - need to find generic method definitions first
-            var loadMethod = Array.Find(typeof(Vector128).GetMethods(),
-                m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!
-                .MakeGenericMethod(typeof(T));
-            var storeMethod = Array.Find(typeof(Vector128).GetMethods(),
-                m => m.Name == "Store" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2)!
-                .MakeGenericMethod(typeof(T));
-            var selectMethod = Array.Find(typeof(Vector128).GetMethods(),
-                m => m.Name == "ConditionalSelect" && m.IsGenericMethodDefinition)!
-                .MakeGenericMethod(typeof(T));
+            var loadMethod = _v128LoadGeneric.MakeGenericMethod(typeof(T));
+            var storeMethod = _v128StoreGeneric.MakeGenericMethod(typeof(T));
+            var selectMethod = _v128ConditionalSelectGeneric.MakeGenericMethod(typeof(T));
 
             // Load address: cond + (i + offset)
             il.Emit(OpCodes.Ldarg_0);

--- a/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
+++ b/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 
 // =============================================================================
 // ILKernelGenerator.Where - IL-generated np.where(condition, x, y) kernels
@@ -253,13 +254,17 @@ namespace NumSharp.Backends.Kernels
         {
             // Get the appropriate mask creation method based on element size
             var maskMethod = GetMaskCreationMethod256((int)elementSize);
-            var loadMethod = typeof(Vector256).GetMethod("Load", new[] { typeof(T*) })!.MakeGenericMethod(typeof(T));
-            var storeMethod = typeof(Vector256).GetMethod("Store", new[] { typeof(Vector256<>).MakeGenericType(typeof(T)), typeof(T*) })!;
-            var selectMethod = typeof(Vector256).GetMethod("ConditionalSelect", new[] {
-                typeof(Vector256<>).MakeGenericType(typeof(T)),
-                typeof(Vector256<>).MakeGenericType(typeof(T)),
-                typeof(Vector256<>).MakeGenericType(typeof(T))
-            })!;
+
+            // Get Vector256 methods via reflection - need to find generic method definitions first
+            var loadMethod = Array.Find(typeof(Vector256).GetMethods(),
+                m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!
+                .MakeGenericMethod(typeof(T));
+            var storeMethod = Array.Find(typeof(Vector256).GetMethods(),
+                m => m.Name == "Store" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2)!
+                .MakeGenericMethod(typeof(T));
+            var selectMethod = Array.Find(typeof(Vector256).GetMethods(),
+                m => m.Name == "ConditionalSelect" && m.IsGenericMethodDefinition)!
+                .MakeGenericMethod(typeof(T));
 
             // Load address: cond + (i + offset)
             il.Emit(OpCodes.Ldarg_0);  // cond
@@ -325,13 +330,17 @@ namespace NumSharp.Backends.Kernels
         private static void EmitWhereV128BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
         {
             var maskMethod = GetMaskCreationMethod128((int)elementSize);
-            var loadMethod = typeof(Vector128).GetMethod("Load", new[] { typeof(T*) })!.MakeGenericMethod(typeof(T));
-            var storeMethod = typeof(Vector128).GetMethod("Store", new[] { typeof(Vector128<>).MakeGenericType(typeof(T)), typeof(T*) })!;
-            var selectMethod = typeof(Vector128).GetMethod("ConditionalSelect", new[] {
-                typeof(Vector128<>).MakeGenericType(typeof(T)),
-                typeof(Vector128<>).MakeGenericType(typeof(T)),
-                typeof(Vector128<>).MakeGenericType(typeof(T))
-            })!;
+
+            // Get Vector128 methods via reflection - need to find generic method definitions first
+            var loadMethod = Array.Find(typeof(Vector128).GetMethods(),
+                m => m.Name == "Load" && m.IsGenericMethodDefinition && m.GetParameters().Length == 1)!
+                .MakeGenericMethod(typeof(T));
+            var storeMethod = Array.Find(typeof(Vector128).GetMethods(),
+                m => m.Name == "Store" && m.IsGenericMethodDefinition && m.GetParameters().Length == 2)!
+                .MakeGenericMethod(typeof(T));
+            var selectMethod = Array.Find(typeof(Vector128).GetMethods(),
+                m => m.Name == "ConditionalSelect" && m.IsGenericMethodDefinition)!
+                .MakeGenericMethod(typeof(T));
 
             // Load address: cond + (i + offset)
             il.Emit(OpCodes.Ldarg_0);
@@ -502,10 +511,22 @@ namespace NumSharp.Backends.Kernels
 
         /// <summary>
         /// Create V256 mask from 16 bools for 2-byte elements.
+        /// Uses AVX2 vpmovzxbw instruction for single-instruction expansion.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe Vector256<ushort> CreateMaskV256_2Byte(byte* bools)
         {
+            if (Avx2.IsSupported)
+            {
+                // Load 16 bytes into Vector128, zero-extend each byte to 16-bit
+                // vpmovzxbw: byte -> word (16 bytes -> 16 words)
+                var bytes128 = Vector128.Load(bools);
+                var expanded = Avx2.ConvertToVector256Int16(bytes128).AsUInt16();
+                // Compare with zero: non-zero becomes 0xFFFF, zero stays 0
+                return Vector256.GreaterThan(expanded, Vector256<ushort>.Zero);
+            }
+
+            // Scalar fallback for non-AVX2 systems
             return Vector256.Create(
                 bools[0] != 0 ? (ushort)0xFFFF : (ushort)0,
                 bools[1] != 0 ? (ushort)0xFFFF : (ushort)0,
@@ -528,10 +549,22 @@ namespace NumSharp.Backends.Kernels
 
         /// <summary>
         /// Create V256 mask from 8 bools for 4-byte elements.
+        /// Uses AVX2 vpmovzxbd instruction for single-instruction expansion.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe Vector256<uint> CreateMaskV256_4Byte(byte* bools)
         {
+            if (Avx2.IsSupported)
+            {
+                // Load 8 bytes into low bytes of Vector128, zero-extend each byte to 32-bit
+                // vpmovzxbd: byte -> dword (8 bytes -> 8 dwords)
+                var bytes128 = Vector128.CreateScalar(*(ulong*)bools).AsByte();
+                var expanded = Avx2.ConvertToVector256Int32(bytes128).AsUInt32();
+                // Compare with zero: non-zero becomes 0xFFFF..., zero stays 0
+                return Vector256.GreaterThan(expanded, Vector256<uint>.Zero);
+            }
+
+            // Scalar fallback for non-AVX2 systems
             return Vector256.Create(
                 bools[0] != 0 ? 0xFFFFFFFFu : 0u,
                 bools[1] != 0 ? 0xFFFFFFFFu : 0u,
@@ -546,10 +579,22 @@ namespace NumSharp.Backends.Kernels
 
         /// <summary>
         /// Create V256 mask from 4 bools for 8-byte elements.
+        /// Uses AVX2 vpmovzxbq instruction for single-instruction expansion.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe Vector256<ulong> CreateMaskV256_8Byte(byte* bools)
         {
+            if (Avx2.IsSupported)
+            {
+                // Load 4 bytes into low bytes of Vector128, zero-extend each byte to 64-bit
+                // vpmovzxbq: byte -> qword (4 bytes -> 4 qwords)
+                var bytes128 = Vector128.CreateScalar(*(uint*)bools).AsByte();
+                var expanded = Avx2.ConvertToVector256Int64(bytes128).AsUInt64();
+                // Compare with zero: non-zero becomes 0xFFFF..., zero stays 0
+                return Vector256.GreaterThan(expanded, Vector256<ulong>.Zero);
+            }
+
+            // Scalar fallback for non-AVX2 systems
             return Vector256.Create(
                 bools[0] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
                 bools[1] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
@@ -572,10 +617,21 @@ namespace NumSharp.Backends.Kernels
 
         /// <summary>
         /// Create V128 mask from 8 bools for 2-byte elements.
+        /// Uses SSE4.1 pmovzxbw instruction for efficient expansion.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe Vector128<ushort> CreateMaskV128_2Byte(byte* bools)
         {
+            if (Sse41.IsSupported)
+            {
+                // Load 8 bytes, zero-extend each to 16-bit
+                // pmovzxbw: byte -> word (8 bytes -> 8 words)
+                var bytes128 = Vector128.CreateScalar(*(ulong*)bools).AsByte();
+                var expanded = Sse41.ConvertToVector128Int16(bytes128).AsUInt16();
+                return Vector128.GreaterThan(expanded, Vector128<ushort>.Zero);
+            }
+
+            // Scalar fallback
             return Vector128.Create(
                 bools[0] != 0 ? (ushort)0xFFFF : (ushort)0,
                 bools[1] != 0 ? (ushort)0xFFFF : (ushort)0,
@@ -590,10 +646,21 @@ namespace NumSharp.Backends.Kernels
 
         /// <summary>
         /// Create V128 mask from 4 bools for 4-byte elements.
+        /// Uses SSE4.1 pmovzxbd instruction for efficient expansion.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe Vector128<uint> CreateMaskV128_4Byte(byte* bools)
         {
+            if (Sse41.IsSupported)
+            {
+                // Load 4 bytes, zero-extend each to 32-bit
+                // pmovzxbd: byte -> dword (4 bytes -> 4 dwords)
+                var bytes128 = Vector128.CreateScalar(*(uint*)bools).AsByte();
+                var expanded = Sse41.ConvertToVector128Int32(bytes128).AsUInt32();
+                return Vector128.GreaterThan(expanded, Vector128<uint>.Zero);
+            }
+
+            // Scalar fallback
             return Vector128.Create(
                 bools[0] != 0 ? 0xFFFFFFFFu : 0u,
                 bools[1] != 0 ? 0xFFFFFFFFu : 0u,
@@ -604,10 +671,21 @@ namespace NumSharp.Backends.Kernels
 
         /// <summary>
         /// Create V128 mask from 2 bools for 8-byte elements.
+        /// Uses SSE4.1 pmovzxbq instruction for efficient expansion.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe Vector128<ulong> CreateMaskV128_8Byte(byte* bools)
         {
+            if (Sse41.IsSupported)
+            {
+                // Load 2 bytes, zero-extend each to 64-bit
+                // pmovzxbq: byte -> qword (2 bytes -> 2 qwords)
+                var bytes128 = Vector128.CreateScalar(*(ushort*)bools).AsByte();
+                var expanded = Sse41.ConvertToVector128Int64(bytes128).AsUInt64();
+                return Vector128.GreaterThan(expanded, Vector128<ulong>.Zero);
+            }
+
+            // Scalar fallback
             return Vector128.Create(
                 bools[0] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
                 bools[1] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul

--- a/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
+++ b/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
@@ -1,0 +1,635 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+// =============================================================================
+// ILKernelGenerator.Where - IL-generated np.where(condition, x, y) kernels
+// =============================================================================
+//
+// RESPONSIBILITY:
+//   - Generate optimized kernels for conditional selection
+//   - result[i] = cond[i] ? x[i] : y[i]
+//
+// ARCHITECTURE:
+//   Uses IL emission to generate type-specific kernels at runtime.
+//   The challenge is bool mask expansion: condition is bool[] (1 byte per element),
+//   but x/y can be any dtype (1-8 bytes per element).
+//
+//   | Element Size | V256 Elements | Bools to Load |
+//   |--------------|---------------|---------------|
+//   | 1 byte       | 32            | 32            |
+//   | 2 bytes      | 16            | 16            |
+//   | 4 bytes      | 8             | 8             |
+//   | 8 bytes      | 4             | 4             |
+//
+// KERNEL TYPES:
+//   - WhereKernel<T>: Main kernel delegate (cond*, x*, y*, result*, count)
+//
+// =============================================================================
+
+namespace NumSharp.Backends.Kernels
+{
+    /// <summary>
+    /// Delegate for where operation kernels.
+    /// </summary>
+    public unsafe delegate void WhereKernel<T>(bool* cond, T* x, T* y, T* result, long count) where T : unmanaged;
+
+    public static partial class ILKernelGenerator
+    {
+        /// <summary>
+        /// Cache of IL-generated where kernels.
+        /// Key: Type
+        /// </summary>
+        private static readonly ConcurrentDictionary<Type, Delegate> _whereKernelCache = new();
+
+        #region Public API
+
+        /// <summary>
+        /// Get or generate an IL-based where kernel for the specified type.
+        /// Returns null if IL generation is disabled or fails.
+        /// </summary>
+        public static WhereKernel<T>? GetWhereKernel<T>() where T : unmanaged
+        {
+            if (!Enabled)
+                return null;
+
+            var type = typeof(T);
+
+            if (_whereKernelCache.TryGetValue(type, out var cached))
+                return (WhereKernel<T>)cached;
+
+            var kernel = TryGenerateWhereKernel<T>();
+            if (kernel == null)
+                return null;
+
+            if (_whereKernelCache.TryAdd(type, kernel))
+                return kernel;
+
+            return (WhereKernel<T>)_whereKernelCache[type];
+        }
+
+        /// <summary>
+        /// Execute where operation using IL-generated kernel or fallback to static helper.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void WhereExecute<T>(bool* cond, T* x, T* y, T* result, long count) where T : unmanaged
+        {
+            if (count == 0)
+                return;
+
+            var kernel = GetWhereKernel<T>();
+            if (kernel != null)
+            {
+                kernel(cond, x, y, result, count);
+            }
+            else
+            {
+                // Fallback to scalar loop
+                WhereScalar(cond, x, y, result, count);
+            }
+        }
+
+        #endregion
+
+        #region Kernel Generation
+
+        private static WhereKernel<T>? TryGenerateWhereKernel<T>() where T : unmanaged
+        {
+            try
+            {
+                return GenerateWhereKernelIL<T>();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[ILKernel] TryGenerateWhereKernel<{typeof(T).Name}>: {ex.GetType().Name}: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static unsafe WhereKernel<T> GenerateWhereKernelIL<T>() where T : unmanaged
+        {
+            int elementSize = Unsafe.SizeOf<T>();
+
+            // Determine if we can use SIMD
+            bool canSimd = elementSize <= 8 && IsSimdSupported<T>();
+
+            var dm = new DynamicMethod(
+                name: $"IL_Where_{typeof(T).Name}",
+                returnType: typeof(void),
+                parameterTypes: new[] { typeof(bool*), typeof(T*), typeof(T*), typeof(T*), typeof(long) },
+                owner: typeof(ILKernelGenerator),
+                skipVisibility: true
+            );
+
+            var il = dm.GetILGenerator();
+
+            // Locals
+            var locI = il.DeclareLocal(typeof(long));  // loop counter
+
+            // Labels
+            var lblScalarLoop = il.DefineLabel();
+            var lblScalarLoopEnd = il.DefineLabel();
+
+            // i = 0
+            il.Emit(OpCodes.Ldc_I8, 0L);
+            il.Emit(OpCodes.Stloc, locI);
+
+            if (canSimd && VectorBits >= 128)
+            {
+                // Generate SIMD path
+                EmitWhereSIMDLoop<T>(il, locI);
+            }
+
+            // Scalar loop for remainder
+            il.MarkLabel(lblScalarLoop);
+
+            // if (i >= count) goto end
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldarg, 4);  // count
+            il.Emit(OpCodes.Bge, lblScalarLoopEnd);
+
+            // result[i] = cond[i] ? x[i] : y[i]
+            EmitWhereScalarElement<T>(il, locI);
+
+            // i++
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldc_I8, 1L);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, locI);
+
+            il.Emit(OpCodes.Br, lblScalarLoop);
+
+            il.MarkLabel(lblScalarLoopEnd);
+            il.Emit(OpCodes.Ret);
+
+            return (WhereKernel<T>)dm.CreateDelegate(typeof(WhereKernel<T>));
+        }
+
+        private static void EmitWhereSIMDLoop<T>(ILGenerator il, LocalBuilder locI) where T : unmanaged
+        {
+            long elementSize = Unsafe.SizeOf<T>();
+            long vectorCount = VectorBits >= 256 ? (32 / elementSize) : (16 / elementSize);
+            long unrollFactor = 4;
+            long unrollStep = vectorCount * unrollFactor;
+            bool useV256 = VectorBits >= 256;
+
+            var locUnrollEnd = il.DeclareLocal(typeof(long));
+            var locVectorEnd = il.DeclareLocal(typeof(long));
+
+            var lblUnrollLoop = il.DefineLabel();
+            var lblUnrollLoopEnd = il.DefineLabel();
+            var lblVectorLoop = il.DefineLabel();
+            var lblVectorLoopEnd = il.DefineLabel();
+
+            // unrollEnd = count - unrollStep (for 4x unrolled loop)
+            il.Emit(OpCodes.Ldarg, 4);  // count
+            il.Emit(OpCodes.Ldc_I8, unrollStep);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Stloc, locUnrollEnd);
+
+            // vectorEnd = count - vectorCount (for remainder loop)
+            il.Emit(OpCodes.Ldarg, 4);  // count
+            il.Emit(OpCodes.Ldc_I8, vectorCount);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Stloc, locVectorEnd);
+
+            // ========== 4x UNROLLED SIMD LOOP ==========
+            il.MarkLabel(lblUnrollLoop);
+
+            // if (i > unrollEnd) goto UnrollLoopEnd
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldloc, locUnrollEnd);
+            il.Emit(OpCodes.Bgt, lblUnrollLoopEnd);
+
+            // Process 4 vectors per iteration
+            for (long u = 0; u < unrollFactor; u++)
+            {
+                long offset = vectorCount * u;
+                if (useV256)
+                    EmitWhereV256BodyWithOffset<T>(il, locI, elementSize, offset);
+                else
+                    EmitWhereV128BodyWithOffset<T>(il, locI, elementSize, offset);
+            }
+
+            // i += unrollStep
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldc_I8, unrollStep);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, locI);
+
+            il.Emit(OpCodes.Br, lblUnrollLoop);
+
+            il.MarkLabel(lblUnrollLoopEnd);
+
+            // ========== REMAINDER SIMD LOOP (1 vector at a time) ==========
+            il.MarkLabel(lblVectorLoop);
+
+            // if (i > vectorEnd) goto VectorLoopEnd
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldloc, locVectorEnd);
+            il.Emit(OpCodes.Bgt, lblVectorLoopEnd);
+
+            // Process 1 vector
+            if (useV256)
+                EmitWhereV256BodyWithOffset<T>(il, locI, elementSize, 0L);
+            else
+                EmitWhereV128BodyWithOffset<T>(il, locI, elementSize, 0L);
+
+            // i += vectorCount
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldc_I8, vectorCount);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, locI);
+
+            il.Emit(OpCodes.Br, lblVectorLoop);
+
+            il.MarkLabel(lblVectorLoopEnd);
+        }
+
+        private static void EmitWhereV256BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
+        {
+            // Get the appropriate mask creation method based on element size
+            var maskMethod = GetMaskCreationMethod256((int)elementSize);
+            var loadMethod = typeof(Vector256).GetMethod("Load", new[] { typeof(T*) })!.MakeGenericMethod(typeof(T));
+            var storeMethod = typeof(Vector256).GetMethod("Store", new[] { typeof(Vector256<>).MakeGenericType(typeof(T)), typeof(T*) })!;
+            var selectMethod = typeof(Vector256).GetMethod("ConditionalSelect", new[] {
+                typeof(Vector256<>).MakeGenericType(typeof(T)),
+                typeof(Vector256<>).MakeGenericType(typeof(T)),
+                typeof(Vector256<>).MakeGenericType(typeof(T))
+            })!;
+
+            // Load address: cond + (i + offset)
+            il.Emit(OpCodes.Ldarg_0);  // cond
+            il.Emit(OpCodes.Ldloc, locI);
+            if (offset > 0)
+            {
+                il.Emit(OpCodes.Ldc_I8, offset);
+                il.Emit(OpCodes.Add);
+            }
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+
+            // Call mask creation: returns Vector256<T> on stack
+            il.Emit(OpCodes.Call, maskMethod);
+
+            // Load x vector: x + (i + offset) * elementSize
+            il.Emit(OpCodes.Ldarg_1);  // x
+            il.Emit(OpCodes.Ldloc, locI);
+            if (offset > 0)
+            {
+                il.Emit(OpCodes.Ldc_I8, offset);
+                il.Emit(OpCodes.Add);
+            }
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Call, loadMethod);
+
+            // Load y vector: y + (i + offset) * elementSize
+            il.Emit(OpCodes.Ldarg_2);  // y
+            il.Emit(OpCodes.Ldloc, locI);
+            if (offset > 0)
+            {
+                il.Emit(OpCodes.Ldc_I8, offset);
+                il.Emit(OpCodes.Add);
+            }
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Call, loadMethod);
+
+            // Stack: mask, xVec, yVec
+            // ConditionalSelect(mask, x, y)
+            il.Emit(OpCodes.Call, selectMethod);
+
+            // Store result: result + (i + offset) * elementSize
+            il.Emit(OpCodes.Ldarg_3);  // result
+            il.Emit(OpCodes.Ldloc, locI);
+            if (offset > 0)
+            {
+                il.Emit(OpCodes.Ldc_I8, offset);
+                il.Emit(OpCodes.Add);
+            }
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Call, storeMethod);
+        }
+
+        private static void EmitWhereV128BodyWithOffset<T>(ILGenerator il, LocalBuilder locI, long elementSize, long offset) where T : unmanaged
+        {
+            var maskMethod = GetMaskCreationMethod128((int)elementSize);
+            var loadMethod = typeof(Vector128).GetMethod("Load", new[] { typeof(T*) })!.MakeGenericMethod(typeof(T));
+            var storeMethod = typeof(Vector128).GetMethod("Store", new[] { typeof(Vector128<>).MakeGenericType(typeof(T)), typeof(T*) })!;
+            var selectMethod = typeof(Vector128).GetMethod("ConditionalSelect", new[] {
+                typeof(Vector128<>).MakeGenericType(typeof(T)),
+                typeof(Vector128<>).MakeGenericType(typeof(T)),
+                typeof(Vector128<>).MakeGenericType(typeof(T))
+            })!;
+
+            // Load address: cond + (i + offset)
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, locI);
+            if (offset > 0)
+            {
+                il.Emit(OpCodes.Ldc_I8, offset);
+                il.Emit(OpCodes.Add);
+            }
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Call, maskMethod);
+
+            // Load x vector
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, locI);
+            if (offset > 0)
+            {
+                il.Emit(OpCodes.Ldc_I8, offset);
+                il.Emit(OpCodes.Add);
+            }
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Call, loadMethod);
+
+            // Load y vector
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldloc, locI);
+            if (offset > 0)
+            {
+                il.Emit(OpCodes.Ldc_I8, offset);
+                il.Emit(OpCodes.Add);
+            }
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Call, loadMethod);
+
+            // ConditionalSelect
+            il.Emit(OpCodes.Call, selectMethod);
+
+            // Store
+            il.Emit(OpCodes.Ldarg_3);
+            il.Emit(OpCodes.Ldloc, locI);
+            if (offset > 0)
+            {
+                il.Emit(OpCodes.Ldc_I8, offset);
+                il.Emit(OpCodes.Add);
+            }
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Call, storeMethod);
+        }
+
+        private static void EmitWhereScalarElement<T>(ILGenerator il, LocalBuilder locI) where T : unmanaged
+        {
+            long elementSize = Unsafe.SizeOf<T>();
+            var typeCode = GetNPTypeCode<T>();
+
+            // result[i] = cond[i] ? x[i] : y[i]
+            var lblFalse = il.DefineLabel();
+            var lblEnd = il.DefineLabel();
+
+            // Load result address: result + i * elementSize
+            il.Emit(OpCodes.Ldarg_3);
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+
+            // Load cond[i]: cond + i (bool is 1 byte)
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Ldind_U1);  // Load bool as byte
+
+            // if (!cond[i]) goto lblFalse
+            il.Emit(OpCodes.Brfalse, lblFalse);
+
+            // True branch: load x[i]
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            EmitLoadIndirect(il, typeCode);
+            il.Emit(OpCodes.Br, lblEnd);
+
+            // False branch: load y[i]
+            il.MarkLabel(lblFalse);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldloc, locI);
+            il.Emit(OpCodes.Ldc_I8, elementSize);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Conv_I);
+            il.Emit(OpCodes.Add);
+            EmitLoadIndirect(il, typeCode);
+
+            il.MarkLabel(lblEnd);
+            // Stack: result_ptr, value
+            EmitStoreIndirect(il, typeCode);
+        }
+
+        private static NPTypeCode GetNPTypeCode<T>() where T : unmanaged
+        {
+            if (typeof(T) == typeof(bool)) return NPTypeCode.Boolean;
+            if (typeof(T) == typeof(byte)) return NPTypeCode.Byte;
+            if (typeof(T) == typeof(short)) return NPTypeCode.Int16;
+            if (typeof(T) == typeof(ushort)) return NPTypeCode.UInt16;
+            if (typeof(T) == typeof(int)) return NPTypeCode.Int32;
+            if (typeof(T) == typeof(uint)) return NPTypeCode.UInt32;
+            if (typeof(T) == typeof(long)) return NPTypeCode.Int64;
+            if (typeof(T) == typeof(ulong)) return NPTypeCode.UInt64;
+            if (typeof(T) == typeof(char)) return NPTypeCode.Char;
+            if (typeof(T) == typeof(float)) return NPTypeCode.Single;
+            if (typeof(T) == typeof(double)) return NPTypeCode.Double;
+            if (typeof(T) == typeof(decimal)) return NPTypeCode.Decimal;
+            return NPTypeCode.Empty;
+        }
+
+        #endregion
+
+        #region Mask Creation Methods
+
+        private static MethodInfo GetMaskCreationMethod256(int elementSize)
+        {
+            return elementSize switch
+            {
+                1 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV256_1Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
+                2 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV256_2Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
+                4 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV256_4Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
+                8 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV256_8Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
+                _ => throw new NotSupportedException($"Element size {elementSize} not supported for SIMD where")
+            };
+        }
+
+        private static MethodInfo GetMaskCreationMethod128(int elementSize)
+        {
+            return elementSize switch
+            {
+                1 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV128_1Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
+                2 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV128_2Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
+                4 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV128_4Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
+                8 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV128_8Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
+                _ => throw new NotSupportedException($"Element size {elementSize} not supported for SIMD where")
+            };
+        }
+
+        /// <summary>
+        /// Create V256 mask from 32 bools for 1-byte elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector256<byte> CreateMaskV256_1Byte(byte* bools)
+        {
+            var vec = Vector256.Load(bools);
+            var zero = Vector256<byte>.Zero;
+            var isZero = Vector256.Equals(vec, zero);
+            return Vector256.OnesComplement(isZero);
+        }
+
+        /// <summary>
+        /// Create V256 mask from 16 bools for 2-byte elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector256<ushort> CreateMaskV256_2Byte(byte* bools)
+        {
+            return Vector256.Create(
+                bools[0] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[1] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[2] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[3] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[4] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[5] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[6] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[7] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[8] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[9] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[10] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[11] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[12] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[13] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[14] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[15] != 0 ? (ushort)0xFFFF : (ushort)0
+            );
+        }
+
+        /// <summary>
+        /// Create V256 mask from 8 bools for 4-byte elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector256<uint> CreateMaskV256_4Byte(byte* bools)
+        {
+            return Vector256.Create(
+                bools[0] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[1] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[2] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[3] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[4] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[5] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[6] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[7] != 0 ? 0xFFFFFFFFu : 0u
+            );
+        }
+
+        /// <summary>
+        /// Create V256 mask from 4 bools for 8-byte elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector256<ulong> CreateMaskV256_8Byte(byte* bools)
+        {
+            return Vector256.Create(
+                bools[0] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
+                bools[1] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
+                bools[2] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
+                bools[3] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul
+            );
+        }
+
+        /// <summary>
+        /// Create V128 mask from 16 bools for 1-byte elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector128<byte> CreateMaskV128_1Byte(byte* bools)
+        {
+            var vec = Vector128.Load(bools);
+            var zero = Vector128<byte>.Zero;
+            var isZero = Vector128.Equals(vec, zero);
+            return Vector128.OnesComplement(isZero);
+        }
+
+        /// <summary>
+        /// Create V128 mask from 8 bools for 2-byte elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector128<ushort> CreateMaskV128_2Byte(byte* bools)
+        {
+            return Vector128.Create(
+                bools[0] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[1] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[2] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[3] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[4] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[5] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[6] != 0 ? (ushort)0xFFFF : (ushort)0,
+                bools[7] != 0 ? (ushort)0xFFFF : (ushort)0
+            );
+        }
+
+        /// <summary>
+        /// Create V128 mask from 4 bools for 4-byte elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector128<uint> CreateMaskV128_4Byte(byte* bools)
+        {
+            return Vector128.Create(
+                bools[0] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[1] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[2] != 0 ? 0xFFFFFFFFu : 0u,
+                bools[3] != 0 ? 0xFFFFFFFFu : 0u
+            );
+        }
+
+        /// <summary>
+        /// Create V128 mask from 2 bools for 8-byte elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Vector128<ulong> CreateMaskV128_8Byte(byte* bools)
+        {
+            return Vector128.Create(
+                bools[0] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
+                bools[1] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul
+            );
+        }
+
+        #endregion
+
+        #region Scalar Fallback
+
+        /// <summary>
+        /// Scalar fallback for where operation.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void WhereScalar<T>(bool* cond, T* x, T* y, T* result, long count) where T : unmanaged
+        {
+            for (long i = 0; i < count; i++)
+            {
+                result[i] = cond[i] ? x[i] : y[i];
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
+++ b/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.Where.cs
@@ -5,6 +5,7 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using NumSharp.Utilities;
 
 // =============================================================================
 // ILKernelGenerator.Where - IL-generated np.where(condition, x, y) kernels
@@ -400,7 +401,7 @@ namespace NumSharp.Backends.Kernels
         private static void EmitWhereScalarElement<T>(ILGenerator il, LocalBuilder locI) where T : unmanaged
         {
             long elementSize = Unsafe.SizeOf<T>();
-            var typeCode = GetNPTypeCode<T>();
+            var typeCode = InfoOf<T>.NPTypeCode;
 
             // result[i] = cond[i] ? x[i] : y[i]
             var lblFalse = il.DefineLabel();
@@ -447,51 +448,6 @@ namespace NumSharp.Backends.Kernels
             il.MarkLabel(lblEnd);
             // Stack: result_ptr, value
             EmitStoreIndirect(il, typeCode);
-        }
-
-        private static NPTypeCode GetNPTypeCode<T>() where T : unmanaged
-        {
-            if (typeof(T) == typeof(bool)) return NPTypeCode.Boolean;
-            if (typeof(T) == typeof(byte)) return NPTypeCode.Byte;
-            if (typeof(T) == typeof(short)) return NPTypeCode.Int16;
-            if (typeof(T) == typeof(ushort)) return NPTypeCode.UInt16;
-            if (typeof(T) == typeof(int)) return NPTypeCode.Int32;
-            if (typeof(T) == typeof(uint)) return NPTypeCode.UInt32;
-            if (typeof(T) == typeof(long)) return NPTypeCode.Int64;
-            if (typeof(T) == typeof(ulong)) return NPTypeCode.UInt64;
-            if (typeof(T) == typeof(char)) return NPTypeCode.Char;
-            if (typeof(T) == typeof(float)) return NPTypeCode.Single;
-            if (typeof(T) == typeof(double)) return NPTypeCode.Double;
-            if (typeof(T) == typeof(decimal)) return NPTypeCode.Decimal;
-            return NPTypeCode.Empty;
-        }
-
-        #endregion
-
-        #region Mask Creation Methods
-
-        private static MethodInfo GetMaskCreationMethod256(int elementSize)
-        {
-            return elementSize switch
-            {
-                1 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV256_1Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
-                2 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV256_2Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
-                4 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV256_4Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
-                8 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV256_8Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
-                _ => throw new NotSupportedException($"Element size {elementSize} not supported for SIMD where")
-            };
-        }
-
-        private static MethodInfo GetMaskCreationMethod128(int elementSize)
-        {
-            return elementSize switch
-            {
-                1 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV128_1Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
-                2 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV128_2Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
-                4 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV128_4Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
-                8 => typeof(ILKernelGenerator).GetMethod(nameof(CreateMaskV128_8Byte), BindingFlags.NonPublic | BindingFlags.Static)!,
-                _ => throw new NotSupportedException($"Element size {elementSize} not supported for SIMD where")
-            };
         }
 
         #endregion
@@ -560,8 +516,6 @@ namespace NumSharp.Backends.Kernels
         private static readonly MethodInfo _v128GreaterThanByte = Array.Find(typeof(Vector128).GetMethods(),
             m => m.Name == "GreaterThan" && m.IsGenericMethodDefinition)!.MakeGenericMethod(typeof(byte));
 
-        private static readonly FieldInfo _v256ZeroULong = typeof(Vector256<ulong>).GetProperty("Zero")!.GetMethod!.IsStatic
-            ? null! : null!; // Use GetMethod call instead
         private static readonly MethodInfo _v256GetZeroULong = typeof(Vector256<ulong>).GetProperty("Zero")!.GetMethod!;
         private static readonly MethodInfo _v256GetZeroUInt = typeof(Vector256<uint>).GetProperty("Zero")!.GetMethod!;
         private static readonly MethodInfo _v256GetZeroUShort = typeof(Vector256<ushort>).GetProperty("Zero")!.GetMethod!;
@@ -712,205 +666,6 @@ namespace NumSharp.Backends.Kernels
                 default:
                     throw new NotSupportedException($"Element size {elementSize} not supported");
             }
-        }
-
-        #endregion
-
-        #region Static Mask Creation Methods (fallback)
-
-        /// <summary>
-        /// Create V256 mask from 32 bools for 1-byte elements.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe Vector256<byte> CreateMaskV256_1Byte(byte* bools)
-        {
-            var vec = Vector256.Load(bools);
-            var zero = Vector256<byte>.Zero;
-            var isZero = Vector256.Equals(vec, zero);
-            return Vector256.OnesComplement(isZero);
-        }
-
-        /// <summary>
-        /// Create V256 mask from 16 bools for 2-byte elements.
-        /// Uses AVX2 vpmovzxbw instruction for single-instruction expansion.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe Vector256<ushort> CreateMaskV256_2Byte(byte* bools)
-        {
-            if (Avx2.IsSupported)
-            {
-                // Load 16 bytes into Vector128, zero-extend each byte to 16-bit
-                // vpmovzxbw: byte -> word (16 bytes -> 16 words)
-                var bytes128 = Vector128.Load(bools);
-                var expanded = Avx2.ConvertToVector256Int16(bytes128).AsUInt16();
-                // Compare with zero: non-zero becomes 0xFFFF, zero stays 0
-                return Vector256.GreaterThan(expanded, Vector256<ushort>.Zero);
-            }
-
-            // Scalar fallback for non-AVX2 systems
-            return Vector256.Create(
-                bools[0] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[1] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[2] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[3] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[4] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[5] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[6] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[7] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[8] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[9] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[10] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[11] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[12] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[13] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[14] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[15] != 0 ? (ushort)0xFFFF : (ushort)0
-            );
-        }
-
-        /// <summary>
-        /// Create V256 mask from 8 bools for 4-byte elements.
-        /// Uses AVX2 vpmovzxbd instruction for single-instruction expansion.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe Vector256<uint> CreateMaskV256_4Byte(byte* bools)
-        {
-            if (Avx2.IsSupported)
-            {
-                // Load 8 bytes into low bytes of Vector128, zero-extend each byte to 32-bit
-                // vpmovzxbd: byte -> dword (8 bytes -> 8 dwords)
-                var bytes128 = Vector128.CreateScalar(*(ulong*)bools).AsByte();
-                var expanded = Avx2.ConvertToVector256Int32(bytes128).AsUInt32();
-                // Compare with zero: non-zero becomes 0xFFFF..., zero stays 0
-                return Vector256.GreaterThan(expanded, Vector256<uint>.Zero);
-            }
-
-            // Scalar fallback for non-AVX2 systems
-            return Vector256.Create(
-                bools[0] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[1] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[2] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[3] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[4] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[5] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[6] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[7] != 0 ? 0xFFFFFFFFu : 0u
-            );
-        }
-
-        /// <summary>
-        /// Create V256 mask from 4 bools for 8-byte elements.
-        /// Uses AVX2 vpmovzxbq instruction for single-instruction expansion.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe Vector256<ulong> CreateMaskV256_8Byte(byte* bools)
-        {
-            if (Avx2.IsSupported)
-            {
-                // Load 4 bytes into low bytes of Vector128, zero-extend each byte to 64-bit
-                // vpmovzxbq: byte -> qword (4 bytes -> 4 qwords)
-                var bytes128 = Vector128.CreateScalar(*(uint*)bools).AsByte();
-                var expanded = Avx2.ConvertToVector256Int64(bytes128).AsUInt64();
-                // Compare with zero: non-zero becomes 0xFFFF..., zero stays 0
-                return Vector256.GreaterThan(expanded, Vector256<ulong>.Zero);
-            }
-
-            // Scalar fallback for non-AVX2 systems
-            return Vector256.Create(
-                bools[0] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
-                bools[1] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
-                bools[2] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
-                bools[3] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul
-            );
-        }
-
-        /// <summary>
-        /// Create V128 mask from 16 bools for 1-byte elements.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe Vector128<byte> CreateMaskV128_1Byte(byte* bools)
-        {
-            var vec = Vector128.Load(bools);
-            var zero = Vector128<byte>.Zero;
-            var isZero = Vector128.Equals(vec, zero);
-            return Vector128.OnesComplement(isZero);
-        }
-
-        /// <summary>
-        /// Create V128 mask from 8 bools for 2-byte elements.
-        /// Uses SSE4.1 pmovzxbw instruction for efficient expansion.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe Vector128<ushort> CreateMaskV128_2Byte(byte* bools)
-        {
-            if (Sse41.IsSupported)
-            {
-                // Load 8 bytes, zero-extend each to 16-bit
-                // pmovzxbw: byte -> word (8 bytes -> 8 words)
-                var bytes128 = Vector128.CreateScalar(*(ulong*)bools).AsByte();
-                var expanded = Sse41.ConvertToVector128Int16(bytes128).AsUInt16();
-                return Vector128.GreaterThan(expanded, Vector128<ushort>.Zero);
-            }
-
-            // Scalar fallback
-            return Vector128.Create(
-                bools[0] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[1] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[2] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[3] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[4] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[5] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[6] != 0 ? (ushort)0xFFFF : (ushort)0,
-                bools[7] != 0 ? (ushort)0xFFFF : (ushort)0
-            );
-        }
-
-        /// <summary>
-        /// Create V128 mask from 4 bools for 4-byte elements.
-        /// Uses SSE4.1 pmovzxbd instruction for efficient expansion.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe Vector128<uint> CreateMaskV128_4Byte(byte* bools)
-        {
-            if (Sse41.IsSupported)
-            {
-                // Load 4 bytes, zero-extend each to 32-bit
-                // pmovzxbd: byte -> dword (4 bytes -> 4 dwords)
-                var bytes128 = Vector128.CreateScalar(*(uint*)bools).AsByte();
-                var expanded = Sse41.ConvertToVector128Int32(bytes128).AsUInt32();
-                return Vector128.GreaterThan(expanded, Vector128<uint>.Zero);
-            }
-
-            // Scalar fallback
-            return Vector128.Create(
-                bools[0] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[1] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[2] != 0 ? 0xFFFFFFFFu : 0u,
-                bools[3] != 0 ? 0xFFFFFFFFu : 0u
-            );
-        }
-
-        /// <summary>
-        /// Create V128 mask from 2 bools for 8-byte elements.
-        /// Uses SSE4.1 pmovzxbq instruction for efficient expansion.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe Vector128<ulong> CreateMaskV128_8Byte(byte* bools)
-        {
-            if (Sse41.IsSupported)
-            {
-                // Load 2 bytes, zero-extend each to 64-bit
-                // pmovzxbq: byte -> qword (2 bytes -> 2 qwords)
-                var bytes128 = Vector128.CreateScalar(*(ushort*)bools).AsByte();
-                var expanded = Sse41.ConvertToVector128Int64(bytes128).AsUInt64();
-                return Vector128.GreaterThan(expanded, Vector128<ulong>.Zero);
-            }
-
-            // Scalar fallback
-            return Vector128.Create(
-                bools[0] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul,
-                bools[1] != 0 ? 0xFFFFFFFFFFFFFFFFul : 0ul
-            );
         }
 
         #endregion

--- a/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.cs
+++ b/src/NumSharp.Core/Backends/Kernels/ILKernelGenerator.cs
@@ -290,7 +290,7 @@ namespace NumSharp.Backends.Kernels
         /// Caching these avoids repeated GetMethod() lookups during kernel generation.
         /// All fields use ?? throw to fail fast at type load if a method is not found.
         /// </summary>
-        private static class CachedMethods
+        private static partial class CachedMethods
         {
             // Math methods (double versions)
             public static readonly MethodInfo MathPow = typeof(Math).GetMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) })

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -97,42 +97,22 @@ namespace NumSharp
         /// </summary>
         private static NDArray ConvertMemory(object a, Type type)
         {
-            var genericDef = type.GetGenericTypeDefinition();
             var elementType = type.GetGenericArguments()[0];
+            var isReadOnly = type.GetGenericTypeDefinition() == typeof(ReadOnlyMemory<>);
 
-            // Handle ReadOnlyMemory<T> first (it cannot be cast to Memory<T>)
-            if (genericDef == typeof(ReadOnlyMemory<>))
-            {
-                if (elementType == typeof(bool)) return np.array(((ReadOnlyMemory<bool>)a).ToArray());
-                if (elementType == typeof(byte)) return np.array(((ReadOnlyMemory<byte>)a).ToArray());
-                if (elementType == typeof(short)) return np.array(((ReadOnlyMemory<short>)a).ToArray());
-                if (elementType == typeof(ushort)) return np.array(((ReadOnlyMemory<ushort>)a).ToArray());
-                if (elementType == typeof(int)) return np.array(((ReadOnlyMemory<int>)a).ToArray());
-                if (elementType == typeof(uint)) return np.array(((ReadOnlyMemory<uint>)a).ToArray());
-                if (elementType == typeof(long)) return np.array(((ReadOnlyMemory<long>)a).ToArray());
-                if (elementType == typeof(ulong)) return np.array(((ReadOnlyMemory<ulong>)a).ToArray());
-                if (elementType == typeof(char)) return np.array(((ReadOnlyMemory<char>)a).ToArray());
-                if (elementType == typeof(float)) return np.array(((ReadOnlyMemory<float>)a).ToArray());
-                if (elementType == typeof(double)) return np.array(((ReadOnlyMemory<double>)a).ToArray());
-                if (elementType == typeof(decimal)) return np.array(((ReadOnlyMemory<decimal>)a).ToArray());
-            }
-
-            // Handle Memory<T>
-            if (genericDef == typeof(Memory<>))
-            {
-                if (elementType == typeof(bool)) return np.array(((Memory<bool>)a).ToArray());
-                if (elementType == typeof(byte)) return np.array(((Memory<byte>)a).ToArray());
-                if (elementType == typeof(short)) return np.array(((Memory<short>)a).ToArray());
-                if (elementType == typeof(ushort)) return np.array(((Memory<ushort>)a).ToArray());
-                if (elementType == typeof(int)) return np.array(((Memory<int>)a).ToArray());
-                if (elementType == typeof(uint)) return np.array(((Memory<uint>)a).ToArray());
-                if (elementType == typeof(long)) return np.array(((Memory<long>)a).ToArray());
-                if (elementType == typeof(ulong)) return np.array(((Memory<ulong>)a).ToArray());
-                if (elementType == typeof(char)) return np.array(((Memory<char>)a).ToArray());
-                if (elementType == typeof(float)) return np.array(((Memory<float>)a).ToArray());
-                if (elementType == typeof(double)) return np.array(((Memory<double>)a).ToArray());
-                if (elementType == typeof(decimal)) return np.array(((Memory<decimal>)a).ToArray());
-            }
+            // Single type switch - extract array via the appropriate cast
+            if (elementType == typeof(bool)) return np.array(isReadOnly ? ((ReadOnlyMemory<bool>)a).ToArray() : ((Memory<bool>)a).ToArray());
+            if (elementType == typeof(byte)) return np.array(isReadOnly ? ((ReadOnlyMemory<byte>)a).ToArray() : ((Memory<byte>)a).ToArray());
+            if (elementType == typeof(short)) return np.array(isReadOnly ? ((ReadOnlyMemory<short>)a).ToArray() : ((Memory<short>)a).ToArray());
+            if (elementType == typeof(ushort)) return np.array(isReadOnly ? ((ReadOnlyMemory<ushort>)a).ToArray() : ((Memory<ushort>)a).ToArray());
+            if (elementType == typeof(int)) return np.array(isReadOnly ? ((ReadOnlyMemory<int>)a).ToArray() : ((Memory<int>)a).ToArray());
+            if (elementType == typeof(uint)) return np.array(isReadOnly ? ((ReadOnlyMemory<uint>)a).ToArray() : ((Memory<uint>)a).ToArray());
+            if (elementType == typeof(long)) return np.array(isReadOnly ? ((ReadOnlyMemory<long>)a).ToArray() : ((Memory<long>)a).ToArray());
+            if (elementType == typeof(ulong)) return np.array(isReadOnly ? ((ReadOnlyMemory<ulong>)a).ToArray() : ((Memory<ulong>)a).ToArray());
+            if (elementType == typeof(char)) return np.array(isReadOnly ? ((ReadOnlyMemory<char>)a).ToArray() : ((Memory<char>)a).ToArray());
+            if (elementType == typeof(float)) return np.array(isReadOnly ? ((ReadOnlyMemory<float>)a).ToArray() : ((Memory<float>)a).ToArray());
+            if (elementType == typeof(double)) return np.array(isReadOnly ? ((ReadOnlyMemory<double>)a).ToArray() : ((Memory<double>)a).ToArray());
+            if (elementType == typeof(decimal)) return np.array(isReadOnly ? ((ReadOnlyMemory<decimal>)a).ToArray() : ((Memory<decimal>)a).ToArray());
 
             return null;
         }
@@ -142,25 +122,7 @@ namespace NumSharp
         ///     Element type is detected from the first item.
         /// </summary>
         private static NDArray ConvertNonGenericEnumerable(IEnumerable enumerable)
-        {
-            // Collect items and detect type from first element
-            var items = new List<object>();
-            Type elementType = null;
-
-            foreach (var item in enumerable)
-            {
-                if (item == null)
-                    continue;
-
-                elementType ??= item.GetType();
-                items.Add(item);
-            }
-
-            if (items.Count == 0 || elementType == null)
-                return null; // Can't determine type from empty collection
-
-            return ConvertObjectListToNDArray(items, elementType);
-        }
+            => ConvertEnumerator(enumerable.GetEnumerator());
 
         /// <summary>
         ///     Converts a non-generic IEnumerator to an NDArray.

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -136,28 +136,39 @@ namespace NumSharp
 
         /// <summary>
         ///     Converts Memory&lt;T&gt; or ReadOnlyMemory&lt;T&gt; to an NDArray.
-        ///     These types don't implement IEnumerable&lt;T&gt;, so we handle them specially.
+        ///     Uses Span.CopyTo + GC.AllocateUninitializedArray for optimal performance.
         /// </summary>
         private static NDArray ConvertMemory(object a, Type type)
         {
             var elementType = type.GetGenericArguments()[0];
             var isReadOnly = type.GetGenericTypeDefinition() == typeof(ReadOnlyMemory<>);
 
-            // Single type switch - extract array via the appropriate cast
-            if (elementType == typeof(bool)) return np.array(isReadOnly ? ((ReadOnlyMemory<bool>)a).ToArray() : ((Memory<bool>)a).ToArray());
-            if (elementType == typeof(byte)) return np.array(isReadOnly ? ((ReadOnlyMemory<byte>)a).ToArray() : ((Memory<byte>)a).ToArray());
-            if (elementType == typeof(short)) return np.array(isReadOnly ? ((ReadOnlyMemory<short>)a).ToArray() : ((Memory<short>)a).ToArray());
-            if (elementType == typeof(ushort)) return np.array(isReadOnly ? ((ReadOnlyMemory<ushort>)a).ToArray() : ((Memory<ushort>)a).ToArray());
-            if (elementType == typeof(int)) return np.array(isReadOnly ? ((ReadOnlyMemory<int>)a).ToArray() : ((Memory<int>)a).ToArray());
-            if (elementType == typeof(uint)) return np.array(isReadOnly ? ((ReadOnlyMemory<uint>)a).ToArray() : ((Memory<uint>)a).ToArray());
-            if (elementType == typeof(long)) return np.array(isReadOnly ? ((ReadOnlyMemory<long>)a).ToArray() : ((Memory<long>)a).ToArray());
-            if (elementType == typeof(ulong)) return np.array(isReadOnly ? ((ReadOnlyMemory<ulong>)a).ToArray() : ((Memory<ulong>)a).ToArray());
-            if (elementType == typeof(char)) return np.array(isReadOnly ? ((ReadOnlyMemory<char>)a).ToArray() : ((Memory<char>)a).ToArray());
-            if (elementType == typeof(float)) return np.array(isReadOnly ? ((ReadOnlyMemory<float>)a).ToArray() : ((Memory<float>)a).ToArray());
-            if (elementType == typeof(double)) return np.array(isReadOnly ? ((ReadOnlyMemory<double>)a).ToArray() : ((Memory<double>)a).ToArray());
-            if (elementType == typeof(decimal)) return np.array(isReadOnly ? ((ReadOnlyMemory<decimal>)a).ToArray() : ((Memory<decimal>)a).ToArray());
+            // Use Span.CopyTo + GC.AllocateUninitializedArray instead of ToArray()
+            if (elementType == typeof(bool)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<bool>)a).Span : ((Memory<bool>)a).Span));
+            if (elementType == typeof(byte)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<byte>)a).Span : ((Memory<byte>)a).Span));
+            if (elementType == typeof(short)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<short>)a).Span : ((Memory<short>)a).Span));
+            if (elementType == typeof(ushort)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<ushort>)a).Span : ((Memory<ushort>)a).Span));
+            if (elementType == typeof(int)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<int>)a).Span : ((Memory<int>)a).Span));
+            if (elementType == typeof(uint)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<uint>)a).Span : ((Memory<uint>)a).Span));
+            if (elementType == typeof(long)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<long>)a).Span : ((Memory<long>)a).Span));
+            if (elementType == typeof(ulong)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<ulong>)a).Span : ((Memory<ulong>)a).Span));
+            if (elementType == typeof(char)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<char>)a).Span : ((Memory<char>)a).Span));
+            if (elementType == typeof(float)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<float>)a).Span : ((Memory<float>)a).Span));
+            if (elementType == typeof(double)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<double>)a).Span : ((Memory<double>)a).Span));
+            if (elementType == typeof(decimal)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<decimal>)a).Span : ((Memory<decimal>)a).Span));
 
             return null;
+        }
+
+        /// <summary>
+        ///     Optimized Span to Array conversion using GC.AllocateUninitializedArray.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static T[] SpanToArrayFast<T>(ReadOnlySpan<T> span)
+        {
+            var arr = GC.AllocateUninitializedArray<T>(span.Length);
+            span.CopyTo(arr);
+            return arr;
         }
 
         /// <summary>
@@ -174,8 +185,12 @@ namespace NumSharp
         /// </summary>
         private static NDArray ConvertEnumerator(IEnumerator enumerator)
         {
-            // Collect items
-            var items = new List<object>();
+            // Pre-size list if count is known (optimization #4)
+            List<object> items;
+            if (enumerator is ICollection collection)
+                items = new List<object>(collection.Count);
+            else
+                items = new List<object>();
 
             while (enumerator.MoveNext())
             {
@@ -194,80 +209,70 @@ namespace NumSharp
 
         /// <summary>
         ///     Finds the common numeric type for a list of objects (NumPy-like promotion).
-        ///     Promotes to the widest type: bool -> int -> long -> float -> double -> decimal
+        ///     Uses existing _FindCommonType_Scalar for consistent type promotion.
+        ///     Early exit when highest-priority types (decimal/double) are found.
         /// </summary>
         private static Type FindCommonNumericType(List<object> items)
         {
-            // NumPy type promotion priority (simplified):
-            // bool < byte < short < ushort < int < uint < long < ulong < float < double
-            // If any float/double is present, result is float/double
-            // decimal is separate (highest priority if present)
+            // Use CollectionsMarshal.AsSpan for faster iteration (no bounds checks)
+            var span = CollectionsMarshal.AsSpan(items);
 
+            // Early exit optimization: track highest-priority types seen
             bool hasDecimal = false;
             bool hasDouble = false;
             bool hasFloat = false;
-            bool hasULong = false;
-            bool hasLong = false;
-            bool hasUInt = false;
-            bool hasInt = false;
-            bool hasUShort = false;
-            bool hasShort = false;
-            bool hasByte = false;
-            bool hasBool = false;
-            bool hasChar = false;
             Type firstType = null;
 
-            foreach (var item in items)
+            // Collect unique type codes for _FindCommonType_Scalar
+            Span<NPTypeCode> typeCodes = stackalloc NPTypeCode[span.Length];
+            int uniqueCount = 0;
+            uint seenMask = 0; // Bitmask for deduplication (NPTypeCode values are small)
+
+            for (int i = 0; i < span.Length; i++)
             {
-                var t = item.GetType();
+                var t = span[i].GetType();
                 firstType ??= t;
 
-                if (t == typeof(decimal)) hasDecimal = true;
-                else if (t == typeof(double)) hasDouble = true;
+                // Early exit: decimal wins everything
+                if (t == typeof(decimal))
+                    return typeof(decimal);
+
+                // Track floating point for early double detection
+                if (t == typeof(double)) hasDouble = true;
                 else if (t == typeof(float)) hasFloat = true;
-                else if (t == typeof(ulong)) hasULong = true;
-                else if (t == typeof(long)) hasLong = true;
-                else if (t == typeof(uint)) hasUInt = true;
-                else if (t == typeof(int)) hasInt = true;
-                else if (t == typeof(ushort)) hasUShort = true;
-                else if (t == typeof(short)) hasShort = true;
-                else if (t == typeof(byte)) hasByte = true;
-                else if (t == typeof(bool)) hasBool = true;
-                else if (t == typeof(char)) hasChar = true;
+
+                var code = t.GetTypeCode();
+                var bit = 1u << (int)code;
+                if ((seenMask & bit) == 0)
+                {
+                    seenMask |= bit;
+                    typeCodes[uniqueCount++] = code;
+                }
             }
 
-            // Promotion rules (NumPy-like):
-            // decimal wins if present
-            if (hasDecimal) return typeof(decimal);
+            // Early exit: any floating point promotes to double
+            if (hasDouble || hasFloat)
+                return typeof(double);
 
-            // Any floating point promotes to double (NumPy uses float64 for mixed int+float)
-            if (hasDouble || hasFloat) return typeof(double);
+            // Use existing type promotion logic for remaining cases
+            if (uniqueCount == 1)
+                return firstType ?? typeof(double);
 
-            // Integer promotion
-            if (hasULong) return typeof(ulong);
-            if (hasLong || hasUInt) return typeof(long); // uint + anything signed -> long
-            if (hasUInt) return typeof(uint);
-            if (hasInt || hasUShort) return typeof(int); // ushort + anything signed -> int
-            if (hasUShort) return typeof(ushort);
-            if (hasShort || hasByte) return typeof(int); // byte + short -> int (safe promotion)
-            if (hasByte) return typeof(byte);
-            if (hasChar) return typeof(char);
-            if (hasBool) return typeof(bool);
-
-            // Fallback to first type
-            return firstType ?? typeof(double);
+            var resultCode = _FindCommonType_Scalar(typeCodes.Slice(0, uniqueCount).ToArray());
+            return resultCode.AsType();
         }
 
         /// <summary>
         ///     Converts a Tuple or ValueTuple to an NDArray.
         ///     Uses ITuple interface available in .NET Core 2.0+.
+        ///     Optimized: pre-sized List, early exit for decimal/double.
         /// </summary>
         private static NDArray ConvertTuple(ITuple tuple)
         {
             if (tuple.Length == 0)
                 return np.array(Array.Empty<double>());
 
-            // Collect items and find common type (NumPy-like promotion)
+            // Pre-sized list (optimization: avoid resize for known count)
             var items = new List<object>(tuple.Length);
 
             for (int i = 0; i < tuple.Length; i++)
@@ -286,131 +291,99 @@ namespace NumSharp
 
         /// <summary>
         ///     Converts a list of objects to an NDArray of the specified element type.
+        ///     Uses CollectionsMarshal.AsSpan for bounds-check-free iteration.
         ///     Uses pattern matching for fast direct cast when types match, with Convert fallback.
         ///     This is ~4x faster than always using Convert for homogeneous collections.
         /// </summary>
         private static NDArray ConvertObjectListToNDArray(List<object> items, Type elementType)
         {
+            // Use CollectionsMarshal.AsSpan for faster iteration (no bounds checks)
+            var span = CollectionsMarshal.AsSpan(items);
+
             // Pattern: `is T v ? v : Convert.ToT(item)` gives direct cast speed for homogeneous
             // collections while still handling mixed types correctly
             if (elementType == typeof(bool))
             {
-                var arr = GC.AllocateUninitializedArray<bool>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is bool v ? v : Convert.ToBoolean(item);
-                }
+                var arr = GC.AllocateUninitializedArray<bool>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is bool v ? v : Convert.ToBoolean(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(byte))
             {
-                var arr = GC.AllocateUninitializedArray<byte>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is byte v ? v : Convert.ToByte(item);
-                }
+                var arr = GC.AllocateUninitializedArray<byte>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is byte v ? v : Convert.ToByte(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(short))
             {
-                var arr = GC.AllocateUninitializedArray<short>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is short v ? v : Convert.ToInt16(item);
-                }
+                var arr = GC.AllocateUninitializedArray<short>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is short v ? v : Convert.ToInt16(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(ushort))
             {
-                var arr = GC.AllocateUninitializedArray<ushort>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is ushort v ? v : Convert.ToUInt16(item);
-                }
+                var arr = GC.AllocateUninitializedArray<ushort>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is ushort v ? v : Convert.ToUInt16(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(int))
             {
-                var arr = GC.AllocateUninitializedArray<int>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is int v ? v : Convert.ToInt32(item);
-                }
+                var arr = GC.AllocateUninitializedArray<int>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is int v ? v : Convert.ToInt32(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(uint))
             {
-                var arr = GC.AllocateUninitializedArray<uint>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is uint v ? v : Convert.ToUInt32(item);
-                }
+                var arr = GC.AllocateUninitializedArray<uint>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is uint v ? v : Convert.ToUInt32(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(long))
             {
-                var arr = GC.AllocateUninitializedArray<long>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is long v ? v : Convert.ToInt64(item);
-                }
+                var arr = GC.AllocateUninitializedArray<long>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is long v ? v : Convert.ToInt64(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(ulong))
             {
-                var arr = GC.AllocateUninitializedArray<ulong>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is ulong v ? v : Convert.ToUInt64(item);
-                }
+                var arr = GC.AllocateUninitializedArray<ulong>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is ulong v ? v : Convert.ToUInt64(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(char))
             {
-                var arr = GC.AllocateUninitializedArray<char>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is char v ? v : Convert.ToChar(item);
-                }
+                var arr = GC.AllocateUninitializedArray<char>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is char v ? v : Convert.ToChar(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(float))
             {
-                var arr = GC.AllocateUninitializedArray<float>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is float v ? v : Convert.ToSingle(item);
-                }
+                var arr = GC.AllocateUninitializedArray<float>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is float v ? v : Convert.ToSingle(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(double))
             {
-                var arr = GC.AllocateUninitializedArray<double>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is double v ? v : Convert.ToDouble(item);
-                }
+                var arr = GC.AllocateUninitializedArray<double>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is double v ? v : Convert.ToDouble(span[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(decimal))
             {
-                var arr = GC.AllocateUninitializedArray<decimal>(items.Count);
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var item = items[i];
-                    arr[i] = item is decimal v ? v : Convert.ToDecimal(item);
-                }
+                var arr = GC.AllocateUninitializedArray<decimal>(span.Length);
+                for (int i = 0; i < span.Length; i++)
+                    arr[i] = span[i] is decimal v ? v : Convert.ToDecimal(span[i]);
                 return np.array(arr);
             }
 

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -41,8 +41,6 @@ namespace NumSharp
                     ret = str; //implicit cast located in NDArray.Implicit.Array
                     break;
 
-                // Handle typed IEnumerable<T> for all 12 NumSharp-supported types
-                // Optimized: Use CopyTo for ICollection<T> (3-7x faster than ToArray for small collections)
                 case IEnumerable<bool> e: ret = np.array(ToArrayFast(e)); break;
                 case IEnumerable<byte> e: ret = np.array(ToArrayFast(e)); break;
                 case IEnumerable<short> e: ret = np.array(ToArrayFast(e)); break;
@@ -58,14 +56,13 @@ namespace NumSharp
 
                 default:
                     var type = a.GetType();
-                    // Check if it's a scalar (primitive or decimal)
                     if (type.IsPrimitive || type == typeof(decimal))
                     {
                         ret = NDArray.Scalar(a);
                         break;
                     }
 
-                    // Handle Memory<T> and ReadOnlyMemory<T> - they don't implement IEnumerable<T>
+                    // Memory<T>/ReadOnlyMemory<T> do not implement IEnumerable<T>.
                     if (type.IsGenericType)
                     {
                         var genericDef = type.GetGenericTypeDefinition();
@@ -77,7 +74,6 @@ namespace NumSharp
                         }
                     }
 
-                    // Handle Tuple<> and ValueTuple<> - they implement ITuple
                     if (a is ITuple tuple)
                     {
                         ret = ConvertTuple(tuple);
@@ -85,7 +81,6 @@ namespace NumSharp
                             break;
                     }
 
-                    // Fallback: non-generic IEnumerable (element type detected from first item)
                     if (a is IEnumerable enumerable)
                     {
                         ret = ConvertNonGenericEnumerable(enumerable);
@@ -93,7 +88,6 @@ namespace NumSharp
                             break;
                     }
 
-                    // Fallback: non-generic IEnumerator
                     if (a is IEnumerator enumerator)
                     {
                         ret = ConvertEnumerator(enumerator);
@@ -111,34 +105,28 @@ namespace NumSharp
         }
 
         /// <summary>
-        ///     Optimized ToArray for IEnumerable&lt;T&gt;.
-        ///     Uses CopyTo for ICollection&lt;T&gt; (3-7x faster for small collections).
-        ///     For List&lt;T&gt;, uses CollectionsMarshal.AsSpan for direct memory access.
-        ///     Uses GC.AllocateUninitializedArray to skip zeroing (4x faster allocation).
+        ///     Copies an <see cref="IEnumerable{T}"/> into a freshly allocated <typeparamref name="T"/>[].
+        ///     Specialised for List&lt;T&gt; and ICollection&lt;T&gt; to skip the enumerator and to
+        ///     use <see cref="GC.AllocateUninitializedArray{T}(int, bool)"/> since we overwrite every slot.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static T[] ToArrayFast<T>(IEnumerable<T> source)
         {
-            // Fast path for List<T> - use CollectionsMarshal for direct span access
             if (source is List<T> list)
             {
                 var span = CollectionsMarshal.AsSpan(list);
-                // Use uninitialized array - we're about to overwrite all elements
                 var arr = GC.AllocateUninitializedArray<T>(span.Length);
                 span.CopyTo(arr);
                 return arr;
             }
 
-            // Fast path for ICollection<T> - use CopyTo (avoids enumerator overhead)
             if (source is ICollection<T> collection)
             {
-                // Use uninitialized array - CopyTo will overwrite all elements
                 var arr = GC.AllocateUninitializedArray<T>(collection.Count);
                 collection.CopyTo(arr, 0);
                 return arr;
             }
 
-            // Fallback to LINQ ToArray for other IEnumerable<T>
             return source.ToArray();
         }
 
@@ -151,7 +139,6 @@ namespace NumSharp
             var elementType = type.GetGenericArguments()[0];
             var isReadOnly = type.GetGenericTypeDefinition() == typeof(ReadOnlyMemory<>);
 
-            // Use Span.CopyTo + GC.AllocateUninitializedArray instead of ToArray()
             if (elementType == typeof(bool)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<bool>)a).Span : ((Memory<bool>)a).Span));
             if (elementType == typeof(byte)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<byte>)a).Span : ((Memory<byte>)a).Span));
             if (elementType == typeof(short)) return np.array(SpanToArrayFast(isReadOnly ? ((ReadOnlyMemory<short>)a).Span : ((Memory<short>)a).Span));
@@ -189,16 +176,13 @@ namespace NumSharp
         /// <summary>
         ///     Converts a non-generic IEnumerator to an NDArray.
         ///     Element type is detected from items with NumPy-like type promotion.
-        ///     Empty collections return empty double[] to match NumPy's behavior.
+        ///     Empty collections return empty double[] to match NumPy's float64 default.
         /// </summary>
         private static NDArray ConvertEnumerator(IEnumerator enumerator)
         {
-            // Pre-size list if count is known (optimization #4)
-            List<object> items;
-            if (enumerator is ICollection collection)
-                items = new List<object>(collection.Count);
-            else
-                items = new List<object>();
+            List<object> items = enumerator is ICollection collection
+                ? new List<object>(collection.Count)
+                : new List<object>();
 
             while (enumerator.MoveNext())
             {
@@ -207,7 +191,6 @@ namespace NumSharp
                     items.Add(item);
             }
 
-            // Empty collection: return empty double[] (NumPy defaults to float64)
             if (items.Count == 0)
                 return np.array(Array.Empty<double>());
 
@@ -218,34 +201,29 @@ namespace NumSharp
         /// <summary>
         ///     Finds the common numeric type for a list of objects (NumPy-like promotion).
         ///     Uses existing _FindCommonType_Scalar for consistent type promotion.
-        ///     Early exit when highest-priority types (decimal/double) are found.
         /// </summary>
         private static Type FindCommonNumericType(List<object> items)
         {
-            // Use CollectionsMarshal.AsSpan for faster iteration (no bounds checks)
             var span = CollectionsMarshal.AsSpan(items);
 
-            // Early exit optimization: track highest-priority types seen
-            bool hasDecimal = false;
             bool hasDouble = false;
             bool hasFloat = false;
             Type firstType = null;
 
-            // Collect unique type codes for _FindCommonType_Scalar
-            Span<NPTypeCode> typeCodes = stackalloc NPTypeCode[span.Length];
+            // At most 12 unique NPTypeCode values exist; bound the stackalloc accordingly
+            // (otherwise large user lists could blow the stack).
+            Span<NPTypeCode> typeCodes = stackalloc NPTypeCode[12];
             int uniqueCount = 0;
-            uint seenMask = 0; // Bitmask for deduplication (NPTypeCode values are small)
+            uint seenMask = 0;
 
             for (int i = 0; i < span.Length; i++)
             {
                 var t = span[i].GetType();
                 firstType ??= t;
 
-                // Early exit: decimal wins everything
                 if (t == typeof(decimal))
                     return typeof(decimal);
 
-                // Track floating point for early double detection
                 if (t == typeof(double)) hasDouble = true;
                 else if (t == typeof(float)) hasFloat = true;
 
@@ -258,11 +236,9 @@ namespace NumSharp
                 }
             }
 
-            // Early exit: any floating point promotes to double
             if (hasDouble || hasFloat)
                 return typeof(double);
 
-            // Use existing type promotion logic for remaining cases
             if (uniqueCount == 1)
                 return firstType ?? typeof(double);
 
@@ -271,16 +247,13 @@ namespace NumSharp
         }
 
         /// <summary>
-        ///     Converts a Tuple or ValueTuple to an NDArray.
-        ///     Uses ITuple interface available in .NET Core 2.0+.
-        ///     Optimized: pre-sized List, early exit for decimal/double.
+        ///     Converts a Tuple or ValueTuple to an NDArray via the ITuple interface.
         /// </summary>
         private static NDArray ConvertTuple(ITuple tuple)
         {
             if (tuple.Length == 0)
                 return np.array(Array.Empty<double>());
 
-            // Pre-sized list (optimization: avoid resize for known count)
             var items = new List<object>(tuple.Length);
 
             for (int i = 0; i < tuple.Length; i++)
@@ -299,17 +272,13 @@ namespace NumSharp
 
         /// <summary>
         ///     Converts a list of objects to an NDArray of the specified element type.
-        ///     Uses CollectionsMarshal.AsSpan for bounds-check-free iteration.
-        ///     Uses pattern matching for fast direct cast when types match, with Convert fallback.
-        ///     This is ~4x faster than always using Convert for homogeneous collections.
+        ///     The pattern <c>is T v ? v : Convert.ToT(item)</c> takes the direct-cast fast path for
+        ///     homogeneous collections while still handling mixed-type promotion via Convert.
         /// </summary>
         private static NDArray ConvertObjectListToNDArray(List<object> items, Type elementType)
         {
-            // Use CollectionsMarshal.AsSpan for faster iteration (no bounds checks)
             var span = CollectionsMarshal.AsSpan(items);
 
-            // Pattern: `is T v ? v : Convert.ToT(item)` gives direct cast speed for homogeneous
-            // collections while still handling mixed types correctly
             if (elementType == typeof(bool))
             {
                 var arr = GC.AllocateUninitializedArray<bool>(span.Length);

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -32,7 +32,7 @@ namespace NumSharp
                     // supported element type.
                     ret = ConvertNonGenericEnumerable(objArr);
                     if (ret is null)
-                        throw new NotSupportedException($"Unable to resolve asanyarray for object array of length {objArr.Length}.");
+                        throw new NotSupportedException($"Unable to resolve asanyarray for object[] (length {objArr.Length}): element type is not a supported NumSharp dtype.");
                     break;
                 case Array array:
                     ret = new NDArray(array);
@@ -206,8 +206,6 @@ namespace NumSharp
         {
             var span = CollectionsMarshal.AsSpan(items);
 
-            bool hasDouble = false;
-            bool hasFloat = false;
             Type firstType = null;
 
             // At most 12 unique NPTypeCode values exist; bound the stackalloc accordingly
@@ -221,11 +219,9 @@ namespace NumSharp
                 var t = span[i].GetType();
                 firstType ??= t;
 
+                // decimal wins everything in NumPy promotion
                 if (t == typeof(decimal))
                     return typeof(decimal);
-
-                if (t == typeof(double)) hasDouble = true;
-                else if (t == typeof(float)) hasFloat = true;
 
                 var code = t.GetTypeCode();
                 var bit = 1u << (int)code;
@@ -235,9 +231,6 @@ namespace NumSharp
                     typeCodes[uniqueCount++] = code;
                 }
             }
-
-            if (hasDouble || hasFloat)
-                return typeof(double);
 
             if (uniqueCount == 1)
                 return firstType ?? typeof(double);

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace NumSharp
 {
@@ -33,18 +34,19 @@ namespace NumSharp
                     break;
 
                 // Handle typed IEnumerable<T> for all 12 NumSharp-supported types
-                case IEnumerable<bool> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<byte> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<short> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<ushort> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<int> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<uint> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<long> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<ulong> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<char> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<float> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<double> e: ret = np.array(e.ToArray()); break;
-                case IEnumerable<decimal> e: ret = np.array(e.ToArray()); break;
+                // Optimized: Use CopyTo for ICollection<T> (3-7x faster than ToArray for small collections)
+                case IEnumerable<bool> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<byte> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<short> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<ushort> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<int> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<uint> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<long> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<ulong> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<char> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<float> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<double> e: ret = np.array(ToArrayFast(e)); break;
+                case IEnumerable<decimal> e: ret = np.array(ToArrayFast(e)); break;
 
                 default:
                     var type = a.GetType();
@@ -98,6 +100,35 @@ namespace NumSharp
                 return ret.astype(dtype, true);
 
             return ret;
+        }
+
+        /// <summary>
+        ///     Optimized ToArray for IEnumerable&lt;T&gt;.
+        ///     Uses CopyTo for ICollection&lt;T&gt; (3-7x faster for small collections).
+        ///     For List&lt;T&gt;, uses CollectionsMarshal.AsSpan for direct memory access.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static T[] ToArrayFast<T>(IEnumerable<T> source)
+        {
+            // Fast path for List<T> - use CollectionsMarshal for direct span access
+            if (source is List<T> list)
+            {
+                var span = CollectionsMarshal.AsSpan(list);
+                var arr = new T[span.Length];
+                span.CopyTo(arr);
+                return arr;
+            }
+
+            // Fast path for ICollection<T> - use CopyTo (avoids enumerator overhead)
+            if (source is ICollection<T> collection)
+            {
+                var arr = new T[collection.Count];
+                collection.CopyTo(arr, 0);
+                return arr;
+            }
+
+            // Fallback to LINQ ToArray for other IEnumerable<T>
+            return source.ToArray();
         }
 
         /// <summary>

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace NumSharp
 {
@@ -66,6 +67,14 @@ namespace NumSharp
                         }
                     }
 
+                    // Handle Tuple<> and ValueTuple<> - they implement ITuple
+                    if (a is ITuple tuple)
+                    {
+                        ret = ConvertTuple(tuple);
+                        if (ret is not null)
+                            break;
+                    }
+
                     // Fallback: non-generic IEnumerable (element type detected from first item)
                     if (a is IEnumerable enumerable)
                     {
@@ -127,6 +136,7 @@ namespace NumSharp
         /// <summary>
         ///     Converts a non-generic IEnumerator to an NDArray.
         ///     Element type is detected from the first item.
+        ///     Empty collections return empty double[] to match NumPy's behavior.
         /// </summary>
         private static NDArray ConvertEnumerator(IEnumerator enumerator)
         {
@@ -144,8 +154,38 @@ namespace NumSharp
                 items.Add(item);
             }
 
+            // Empty collection: return empty double[] (NumPy defaults to float64)
             if (items.Count == 0 || elementType == null)
-                return null; // Can't determine type from empty collection
+                return np.array(Array.Empty<double>());
+
+            return ConvertObjectListToNDArray(items, elementType);
+        }
+
+        /// <summary>
+        ///     Converts a Tuple or ValueTuple to an NDArray.
+        ///     Uses ITuple interface available in .NET Core 2.0+.
+        /// </summary>
+        private static NDArray ConvertTuple(ITuple tuple)
+        {
+            if (tuple.Length == 0)
+                return np.array(Array.Empty<double>());
+
+            // Collect items and detect type from first non-null element
+            var items = new List<object>(tuple.Length);
+            Type elementType = null;
+
+            for (int i = 0; i < tuple.Length; i++)
+            {
+                var item = tuple[i];
+                if (item == null)
+                    continue;
+
+                elementType ??= item.GetType();
+                items.Add(item);
+            }
+
+            if (items.Count == 0 || elementType == null)
+                return np.array(Array.Empty<double>());
 
             return ConvertObjectListToNDArray(items, elementType);
         }

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -106,6 +106,7 @@ namespace NumSharp
         ///     Optimized ToArray for IEnumerable&lt;T&gt;.
         ///     Uses CopyTo for ICollection&lt;T&gt; (3-7x faster for small collections).
         ///     For List&lt;T&gt;, uses CollectionsMarshal.AsSpan for direct memory access.
+        ///     Uses GC.AllocateUninitializedArray to skip zeroing (4x faster allocation).
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static T[] ToArrayFast<T>(IEnumerable<T> source)
@@ -114,7 +115,8 @@ namespace NumSharp
             if (source is List<T> list)
             {
                 var span = CollectionsMarshal.AsSpan(list);
-                var arr = new T[span.Length];
+                // Use uninitialized array - we're about to overwrite all elements
+                var arr = GC.AllocateUninitializedArray<T>(span.Length);
                 span.CopyTo(arr);
                 return arr;
             }
@@ -122,7 +124,8 @@ namespace NumSharp
             // Fast path for ICollection<T> - use CopyTo (avoids enumerator overhead)
             if (source is ICollection<T> collection)
             {
-                var arr = new T[collection.Count];
+                // Use uninitialized array - CopyTo will overwrite all elements
+                var arr = GC.AllocateUninitializedArray<T>(collection.Count);
                 collection.CopyTo(arr, 0);
                 return arr;
             }
@@ -292,7 +295,7 @@ namespace NumSharp
             // collections while still handling mixed types correctly
             if (elementType == typeof(bool))
             {
-                var arr = new bool[items.Count];
+                var arr = GC.AllocateUninitializedArray<bool>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -302,7 +305,7 @@ namespace NumSharp
             }
             if (elementType == typeof(byte))
             {
-                var arr = new byte[items.Count];
+                var arr = GC.AllocateUninitializedArray<byte>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -312,7 +315,7 @@ namespace NumSharp
             }
             if (elementType == typeof(short))
             {
-                var arr = new short[items.Count];
+                var arr = GC.AllocateUninitializedArray<short>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -322,7 +325,7 @@ namespace NumSharp
             }
             if (elementType == typeof(ushort))
             {
-                var arr = new ushort[items.Count];
+                var arr = GC.AllocateUninitializedArray<ushort>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -332,7 +335,7 @@ namespace NumSharp
             }
             if (elementType == typeof(int))
             {
-                var arr = new int[items.Count];
+                var arr = GC.AllocateUninitializedArray<int>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -342,7 +345,7 @@ namespace NumSharp
             }
             if (elementType == typeof(uint))
             {
-                var arr = new uint[items.Count];
+                var arr = GC.AllocateUninitializedArray<uint>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -352,7 +355,7 @@ namespace NumSharp
             }
             if (elementType == typeof(long))
             {
-                var arr = new long[items.Count];
+                var arr = GC.AllocateUninitializedArray<long>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -362,7 +365,7 @@ namespace NumSharp
             }
             if (elementType == typeof(ulong))
             {
-                var arr = new ulong[items.Count];
+                var arr = GC.AllocateUninitializedArray<ulong>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -372,7 +375,7 @@ namespace NumSharp
             }
             if (elementType == typeof(char))
             {
-                var arr = new char[items.Count];
+                var arr = GC.AllocateUninitializedArray<char>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -382,7 +385,7 @@ namespace NumSharp
             }
             if (elementType == typeof(float))
             {
-                var arr = new float[items.Count];
+                var arr = GC.AllocateUninitializedArray<float>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -392,7 +395,7 @@ namespace NumSharp
             }
             if (elementType == typeof(double))
             {
-                var arr = new double[items.Count];
+                var arr = GC.AllocateUninitializedArray<double>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];
@@ -402,7 +405,7 @@ namespace NumSharp
             }
             if (elementType == typeof(decimal))
             {
-                var arr = new decimal[items.Count];
+                var arr = GC.AllocateUninitializedArray<decimal>(items.Count);
                 for (int i = 0; i < items.Count; i++)
                 {
                     var item = items[i];

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NumSharp
 {
@@ -18,29 +21,104 @@ namespace NumSharp
                 case null:
                     throw new ArgumentNullException(nameof(a));
                 case NDArray nd:
-                    return nd;
+                    if (dtype == null || Equals(nd.dtype, dtype))
+                        return nd;
+                    return nd.astype(dtype, true);
                 case Array array:
                     ret = new NDArray(array);
                     break;
                 case string str:
                     ret = str; //implicit cast located in NDArray.Implicit.Array
                     break;
+
+                // Handle typed IEnumerable<T> for all 12 NumSharp-supported types
+                case IEnumerable<bool> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<byte> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<short> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<ushort> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<int> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<uint> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<long> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<ulong> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<char> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<float> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<double> e: ret = np.array(e.ToArray()); break;
+                case IEnumerable<decimal> e: ret = np.array(e.ToArray()); break;
+
                 default:
                     var type = a.GetType();
-                    //is it a scalar
+                    // Check if it's a scalar (primitive or decimal)
                     if (type.IsPrimitive || type == typeof(decimal))
                     {
                         ret = NDArray.Scalar(a);
                         break;
                     }
 
-                    throw new NotSupportedException($"Unable resolve asanyarray for type {a.GetType().Name}");
+                    // Handle Memory<T> and ReadOnlyMemory<T> - they don't implement IEnumerable<T>
+                    if (type.IsGenericType)
+                    {
+                        var genericDef = type.GetGenericTypeDefinition();
+                        if (genericDef == typeof(Memory<>) || genericDef == typeof(ReadOnlyMemory<>))
+                        {
+                            ret = ConvertMemory(a, type);
+                            if (ret is not null)
+                                break;
+                        }
+                    }
+
+                    throw new NotSupportedException($"Unable to resolve asanyarray for type {type.Name}");
             }
 
-            if (dtype != null && a.GetType() != dtype)
+            if (dtype != null && !Equals(ret.dtype, dtype))
                 return ret.astype(dtype, true);
 
             return ret;
+        }
+
+        /// <summary>
+        ///     Converts Memory&lt;T&gt; or ReadOnlyMemory&lt;T&gt; to an NDArray.
+        ///     These types don't implement IEnumerable&lt;T&gt;, so we handle them specially.
+        /// </summary>
+        private static NDArray ConvertMemory(object a, Type type)
+        {
+            var genericDef = type.GetGenericTypeDefinition();
+            var elementType = type.GetGenericArguments()[0];
+
+            // Handle ReadOnlyMemory<T> first (it cannot be cast to Memory<T>)
+            if (genericDef == typeof(ReadOnlyMemory<>))
+            {
+                if (elementType == typeof(bool)) return np.array(((ReadOnlyMemory<bool>)a).ToArray());
+                if (elementType == typeof(byte)) return np.array(((ReadOnlyMemory<byte>)a).ToArray());
+                if (elementType == typeof(short)) return np.array(((ReadOnlyMemory<short>)a).ToArray());
+                if (elementType == typeof(ushort)) return np.array(((ReadOnlyMemory<ushort>)a).ToArray());
+                if (elementType == typeof(int)) return np.array(((ReadOnlyMemory<int>)a).ToArray());
+                if (elementType == typeof(uint)) return np.array(((ReadOnlyMemory<uint>)a).ToArray());
+                if (elementType == typeof(long)) return np.array(((ReadOnlyMemory<long>)a).ToArray());
+                if (elementType == typeof(ulong)) return np.array(((ReadOnlyMemory<ulong>)a).ToArray());
+                if (elementType == typeof(char)) return np.array(((ReadOnlyMemory<char>)a).ToArray());
+                if (elementType == typeof(float)) return np.array(((ReadOnlyMemory<float>)a).ToArray());
+                if (elementType == typeof(double)) return np.array(((ReadOnlyMemory<double>)a).ToArray());
+                if (elementType == typeof(decimal)) return np.array(((ReadOnlyMemory<decimal>)a).ToArray());
+            }
+
+            // Handle Memory<T>
+            if (genericDef == typeof(Memory<>))
+            {
+                if (elementType == typeof(bool)) return np.array(((Memory<bool>)a).ToArray());
+                if (elementType == typeof(byte)) return np.array(((Memory<byte>)a).ToArray());
+                if (elementType == typeof(short)) return np.array(((Memory<short>)a).ToArray());
+                if (elementType == typeof(ushort)) return np.array(((Memory<ushort>)a).ToArray());
+                if (elementType == typeof(int)) return np.array(((Memory<int>)a).ToArray());
+                if (elementType == typeof(uint)) return np.array(((Memory<uint>)a).ToArray());
+                if (elementType == typeof(long)) return np.array(((Memory<long>)a).ToArray());
+                if (elementType == typeof(ulong)) return np.array(((Memory<ulong>)a).ToArray());
+                if (elementType == typeof(char)) return np.array(((Memory<char>)a).ToArray());
+                if (elementType == typeof(float)) return np.array(((Memory<float>)a).ToArray());
+                if (elementType == typeof(double)) return np.array(((Memory<double>)a).ToArray());
+                if (elementType == typeof(decimal)) return np.array(((Memory<decimal>)a).ToArray());
+            }
+
+            return null;
         }
     }
 }

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -66,6 +66,22 @@ namespace NumSharp
                         }
                     }
 
+                    // Fallback: non-generic IEnumerable (element type detected from first item)
+                    if (a is IEnumerable enumerable)
+                    {
+                        ret = ConvertNonGenericEnumerable(enumerable);
+                        if (ret is not null)
+                            break;
+                    }
+
+                    // Fallback: non-generic IEnumerator
+                    if (a is IEnumerator enumerator)
+                    {
+                        ret = ConvertEnumerator(enumerator);
+                        if (ret is not null)
+                            break;
+                    }
+
                     throw new NotSupportedException($"Unable to resolve asanyarray for type {type.Name}");
             }
 
@@ -119,6 +135,139 @@ namespace NumSharp
             }
 
             return null;
+        }
+
+        /// <summary>
+        ///     Converts a non-generic IEnumerable to an NDArray.
+        ///     Element type is detected from the first item.
+        /// </summary>
+        private static NDArray ConvertNonGenericEnumerable(IEnumerable enumerable)
+        {
+            // Collect items and detect type from first element
+            var items = new List<object>();
+            Type elementType = null;
+
+            foreach (var item in enumerable)
+            {
+                if (item == null)
+                    continue;
+
+                elementType ??= item.GetType();
+                items.Add(item);
+            }
+
+            if (items.Count == 0 || elementType == null)
+                return null; // Can't determine type from empty collection
+
+            return ConvertObjectListToNDArray(items, elementType);
+        }
+
+        /// <summary>
+        ///     Converts a non-generic IEnumerator to an NDArray.
+        ///     Element type is detected from the first item.
+        /// </summary>
+        private static NDArray ConvertEnumerator(IEnumerator enumerator)
+        {
+            // Collect items and detect type from first element
+            var items = new List<object>();
+            Type elementType = null;
+
+            while (enumerator.MoveNext())
+            {
+                var item = enumerator.Current;
+                if (item == null)
+                    continue;
+
+                elementType ??= item.GetType();
+                items.Add(item);
+            }
+
+            if (items.Count == 0 || elementType == null)
+                return null; // Can't determine type from empty collection
+
+            return ConvertObjectListToNDArray(items, elementType);
+        }
+
+        /// <summary>
+        ///     Converts a list of objects to an NDArray of the specified element type.
+        /// </summary>
+        private static NDArray ConvertObjectListToNDArray(List<object> items, Type elementType)
+        {
+            // Type switch to create typed array without reflection
+            if (elementType == typeof(bool))
+            {
+                var arr = new bool[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (bool)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(byte))
+            {
+                var arr = new byte[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (byte)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(short))
+            {
+                var arr = new short[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (short)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(ushort))
+            {
+                var arr = new ushort[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (ushort)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(int))
+            {
+                var arr = new int[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (int)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(uint))
+            {
+                var arr = new uint[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (uint)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(long))
+            {
+                var arr = new long[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (long)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(ulong))
+            {
+                var arr = new ulong[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (ulong)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(char))
+            {
+                var arr = new char[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (char)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(float))
+            {
+                var arr = new float[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (float)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(double))
+            {
+                var arr = new double[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (double)items[i];
+                return np.array(arr);
+            }
+            if (elementType == typeof(decimal))
+            {
+                var arr = new decimal[items.Count];
+                for (int i = 0; i < items.Count; i++) arr[i] = (decimal)items[i];
+                return np.array(arr);
+            }
+
+            return null; // Unsupported element type
         }
     }
 }

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -135,30 +135,93 @@ namespace NumSharp
 
         /// <summary>
         ///     Converts a non-generic IEnumerator to an NDArray.
-        ///     Element type is detected from the first item.
+        ///     Element type is detected from items with NumPy-like type promotion.
         ///     Empty collections return empty double[] to match NumPy's behavior.
         /// </summary>
         private static NDArray ConvertEnumerator(IEnumerator enumerator)
         {
-            // Collect items and detect type from first element
+            // Collect items
             var items = new List<object>();
-            Type elementType = null;
 
             while (enumerator.MoveNext())
             {
                 var item = enumerator.Current;
-                if (item == null)
-                    continue;
-
-                elementType ??= item.GetType();
-                items.Add(item);
+                if (item != null)
+                    items.Add(item);
             }
 
             // Empty collection: return empty double[] (NumPy defaults to float64)
-            if (items.Count == 0 || elementType == null)
+            if (items.Count == 0)
                 return np.array(Array.Empty<double>());
 
+            var elementType = FindCommonNumericType(items);
             return ConvertObjectListToNDArray(items, elementType);
+        }
+
+        /// <summary>
+        ///     Finds the common numeric type for a list of objects (NumPy-like promotion).
+        ///     Promotes to the widest type: bool -> int -> long -> float -> double -> decimal
+        /// </summary>
+        private static Type FindCommonNumericType(List<object> items)
+        {
+            // NumPy type promotion priority (simplified):
+            // bool < byte < short < ushort < int < uint < long < ulong < float < double
+            // If any float/double is present, result is float/double
+            // decimal is separate (highest priority if present)
+
+            bool hasDecimal = false;
+            bool hasDouble = false;
+            bool hasFloat = false;
+            bool hasULong = false;
+            bool hasLong = false;
+            bool hasUInt = false;
+            bool hasInt = false;
+            bool hasUShort = false;
+            bool hasShort = false;
+            bool hasByte = false;
+            bool hasBool = false;
+            bool hasChar = false;
+            Type firstType = null;
+
+            foreach (var item in items)
+            {
+                var t = item.GetType();
+                firstType ??= t;
+
+                if (t == typeof(decimal)) hasDecimal = true;
+                else if (t == typeof(double)) hasDouble = true;
+                else if (t == typeof(float)) hasFloat = true;
+                else if (t == typeof(ulong)) hasULong = true;
+                else if (t == typeof(long)) hasLong = true;
+                else if (t == typeof(uint)) hasUInt = true;
+                else if (t == typeof(int)) hasInt = true;
+                else if (t == typeof(ushort)) hasUShort = true;
+                else if (t == typeof(short)) hasShort = true;
+                else if (t == typeof(byte)) hasByte = true;
+                else if (t == typeof(bool)) hasBool = true;
+                else if (t == typeof(char)) hasChar = true;
+            }
+
+            // Promotion rules (NumPy-like):
+            // decimal wins if present
+            if (hasDecimal) return typeof(decimal);
+
+            // Any floating point promotes to double (NumPy uses float64 for mixed int+float)
+            if (hasDouble || hasFloat) return typeof(double);
+
+            // Integer promotion
+            if (hasULong) return typeof(ulong);
+            if (hasLong || hasUInt) return typeof(long); // uint + anything signed -> long
+            if (hasUInt) return typeof(uint);
+            if (hasInt || hasUShort) return typeof(int); // ushort + anything signed -> int
+            if (hasUShort) return typeof(ushort);
+            if (hasShort || hasByte) return typeof(int); // byte + short -> int (safe promotion)
+            if (hasByte) return typeof(byte);
+            if (hasChar) return typeof(char);
+            if (hasBool) return typeof(bool);
+
+            // Fallback to first type
+            return firstType ?? typeof(double);
         }
 
         /// <summary>
@@ -170,102 +233,101 @@ namespace NumSharp
             if (tuple.Length == 0)
                 return np.array(Array.Empty<double>());
 
-            // Collect items and detect type from first non-null element
+            // Collect items and find common type (NumPy-like promotion)
             var items = new List<object>(tuple.Length);
-            Type elementType = null;
 
             for (int i = 0; i < tuple.Length; i++)
             {
                 var item = tuple[i];
-                if (item == null)
-                    continue;
-
-                elementType ??= item.GetType();
-                items.Add(item);
+                if (item != null)
+                    items.Add(item);
             }
 
-            if (items.Count == 0 || elementType == null)
+            if (items.Count == 0)
                 return np.array(Array.Empty<double>());
 
+            var elementType = FindCommonNumericType(items);
             return ConvertObjectListToNDArray(items, elementType);
         }
 
         /// <summary>
         ///     Converts a list of objects to an NDArray of the specified element type.
+        ///     Uses Convert.ChangeType for mixed-type support (e.g., int + double -> double).
         /// </summary>
         private static NDArray ConvertObjectListToNDArray(List<object> items, Type elementType)
         {
             // Type switch to create typed array without reflection
+            // Use Convert.ChangeType to handle mixed numeric types (NumPy-like promotion)
             if (elementType == typeof(bool))
             {
                 var arr = new bool[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (bool)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToBoolean(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(byte))
             {
                 var arr = new byte[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (byte)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToByte(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(short))
             {
                 var arr = new short[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (short)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToInt16(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(ushort))
             {
                 var arr = new ushort[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (ushort)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToUInt16(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(int))
             {
                 var arr = new int[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (int)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToInt32(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(uint))
             {
                 var arr = new uint[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (uint)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToUInt32(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(long))
             {
                 var arr = new long[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (long)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToInt64(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(ulong))
             {
                 var arr = new ulong[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (ulong)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToUInt64(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(char))
             {
                 var arr = new char[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (char)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToChar(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(float))
             {
                 var arr = new float[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (float)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToSingle(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(double))
             {
                 var arr = new double[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (double)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToDouble(items[i]);
                 return np.array(arr);
             }
             if (elementType == typeof(decimal))
             {
                 var arr = new decimal[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = (decimal)items[i];
+                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToDecimal(items[i]);
                 return np.array(arr);
             }
 

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -252,82 +252,131 @@ namespace NumSharp
 
         /// <summary>
         ///     Converts a list of objects to an NDArray of the specified element type.
-        ///     Uses Convert.ChangeType for mixed-type support (e.g., int + double -> double).
+        ///     Uses pattern matching for fast direct cast when types match, with Convert fallback.
+        ///     This is ~4x faster than always using Convert for homogeneous collections.
         /// </summary>
         private static NDArray ConvertObjectListToNDArray(List<object> items, Type elementType)
         {
-            // Type switch to create typed array without reflection
-            // Use Convert.ChangeType to handle mixed numeric types (NumPy-like promotion)
+            // Pattern: `is T v ? v : Convert.ToT(item)` gives direct cast speed for homogeneous
+            // collections while still handling mixed types correctly
             if (elementType == typeof(bool))
             {
                 var arr = new bool[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToBoolean(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is bool v ? v : Convert.ToBoolean(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(byte))
             {
                 var arr = new byte[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToByte(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is byte v ? v : Convert.ToByte(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(short))
             {
                 var arr = new short[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToInt16(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is short v ? v : Convert.ToInt16(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(ushort))
             {
                 var arr = new ushort[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToUInt16(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is ushort v ? v : Convert.ToUInt16(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(int))
             {
                 var arr = new int[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToInt32(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is int v ? v : Convert.ToInt32(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(uint))
             {
                 var arr = new uint[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToUInt32(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is uint v ? v : Convert.ToUInt32(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(long))
             {
                 var arr = new long[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToInt64(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is long v ? v : Convert.ToInt64(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(ulong))
             {
                 var arr = new ulong[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToUInt64(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is ulong v ? v : Convert.ToUInt64(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(char))
             {
                 var arr = new char[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToChar(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is char v ? v : Convert.ToChar(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(float))
             {
                 var arr = new float[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToSingle(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is float v ? v : Convert.ToSingle(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(double))
             {
                 var arr = new double[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToDouble(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is double v ? v : Convert.ToDouble(item);
+                }
                 return np.array(arr);
             }
             if (elementType == typeof(decimal))
             {
                 var arr = new decimal[items.Count];
-                for (int i = 0; i < items.Count; i++) arr[i] = Convert.ToDecimal(items[i]);
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+                    arr[i] = item is decimal v ? v : Convert.ToDecimal(item);
+                }
                 return np.array(arr);
             }
 

--- a/src/NumSharp.Core/Creation/np.asanyarray.cs
+++ b/src/NumSharp.Core/Creation/np.asanyarray.cs
@@ -26,6 +26,14 @@ namespace NumSharp
                     if (dtype == null || Equals(nd.dtype, dtype))
                         return nd;
                     return nd.astype(dtype, true);
+                case object[] objArr:
+                    // object[] has no fixed dtype — route through type-promotion path.
+                    // new NDArray(object[]) throws NotSupportedException since object isn't a
+                    // supported element type.
+                    ret = ConvertNonGenericEnumerable(objArr);
+                    if (ret is null)
+                        throw new NotSupportedException($"Unable to resolve asanyarray for object array of length {objArr.Length}.");
+                    break;
                 case Array array:
                     ret = new NDArray(array);
                     break;

--- a/test/NumSharp.UnitTest/Backends/Kernels/WhereSimdTests.cs
+++ b/test/NumSharp.UnitTest/Backends/Kernels/WhereSimdTests.cs
@@ -1,0 +1,515 @@
+using System;
+using System.Diagnostics;
+using NumSharp.Backends.Kernels;
+using TUnit.Core;
+using NumSharp.UnitTest.Utilities;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+namespace NumSharp.UnitTest.Backends.Kernels
+{
+    /// <summary>
+    /// Tests for SIMD-optimized np.where implementation.
+    /// Verifies correctness of the SIMD path for all supported dtypes.
+    /// </summary>
+    public class WhereSimdTests
+    {
+        #region SIMD Correctness
+
+        [Test]
+        public void Where_Simd_Float32_Correctness()
+        {
+            var rng = np.random.RandomState(42);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = rng.rand(size).astype(NPTypeCode.Single);
+            var y = rng.rand(size).astype(NPTypeCode.Single);
+
+            var result = np.where(cond, x, y);
+
+            // Verify correctness manually
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (float)x[i] : (float)y[i];
+                Assert.AreEqual(expected, (float)result[i], 1e-6f, $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_Float64_Correctness()
+        {
+            var rng = np.random.RandomState(43);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = rng.rand(size);
+            var y = rng.rand(size);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (double)x[i] : (double)y[i];
+                Assert.AreEqual(expected, (double)result[i], 1e-10, $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_Int32_Correctness()
+        {
+            var rng = np.random.RandomState(44);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = rng.randint(0, 1000, new[] { size });
+            var y = rng.randint(0, 1000, new[] { size });
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (int)x[i] : (int)y[i];
+                Assert.AreEqual(expected, (int)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_Int64_Correctness()
+        {
+            var rng = np.random.RandomState(45);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = np.arange(size).astype(NPTypeCode.Int64);
+            var y = np.arange(size, size * 2).astype(NPTypeCode.Int64);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (long)x[i] : (long)y[i];
+                Assert.AreEqual(expected, (long)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_Byte_Correctness()
+        {
+            var rng = np.random.RandomState(46);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = (rng.rand(size) * 255).astype(NPTypeCode.Byte);
+            var y = (rng.rand(size) * 255).astype(NPTypeCode.Byte);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (byte)x[i] : (byte)y[i];
+                Assert.AreEqual(expected, (byte)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_Int16_Correctness()
+        {
+            var rng = np.random.RandomState(47);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = np.arange(size).astype(NPTypeCode.Int16);
+            var y = np.arange(size, size * 2).astype(NPTypeCode.Int16);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (short)x[i] : (short)y[i];
+                Assert.AreEqual(expected, (short)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_UInt16_Correctness()
+        {
+            var rng = np.random.RandomState(48);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = np.arange(size).astype(NPTypeCode.UInt16);
+            var y = np.arange(size, size * 2).astype(NPTypeCode.UInt16);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (ushort)x[i] : (ushort)y[i];
+                Assert.AreEqual(expected, (ushort)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_UInt32_Correctness()
+        {
+            var rng = np.random.RandomState(49);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = np.arange(size).astype(NPTypeCode.UInt32);
+            var y = np.arange(size, size * 2).astype(NPTypeCode.UInt32);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (uint)x[i] : (uint)y[i];
+                Assert.AreEqual(expected, (uint)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_UInt64_Correctness()
+        {
+            var rng = np.random.RandomState(50);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = np.arange(size).astype(NPTypeCode.UInt64);
+            var y = np.arange(size, size * 2).astype(NPTypeCode.UInt64);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (ulong)x[i] : (ulong)y[i];
+                Assert.AreEqual(expected, (ulong)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_Boolean_Correctness()
+        {
+            var rng = np.random.RandomState(51);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var x = rng.rand(size) > 0.3;
+            var y = rng.rand(size) > 0.7;
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (bool)x[i] : (bool)y[i];
+                Assert.AreEqual(expected, (bool)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_Char_Correctness()
+        {
+            var rng = np.random.RandomState(52);
+            var size = 1000;
+            var cond = rng.rand(size) > 0.5;
+            var xData = new char[size];
+            var yData = new char[size];
+            for (int i = 0; i < size; i++)
+            {
+                xData[i] = (char)('A' + (i % 26));
+                yData[i] = (char)('a' + (i % 26));
+            }
+            var x = np.array(xData);
+            var y = np.array(yData);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (char)x[i] : (char)y[i];
+                Assert.AreEqual(expected, (char)result[i], $"Mismatch at index {i}");
+            }
+        }
+
+        #endregion
+
+        #region Path Selection
+
+        [Test]
+        public void Where_NonContiguous_Works()
+        {
+            // Sliced arrays are non-contiguous, should work correctly
+            var baseArr = np.arange(20);
+            var cond = (baseArr % 2 == 0)["::2"];  // Sliced: [true, true, true, true, true, true, true, true, true, true]
+            var x = np.ones(10, NPTypeCode.Int32);
+            var y = np.zeros(10, NPTypeCode.Int32);
+
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(10, result.size);
+            // All true -> all from x
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.AreEqual(1, (int)result[i]);
+            }
+        }
+
+        [Test]
+        public void Where_Broadcast_Works()
+        {
+            // Broadcasted arrays
+            // cond shape (3,) broadcasts to (3,3): [[T,F,T],[T,F,T],[T,F,T]]
+            // x shape (3,1) broadcasts to (3,3): [[1,1,1],[2,2,2],[3,3,3]]
+            // y shape (1,3) broadcasts to (3,3): [[10,20,30],[10,20,30],[10,20,30]]
+            var cond = np.array(new[] { true, false, true });
+            var x = np.array(new int[,] { { 1 }, { 2 }, { 3 } });
+            var y = np.array(new int[,] { { 10, 20, 30 } });
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(3, 3);
+            // Verify values: result[i,j] = cond[j] ? x[i,0] : y[0,j]
+            Assert.AreEqual(1, (int)result[0, 0]);   // cond[0]=true -> x=1
+            Assert.AreEqual(20, (int)result[0, 1]);  // cond[1]=false -> y=20
+            Assert.AreEqual(1, (int)result[0, 2]);   // cond[2]=true -> x=1
+            Assert.AreEqual(2, (int)result[1, 0]);   // cond[0]=true -> x=2
+            Assert.AreEqual(20, (int)result[1, 1]);  // cond[1]=false -> y=20
+        }
+
+        [Test]
+        public void Where_Decimal_Works()
+        {
+            var cond = np.array(new[] { true, false, true });
+            var x = np.array(new decimal[] { 1.1m, 2.2m, 3.3m });
+            var y = np.array(new decimal[] { 10.1m, 20.2m, 30.3m });
+
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(decimal), result.dtype);
+            Assert.AreEqual(1.1m, (decimal)result[0]);
+            Assert.AreEqual(20.2m, (decimal)result[1]);
+            Assert.AreEqual(3.3m, (decimal)result[2]);
+        }
+
+        [Test]
+        public void Where_NonBoolCondition_Works()
+        {
+            // Non-bool condition requires truthiness check
+            var cond = np.array(new[] { 0, 1, 2, 0 });  // int condition
+            var result = np.where(cond, 100, -100);
+
+            result.Should().BeOfValues(-100, 100, 100, -100);
+        }
+
+        #endregion
+
+        #region Edge Cases
+
+        [Test]
+        public void Where_Simd_SmallArray()
+        {
+            // Array smaller than vector width
+            var cond = np.array(new[] { true, false, true });
+            var x = np.array(new[] { 1, 2, 3 });
+            var y = np.array(new[] { 10, 20, 30 });
+
+            var result = np.where(cond, x, y);
+
+            result.Should().BeOfValues(1, 20, 3);
+        }
+
+        [Test]
+        public void Where_Simd_VectorAlignedSize()
+        {
+            var rng = np.random.RandomState(53);
+            // Size exactly matches vector width (no scalar tail)
+            var size = 32;  // V256 byte count
+            var cond = rng.rand(size) > 0.5;
+            var x = np.ones(size, NPTypeCode.Byte);
+            var y = np.zeros(size, NPTypeCode.Byte);
+
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(size, result.size);
+            for (int i = 0; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? (byte)1 : (byte)0;
+                Assert.AreEqual(expected, (byte)result[i]);
+            }
+        }
+
+        [Test]
+        public void Where_Simd_WithScalarTail()
+        {
+            // Size that requires scalar tail processing
+            var size = 35;  // 32 + 3 tail for bytes
+            var cond = np.ones(size, NPTypeCode.Boolean);
+            var x = np.full(size, (byte)255);
+            var y = np.zeros(size, NPTypeCode.Byte);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                Assert.AreEqual((byte)255, (byte)result[i], $"Mismatch at {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_AllTrue()
+        {
+            var size = 100;
+            var cond = np.ones(size, NPTypeCode.Boolean);
+            var x = np.arange(size);
+            var y = np.full(size, -1L);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                Assert.AreEqual((long)i, (long)result[i]);
+            }
+        }
+
+        [Test]
+        public void Where_Simd_AllFalse()
+        {
+            var size = 100;
+            var cond = np.zeros(size, NPTypeCode.Boolean);
+            var x = np.arange(size);
+            var y = np.full(size, -1L);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                Assert.AreEqual(-1L, (long)result[i]);
+            }
+        }
+
+        [Test]
+        public void Where_Simd_Alternating()
+        {
+            var size = 100;
+            var condData = new bool[size];
+            for (int i = 0; i < size; i++)
+                condData[i] = i % 2 == 0;
+            var cond = np.array(condData);
+            var x = np.ones(size, NPTypeCode.Int32);
+            var y = np.zeros(size, NPTypeCode.Int32);
+
+            var result = np.where(cond, x, y);
+
+            for (int i = 0; i < size; i++)
+            {
+                Assert.AreEqual(i % 2 == 0 ? 1 : 0, (int)result[i], $"Mismatch at {i}");
+            }
+        }
+
+        [Test]
+        public void Where_Simd_NaN_Propagates()
+        {
+            var cond = np.array(new[] { true, false, true });
+            var x = np.array(new[] { double.NaN, 1.0, 2.0 });
+            var y = np.array(new[] { 0.0, double.NaN, 0.0 });
+
+            var result = np.where(cond, x, y);
+
+            Assert.IsTrue(double.IsNaN((double)result[0]));  // NaN from x
+            Assert.IsTrue(double.IsNaN((double)result[1]));  // NaN from y
+            Assert.AreEqual(2.0, (double)result[2], 1e-10);
+        }
+
+        [Test]
+        public void Where_Simd_Infinity()
+        {
+            var cond = np.array(new[] { true, false, true, false });
+            var x = np.array(new[] { double.PositiveInfinity, 0.0, double.NegativeInfinity, 0.0 });
+            var y = np.array(new[] { 0.0, double.PositiveInfinity, 0.0, double.NegativeInfinity });
+
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(double.PositiveInfinity, (double)result[0]);
+            Assert.AreEqual(double.PositiveInfinity, (double)result[1]);
+            Assert.AreEqual(double.NegativeInfinity, (double)result[2]);
+            Assert.AreEqual(double.NegativeInfinity, (double)result[3]);
+        }
+
+        #endregion
+
+        #region Performance Sanity Check
+
+        [Test]
+        public void Where_Simd_LargeArray_Correctness()
+        {
+            var rng = np.random.RandomState(54);
+            var size = 100_000;
+            var cond = rng.rand(size) > 0.5;
+            var x = np.ones(size, NPTypeCode.Double);
+            var y = np.zeros(size, NPTypeCode.Double);
+
+            var result = np.where(cond, x, y);
+
+            // Spot check
+            for (int i = 0; i < 100; i++)
+            {
+                var expected = (bool)cond[i] ? 1.0 : 0.0;
+                Assert.AreEqual(expected, (double)result[i], 1e-10);
+            }
+
+            // Check last few elements (scalar tail)
+            for (int i = size - 10; i < size; i++)
+            {
+                var expected = (bool)cond[i] ? 1.0 : 0.0;
+                Assert.AreEqual(expected, (double)result[i], 1e-10);
+            }
+        }
+
+        #endregion
+
+        #region 2D/Multi-dimensional
+
+        [Test]
+        public void Where_Simd_2D_Contiguous()
+        {
+            var rng = np.random.RandomState(55);
+            // 2D contiguous array should use SIMD
+            var shape = new[] { 100, 100 };
+            var cond = rng.rand(shape) > 0.5;
+            var x = np.ones(shape, NPTypeCode.Int32);
+            var y = np.zeros(shape, NPTypeCode.Int32);
+
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(100, 100);
+
+            // Spot check
+            for (int i = 0; i < 10; i++)
+            {
+                for (int j = 0; j < 10; j++)
+                {
+                    var expected = (bool)cond[i, j] ? 1 : 0;
+                    Assert.AreEqual(expected, (int)result[i, j]);
+                }
+            }
+        }
+
+        [Test]
+        public void Where_Simd_3D_Contiguous()
+        {
+            var rng = np.random.RandomState(56);
+            var shape = new[] { 10, 20, 30 };
+            var cond = rng.rand(shape) > 0.5;
+            var x = np.ones(shape, NPTypeCode.Single);
+            var y = np.zeros(shape, NPTypeCode.Single);
+
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(10, 20, 30);
+
+            // Spot check
+            for (int i = 0; i < 5; i++)
+            {
+                for (int j = 0; j < 5; j++)
+                {
+                    for (int k = 0; k < 5; k++)
+                    {
+                        var expected = (bool)cond[i, j, k] ? 1.0f : 0.0f;
+                        Assert.AreEqual(expected, (float)result[i, j, k], 1e-6f);
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/NumSharp.UnitTest/Backends/Kernels/WhereSimdTests.cs
+++ b/test/NumSharp.UnitTest/Backends/Kernels/WhereSimdTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using NumSharp.Backends.Kernels;
-using TUnit.Core;
 using NumSharp.UnitTest.Utilities;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
@@ -11,11 +10,12 @@ namespace NumSharp.UnitTest.Backends.Kernels
     /// Tests for SIMD-optimized np.where implementation.
     /// Verifies correctness of the SIMD path for all supported dtypes.
     /// </summary>
+    [TestClass]
     public class WhereSimdTests
     {
         #region SIMD Correctness
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Float32_Correctness()
         {
             var rng = np.random.RandomState(42);
@@ -34,7 +34,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Float64_Correctness()
         {
             var rng = np.random.RandomState(43);
@@ -52,7 +52,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Int32_Correctness()
         {
             var rng = np.random.RandomState(44);
@@ -70,7 +70,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Int64_Correctness()
         {
             var rng = np.random.RandomState(45);
@@ -88,7 +88,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Byte_Correctness()
         {
             var rng = np.random.RandomState(46);
@@ -106,7 +106,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Int16_Correctness()
         {
             var rng = np.random.RandomState(47);
@@ -124,7 +124,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_UInt16_Correctness()
         {
             var rng = np.random.RandomState(48);
@@ -142,7 +142,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_UInt32_Correctness()
         {
             var rng = np.random.RandomState(49);
@@ -160,7 +160,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_UInt64_Correctness()
         {
             var rng = np.random.RandomState(50);
@@ -178,7 +178,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Boolean_Correctness()
         {
             var rng = np.random.RandomState(51);
@@ -196,7 +196,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Char_Correctness()
         {
             var rng = np.random.RandomState(52);
@@ -225,7 +225,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
 
         #region Path Selection
 
-        [Test]
+        [TestMethod]
         public void Where_NonContiguous_Works()
         {
             // Sliced arrays are non-contiguous, should work correctly
@@ -244,7 +244,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Broadcast_Works()
         {
             // Broadcasted arrays
@@ -265,7 +265,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             Assert.AreEqual(20, (int)result[1, 1]);  // cond[1]=false -> y=20
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Decimal_Works()
         {
             var cond = np.array(new[] { true, false, true });
@@ -280,7 +280,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             Assert.AreEqual(3.3m, (decimal)result[2]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_NonBoolCondition_Works()
         {
             // Non-bool condition requires truthiness check
@@ -294,7 +294,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
 
         #region Edge Cases
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_SmallArray()
         {
             // Array smaller than vector width
@@ -307,7 +307,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             result.Should().BeOfValues(1, 20, 3);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_VectorAlignedSize()
         {
             var rng = np.random.RandomState(53);
@@ -327,7 +327,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_WithScalarTail()
         {
             // Size that requires scalar tail processing
@@ -344,7 +344,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_AllTrue()
         {
             var size = 100;
@@ -360,7 +360,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_AllFalse()
         {
             var size = 100;
@@ -376,7 +376,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Alternating()
         {
             var size = 100;
@@ -395,7 +395,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_NaN_Propagates()
         {
             var cond = np.array(new[] { true, false, true });
@@ -409,7 +409,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             Assert.AreEqual(2.0, (double)result[2], 1e-10);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_Infinity()
         {
             var cond = np.array(new[] { true, false, true, false });
@@ -428,7 +428,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
 
         #region Performance Sanity Check
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_LargeArray_Correctness()
         {
             var rng = np.random.RandomState(54);
@@ -458,7 +458,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
 
         #region 2D/Multi-dimensional
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_2D_Contiguous()
         {
             var rng = np.random.RandomState(55);
@@ -483,7 +483,7 @@ namespace NumSharp.UnitTest.Backends.Kernels
             }
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Simd_3D_Contiguous()
         {
             var rng = np.random.RandomState(56);

--- a/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
+++ b/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
@@ -11,11 +11,12 @@ namespace NumSharp.UnitTest.Creation
     /// <summary>
     /// Tests for np.asanyarray covering all built-in C# collection types.
     /// </summary>
+    [TestClass]
     public class np_asanyarray_tests
     {
         #region NDArray passthrough
 
-        [Test]
+        [TestMethod]
         public void NDArray_ReturnsAsIs()
         {
             var original = np.array(1, 2, 3, 4, 5);
@@ -25,7 +26,7 @@ namespace NumSharp.UnitTest.Creation
             ReferenceEquals(original, result).Should().BeTrue();
         }
 
-        [Test]
+        [TestMethod]
         public void NDArray_WithDtype_ReturnsConverted()
         {
             var original = np.array(1, 2, 3, 4, 5);
@@ -35,7 +36,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5);
         }
 
-        [Test]
+        [TestMethod]
         public void NDArray_WithSameDtype_ReturnsAsIs()
         {
             var original = np.array(1, 2, 3, 4, 5);
@@ -49,7 +50,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region Array types
 
-        [Test]
+        [TestMethod]
         public void Array_1D()
         {
             var arr = new int[] { 1, 2, 3, 4, 5 };
@@ -59,7 +60,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(int));
         }
 
-        [Test]
+        [TestMethod]
         public void Array_2D()
         {
             var arr = new int[,] { { 1, 2, 3 }, { 4, 5, 6 } };
@@ -68,7 +69,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(2, 3).And.BeOfValues(1, 2, 3, 4, 5, 6);
         }
 
-        [Test]
+        [TestMethod]
         public void Array_WithDtype()
         {
             var arr = new int[] { 1, 2, 3 };
@@ -82,7 +83,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region Scalars
 
-        [Test]
+        [TestMethod]
         public void Scalar_Int()
         {
             var result = np.asanyarray(42);
@@ -91,7 +92,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(int));
         }
 
-        [Test]
+        [TestMethod]
         public void Scalar_Double()
         {
             var result = np.asanyarray(3.14);
@@ -100,7 +101,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(double));
         }
 
-        [Test]
+        [TestMethod]
         public void Scalar_Decimal()
         {
             var result = np.asanyarray(123.456m);
@@ -109,7 +110,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(decimal));
         }
 
-        [Test]
+        [TestMethod]
         public void Scalar_Bool()
         {
             var result = np.asanyarray(true);
@@ -122,7 +123,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region List<T>
 
-        [Test]
+        [TestMethod]
         public void List_Int()
         {
             var list = new List<int> { 1, 2, 3, 4, 5 };
@@ -132,7 +133,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(int));
         }
 
-        [Test]
+        [TestMethod]
         public void List_Double()
         {
             var list = new List<double> { 1.1, 2.2, 3.3 };
@@ -142,7 +143,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(double));
         }
 
-        [Test]
+        [TestMethod]
         public void List_Bool()
         {
             var list = new List<bool> { true, false, true };
@@ -152,7 +153,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(bool));
         }
 
-        [Test]
+        [TestMethod]
         public void List_Empty()
         {
             var list = new List<int>();
@@ -162,7 +163,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(int));
         }
 
-        [Test]
+        [TestMethod]
         public void List_WithDtype()
         {
             var list = new List<int> { 1, 2, 3 };
@@ -176,7 +177,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region IList<T> / ICollection<T> / IEnumerable<T>
 
-        [Test]
+        [TestMethod]
         public void IList_Int()
         {
             IList<int> list = new List<int> { 1, 2, 3, 4, 5 };
@@ -185,7 +186,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
         }
 
-        [Test]
+        [TestMethod]
         public void ICollection_Int()
         {
             ICollection<int> collection = new List<int> { 1, 2, 3, 4, 5 };
@@ -194,7 +195,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
         }
 
-        [Test]
+        [TestMethod]
         public void IEnumerable_Int()
         {
             IEnumerable<int> enumerable = new List<int> { 1, 2, 3, 4, 5 };
@@ -203,7 +204,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
         }
 
-        [Test]
+        [TestMethod]
         public void IEnumerable_FromLinq()
         {
             var enumerable = Enumerable.Range(1, 5);
@@ -212,7 +213,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
         }
 
-        [Test]
+        [TestMethod]
         public void IEnumerable_FromLinqSelect()
         {
             var enumerable = new[] { 1, 2, 3 }.Select(x => x * 2);
@@ -225,7 +226,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region IReadOnlyList<T> / IReadOnlyCollection<T>
 
-        [Test]
+        [TestMethod]
         public void IReadOnlyList_Int()
         {
             IReadOnlyList<int> list = new List<int> { 1, 2, 3, 4, 5 };
@@ -234,7 +235,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
         }
 
-        [Test]
+        [TestMethod]
         public void IReadOnlyCollection_Int()
         {
             IReadOnlyCollection<int> collection = new List<int> { 1, 2, 3, 4, 5 };
@@ -247,7 +248,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region ReadOnlyCollection<T>
 
-        [Test]
+        [TestMethod]
         public void ReadOnlyCollection_Int()
         {
             var collection = new ReadOnlyCollection<int>(new List<int> { 1, 2, 3, 4, 5 });
@@ -260,7 +261,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region LinkedList<T>
 
-        [Test]
+        [TestMethod]
         public void LinkedList_Int()
         {
             var linkedList = new LinkedList<int>();
@@ -276,7 +277,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region HashSet<T> / SortedSet<T>
 
-        [Test]
+        [TestMethod]
         public void HashSet_Int()
         {
             var set = new HashSet<int> { 3, 1, 4, 1, 5, 9 }; // Duplicates removed
@@ -286,7 +287,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(int));
         }
 
-        [Test]
+        [TestMethod]
         public void SortedSet_Int()
         {
             var set = new SortedSet<int> { 3, 1, 4, 1, 5, 9 };
@@ -299,7 +300,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region Queue<T> / Stack<T>
 
-        [Test]
+        [TestMethod]
         public void Queue_Int()
         {
             var queue = new Queue<int>();
@@ -311,7 +312,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(3).And.BeOfValues(1, 2, 3);
         }
 
-        [Test]
+        [TestMethod]
         public void Stack_Int()
         {
             var stack = new Stack<int>();
@@ -327,7 +328,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region ArraySegment<T>
 
-        [Test]
+        [TestMethod]
         public void ArraySegment_Int()
         {
             var array = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -337,7 +338,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5).And.BeOfValues(2, 3, 4, 5, 6);
         }
 
-        [Test]
+        [TestMethod]
         public void ArraySegment_Empty()
         {
             var array = new int[] { 1, 2, 3 };
@@ -347,7 +348,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(0);
         }
 
-        [Test]
+        [TestMethod]
         public void ArraySegment_Full()
         {
             var array = new int[] { 1, 2, 3, 4, 5 };
@@ -361,7 +362,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region Memory<T> / ReadOnlyMemory<T>
 
-        [Test]
+        [TestMethod]
         public void Memory_Int()
         {
             var array = new int[] { 1, 2, 3, 4, 5 };
@@ -371,7 +372,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(3).And.BeOfValues(2, 3, 4);
         }
 
-        [Test]
+        [TestMethod]
         public void ReadOnlyMemory_Int()
         {
             var array = new int[] { 1, 2, 3, 4, 5 };
@@ -385,7 +386,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region ImmutableArray<T> / ImmutableList<T>
 
-        [Test]
+        [TestMethod]
         public void ImmutableArray_Int()
         {
             var immutableArray = ImmutableArray.Create(1, 2, 3, 4, 5);
@@ -394,7 +395,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
         }
 
-        [Test]
+        [TestMethod]
         public void ImmutableList_Int()
         {
             var immutableList = ImmutableList.Create(1, 2, 3, 4, 5);
@@ -403,7 +404,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
         }
 
-        [Test]
+        [TestMethod]
         public void ImmutableHashSet_Int()
         {
             var immutableSet = ImmutableHashSet.Create(3, 1, 4, 1, 5);
@@ -416,7 +417,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region All supported dtypes via List<T>
 
-        [Test]
+        [TestMethod]
         public void List_Byte()
         {
             var list = new List<byte> { 1, 2, 3 };
@@ -427,7 +428,7 @@ namespace NumSharp.UnitTest.Creation
 
         // Note: sbyte is NOT supported by NumSharp (12 supported types: bool, byte, short, ushort, int, uint, long, ulong, char, float, double, decimal)
 
-        [Test]
+        [TestMethod]
         public void List_Short()
         {
             var list = new List<short> { 1, 2, 3 };
@@ -436,7 +437,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(3);
         }
 
-        [Test]
+        [TestMethod]
         public void List_UShort()
         {
             var list = new List<ushort> { 1, 2, 3 };
@@ -445,7 +446,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(3);
         }
 
-        [Test]
+        [TestMethod]
         public void List_UInt()
         {
             var list = new List<uint> { 1, 2, 3 };
@@ -454,7 +455,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(3);
         }
 
-        [Test]
+        [TestMethod]
         public void List_Long()
         {
             var list = new List<long> { 1, 2, 3 };
@@ -463,7 +464,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(3);
         }
 
-        [Test]
+        [TestMethod]
         public void List_ULong()
         {
             var list = new List<ulong> { 1, 2, 3 };
@@ -472,7 +473,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(3);
         }
 
-        [Test]
+        [TestMethod]
         public void List_Float()
         {
             var list = new List<float> { 1.1f, 2.2f, 3.3f };
@@ -481,7 +482,7 @@ namespace NumSharp.UnitTest.Creation
             result.Should().BeShaped(3);
         }
 
-        [Test]
+        [TestMethod]
         public void List_Char()
         {
             var list = new List<char> { 'a', 'b', 'c' };
@@ -494,13 +495,13 @@ namespace NumSharp.UnitTest.Creation
 
         #region Error cases
 
-        [Test]
+        [TestMethod]
         public void Null_ThrowsArgumentNullException()
         {
             Assert.ThrowsException<ArgumentNullException>(() => np.asanyarray(null));
         }
 
-        [Test]
+        [TestMethod]
         public void UnsupportedType_ThrowsNotSupportedException()
         {
             // String collections are not supported (string is not primitive/decimal)
@@ -508,7 +509,7 @@ namespace NumSharp.UnitTest.Creation
             Assert.ThrowsException<NotSupportedException>(() => np.asanyarray(stringList));
         }
 
-        [Test]
+        [TestMethod]
         public void CustomClass_ThrowsNotSupportedException()
         {
             var customObject = new object();
@@ -519,7 +520,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region String special case
 
-        [Test]
+        [TestMethod]
         public void String_CreatesCharArray()
         {
             var result = np.asanyarray("hello");
@@ -532,7 +533,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region Non-generic IEnumerable fallback
 
-        [Test]
+        [TestMethod]
         public void ArrayList_Int()
         {
             var arrayList = new System.Collections.ArrayList { 1, 2, 3, 4, 5 };
@@ -542,7 +543,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(int));
         }
 
-        [Test]
+        [TestMethod]
         public void ArrayList_Double()
         {
             var arrayList = new System.Collections.ArrayList { 1.1, 2.2, 3.3 };
@@ -552,7 +553,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(double));
         }
 
-        [Test]
+        [TestMethod]
         public void Hashtable_Keys()
         {
             var hashtable = new System.Collections.Hashtable { { 1, "a" }, { 2, "b" }, { 3, "c" } };
@@ -566,7 +567,7 @@ namespace NumSharp.UnitTest.Creation
 
         #region IEnumerator fallback
 
-        [Test]
+        [TestMethod]
         public void IEnumerator_Int()
         {
             static System.Collections.IEnumerator GetEnumerator()
@@ -591,7 +592,7 @@ namespace NumSharp.UnitTest.Creation
         /// NumPy: np.asanyarray("hello") -> dtype=&lt;U5, shape=(), ndim=0 (SCALAR)
         /// NumSharp: dtype=Char, shape=(5), ndim=1 (ARRAY)
         /// </summary>
-        [Test]
+        [TestMethod]
         [Misaligned]
         public void String_IsCharArray_NotScalar()
         {
@@ -611,7 +612,7 @@ namespace NumSharp.UnitTest.Creation
         /// NumPy: np.asanyarray({1,2,3}) -> dtype=object, shape=() (SCALAR)
         /// NumSharp: dtype=Int32, shape=(3) (ARRAY)
         /// </summary>
-        [Test]
+        [TestMethod]
         [Misaligned]
         public void HashSet_IsIterated_NotObjectScalar()
         {
@@ -631,7 +632,7 @@ namespace NumSharp.UnitTest.Creation
         /// NumSharp consumes IEnumerable and converts to array.
         /// This is arguably more useful behavior for C#.
         /// </summary>
-        [Test]
+        [TestMethod]
         [Misaligned]
         public void LinqEnumerable_IsConsumed_NotObjectScalar()
         {
@@ -650,7 +651,7 @@ namespace NumSharp.UnitTest.Creation
         /// NumPy defaults to float64 for untyped empty lists.
         /// This is a design choice: C# generics provide type information that NumPy doesn't have.
         /// </summary>
-        [Test]
+        [TestMethod]
         [Misaligned]
         public void EmptyTypedList_PreservesTypeParameter()
         {
@@ -672,7 +673,7 @@ namespace NumSharp.UnitTest.Creation
         /// C# ValueTuples are iterable like Python tuples.
         /// NumPy: np.asanyarray((1,2,3)) -> dtype=int64, shape=(3,)
         /// </summary>
-        [Test]
+        [TestMethod]
         public void ValueTuple_IsIterable()
         {
             var tuple = (1, 2, 3);
@@ -685,7 +686,7 @@ namespace NumSharp.UnitTest.Creation
         /// <summary>
         /// C# Tuple class is iterable like Python tuples.
         /// </summary>
-        [Test]
+        [TestMethod]
         public void Tuple_IsIterable()
         {
             var tuple = Tuple.Create(1, 2, 3);
@@ -695,7 +696,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(int));
         }
 
-        [Test]
+        [TestMethod]
         public void ValueTuple_MixedTypes_PromotesToCommonType()
         {
             // Mixed int + double promotes to double (NumPy behavior)
@@ -706,7 +707,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(double)); // Promoted from int to double
         }
 
-        [Test]
+        [TestMethod]
         public void ValueTuple_IntAndBool_PromotesToInt()
         {
             // Mixed int + bool promotes to int (NumPy behavior)
@@ -717,7 +718,7 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(int));
         }
 
-        [Test]
+        [TestMethod]
         public void EmptyTuple_ReturnsEmptyDoubleArray()
         {
             var tuple = ValueTuple.Create();
@@ -734,7 +735,7 @@ namespace NumSharp.UnitTest.Creation
         /// <summary>
         /// Empty non-generic collections return empty double[] (NumPy defaults to float64).
         /// </summary>
-        [Test]
+        [TestMethod]
         public void EmptyArrayList_ReturnsEmptyDoubleArray()
         {
             var arrayList = new System.Collections.ArrayList();

--- a/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
+++ b/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
@@ -747,5 +747,50 @@ namespace NumSharp.UnitTest.Creation
         }
 
         #endregion
+
+        #region object[] regression
+
+        [TestMethod]
+        public void ObjectArray_Homogeneous_Int()
+        {
+            var arr = new object[] { 1, 2, 3 };
+            var result = np.asanyarray(arr);
+
+            result.dtype.Should().Be(typeof(int));
+            result.Should().BeShaped(3).And.BeOfValues(1, 2, 3);
+        }
+
+        [TestMethod]
+        public void ObjectArray_MixedIntFloat_PromotesToDouble()
+        {
+            var arr = new object[] { 1, 2.5, 3 };
+            var result = np.asanyarray(arr);
+
+            result.dtype.Should().Be(typeof(double));
+            result.Should().BeShaped(3).And.BeOfValues(1.0, 2.5, 3.0);
+        }
+
+        [TestMethod]
+        public void ObjectArray_MixedBoolInt_PromotesToInt()
+        {
+            var arr = new object[] { true, 2, false };
+            var result = np.asanyarray(arr);
+
+            result.dtype.Should().Be(typeof(int));
+            result.Should().BeShaped(3).And.BeOfValues(1, 2, 0);
+        }
+
+        [TestMethod]
+        public void ObjectArray_Empty_ReturnsFloat64()
+        {
+            var arr = new object[0];
+            var result = np.asanyarray(arr);
+
+            result.size.Should().Be(0);
+            result.ndim.Should().Be(1);
+            result.dtype.Should().Be(typeof(double));
+        }
+
+        #endregion
     }
 }

--- a/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
+++ b/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
@@ -583,5 +583,157 @@ namespace NumSharp.UnitTest.Creation
         }
 
         #endregion
+
+        #region NumPy Parity - Misaligned Behaviors
+
+        /// <summary>
+        /// NumPy treats strings as scalar Unicode values, NumSharp treats as char arrays.
+        /// NumPy: np.asanyarray("hello") -> dtype=&lt;U5, shape=(), ndim=0 (SCALAR)
+        /// NumSharp: dtype=Char, shape=(5), ndim=1 (ARRAY)
+        /// </summary>
+        [Test]
+        [Misaligned]
+        public void String_IsCharArray_NotScalar()
+        {
+            var result = np.asanyarray("hello");
+
+            // NumSharp behavior: char array
+            result.ndim.Should().Be(1);
+            result.shape.Should().BeEquivalentTo(new[] { 5 });
+            result.dtype.Should().Be(typeof(char));
+
+            // NumPy would be: ndim=0, shape=(), dtype=<U5 (scalar)
+        }
+
+        /// <summary>
+        /// NumPy stores sets as object scalars (not iterated).
+        /// NumSharp iterates sets and converts to array.
+        /// NumPy: np.asanyarray({1,2,3}) -> dtype=object, shape=() (SCALAR)
+        /// NumSharp: dtype=Int32, shape=(3) (ARRAY)
+        /// </summary>
+        [Test]
+        [Misaligned]
+        public void HashSet_IsIterated_NotObjectScalar()
+        {
+            var set = new HashSet<int> { 1, 2, 3 };
+            var result = np.asanyarray(set);
+
+            // NumSharp behavior: iterates and creates array
+            result.ndim.Should().Be(1);
+            result.size.Should().Be(3);
+            result.dtype.Should().Be(typeof(int));
+
+            // NumPy would be: dtype=object, shape=() (object scalar containing set)
+        }
+
+        /// <summary>
+        /// NumPy stores generators as object scalars (NOT consumed).
+        /// NumSharp consumes IEnumerable and converts to array.
+        /// This is arguably more useful behavior for C#.
+        /// </summary>
+        [Test]
+        [Misaligned]
+        public void LinqEnumerable_IsConsumed_NotObjectScalar()
+        {
+            var enumerable = new[] { 1, 2, 3 }.Select(x => x * 2);
+            var result = np.asanyarray(enumerable);
+
+            // NumSharp behavior: consumes and creates array
+            result.ndim.Should().Be(1);
+            result.Should().BeShaped(3).And.BeOfValues(2, 4, 6);
+
+            // NumPy generator would be: dtype=object, shape=() (NOT consumed)
+        }
+
+        /// <summary>
+        /// For typed empty collections (List&lt;T&gt;), NumSharp preserves the generic type parameter.
+        /// NumPy defaults to float64 for untyped empty lists.
+        /// This is a design choice: C# generics provide type information that NumPy doesn't have.
+        /// </summary>
+        [Test]
+        [Misaligned]
+        public void EmptyTypedList_PreservesTypeParameter()
+        {
+            var result = np.asanyarray(new List<int>());
+
+            // NumSharp behavior: preserves int dtype from generic type parameter
+            result.dtype.Should().Be(typeof(int));
+            result.shape.Should().BeEquivalentTo(new[] { 0 });
+
+            // NumPy would be: dtype=float64, shape=(0,)
+            // NumSharp can do better because C# generics provide the type at compile time
+        }
+
+        #endregion
+
+        #region Tuple support
+
+        /// <summary>
+        /// C# ValueTuples are iterable like Python tuples.
+        /// NumPy: np.asanyarray((1,2,3)) -> dtype=int64, shape=(3,)
+        /// </summary>
+        [Test]
+        public void ValueTuple_IsIterable()
+        {
+            var tuple = (1, 2, 3);
+            var result = np.asanyarray(tuple);
+
+            result.Should().BeShaped(3).And.BeOfValues(1, 2, 3);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        /// <summary>
+        /// C# Tuple class is iterable like Python tuples.
+        /// </summary>
+        [Test]
+        public void Tuple_IsIterable()
+        {
+            var tuple = Tuple.Create(1, 2, 3);
+            var result = np.asanyarray(tuple);
+
+            result.Should().BeShaped(3).And.BeOfValues(1, 2, 3);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        [Test]
+        public void ValueTuple_MixedTypes_UsesFirstElementType()
+        {
+            // Mixed tuple - type is detected from first element
+            var tuple = (1.5, 2.5, 3.5);
+            var result = np.asanyarray(tuple);
+
+            result.Should().BeShaped(3);
+            result.dtype.Should().Be(typeof(double));
+        }
+
+        [Test]
+        public void EmptyTuple_ReturnsEmptyDoubleArray()
+        {
+            var tuple = ValueTuple.Create();
+            var result = np.asanyarray(tuple);
+
+            result.Should().BeShaped(0);
+            result.dtype.Should().Be(typeof(double));
+        }
+
+        #endregion
+
+        #region Empty non-generic collections
+
+        /// <summary>
+        /// Empty non-generic collections return empty double[] (NumPy defaults to float64).
+        /// </summary>
+        [Test]
+        public void EmptyArrayList_ReturnsEmptyDoubleArray()
+        {
+            var arrayList = new System.Collections.ArrayList();
+            var result = np.asanyarray(arrayList);
+
+            result.size.Should().Be(0);
+            result.ndim.Should().Be(1);
+            result.dtype.Should().Be(typeof(double)); // NumPy: float64
+        }
+
+        #endregion
     }
 }

--- a/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
+++ b/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
@@ -696,14 +696,25 @@ namespace NumSharp.UnitTest.Creation
         }
 
         [Test]
-        public void ValueTuple_MixedTypes_UsesFirstElementType()
+        public void ValueTuple_MixedTypes_PromotesToCommonType()
         {
-            // Mixed tuple - type is detected from first element
-            var tuple = (1.5, 2.5, 3.5);
+            // Mixed int + double promotes to double (NumPy behavior)
+            var tuple = (1, 2.5, 3);
             var result = np.asanyarray(tuple);
 
             result.Should().BeShaped(3);
-            result.dtype.Should().Be(typeof(double));
+            result.dtype.Should().Be(typeof(double)); // Promoted from int to double
+        }
+
+        [Test]
+        public void ValueTuple_IntAndBool_PromotesToInt()
+        {
+            // Mixed int + bool promotes to int (NumPy behavior)
+            var tuple = (1, true, 3);
+            var result = np.asanyarray(tuple);
+
+            result.Should().BeShaped(3);
+            result.dtype.Should().Be(typeof(int));
         }
 
         [Test]

--- a/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
+++ b/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
@@ -791,6 +791,29 @@ namespace NumSharp.UnitTest.Creation
             result.dtype.Should().Be(typeof(double));
         }
 
+        [TestMethod]
+        public void ObjectArray_AllFloat_PreservesSingle()
+        {
+            // Regression: an earlier FindCommonNumericType short-circuit promoted any float
+            // to double. NumPy preserves float32 for homogeneous float32 inputs.
+            var arr = new object[] { 1.5f, 2.5f, 3.5f };
+            var result = np.asanyarray(arr);
+
+            result.dtype.Should().Be(typeof(float));
+            result.Should().BeShaped(3).And.BeOfValues(1.5f, 2.5f, 3.5f);
+        }
+
+        [TestMethod]
+        public void ObjectArray_MixedIntAndFloat32_PromotesToDouble()
+        {
+            // int + float32 -> float64 per NumPy NEP50.
+            var arr = new object[] { 1, 2.5f, 3 };
+            var result = np.asanyarray(arr);
+
+            result.dtype.Should().Be(typeof(double));
+            result.Should().BeShaped(3);
+        }
+
         #endregion
     }
 }

--- a/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
+++ b/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
@@ -1,0 +1,533 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Linq;
+using AwesomeAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NumSharp.UnitTest.Creation
+{
+    /// <summary>
+    /// Tests for np.asanyarray covering all built-in C# collection types.
+    /// </summary>
+    public class np_asanyarray_tests
+    {
+        #region NDArray passthrough
+
+        [Test]
+        public void NDArray_ReturnsAsIs()
+        {
+            var original = np.array(1, 2, 3, 4, 5);
+            var result = np.asanyarray(original);
+
+            // Should return the same instance (no copy)
+            ReferenceEquals(original, result).Should().BeTrue();
+        }
+
+        [Test]
+        public void NDArray_WithDtype_ReturnsConverted()
+        {
+            var original = np.array(1, 2, 3, 4, 5);
+            var result = np.asanyarray(original, typeof(double));
+
+            result.dtype.Should().Be(typeof(double));
+            result.Should().BeShaped(5);
+        }
+
+        [Test]
+        public void NDArray_WithSameDtype_ReturnsAsIs()
+        {
+            var original = np.array(1, 2, 3, 4, 5);
+            var result = np.asanyarray(original, typeof(int));
+
+            // Same dtype, should return same instance
+            ReferenceEquals(original, result).Should().BeTrue();
+        }
+
+        #endregion
+
+        #region Array types
+
+        [Test]
+        public void Array_1D()
+        {
+            var arr = new int[] { 1, 2, 3, 4, 5 };
+            var result = np.asanyarray(arr);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        [Test]
+        public void Array_2D()
+        {
+            var arr = new int[,] { { 1, 2, 3 }, { 4, 5, 6 } };
+            var result = np.asanyarray(arr);
+
+            result.Should().BeShaped(2, 3).And.BeOfValues(1, 2, 3, 4, 5, 6);
+        }
+
+        [Test]
+        public void Array_WithDtype()
+        {
+            var arr = new int[] { 1, 2, 3 };
+            var result = np.asanyarray(arr, typeof(double));
+
+            result.dtype.Should().Be(typeof(double));
+            result.Should().BeShaped(3);
+        }
+
+        #endregion
+
+        #region Scalars
+
+        [Test]
+        public void Scalar_Int()
+        {
+            var result = np.asanyarray(42);
+
+            result.Should().BeScalar().And.BeOfValues(42);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        [Test]
+        public void Scalar_Double()
+        {
+            var result = np.asanyarray(3.14);
+
+            result.Should().BeScalar();
+            result.dtype.Should().Be(typeof(double));
+        }
+
+        [Test]
+        public void Scalar_Decimal()
+        {
+            var result = np.asanyarray(123.456m);
+
+            result.Should().BeScalar();
+            result.dtype.Should().Be(typeof(decimal));
+        }
+
+        [Test]
+        public void Scalar_Bool()
+        {
+            var result = np.asanyarray(true);
+
+            result.Should().BeScalar().And.BeOfValues(true);
+            result.dtype.Should().Be(typeof(bool));
+        }
+
+        #endregion
+
+        #region List<T>
+
+        [Test]
+        public void List_Int()
+        {
+            var list = new List<int> { 1, 2, 3, 4, 5 };
+            var result = np.asanyarray(list);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        [Test]
+        public void List_Double()
+        {
+            var list = new List<double> { 1.1, 2.2, 3.3 };
+            var result = np.asanyarray(list);
+
+            result.Should().BeShaped(3);
+            result.dtype.Should().Be(typeof(double));
+        }
+
+        [Test]
+        public void List_Bool()
+        {
+            var list = new List<bool> { true, false, true };
+            var result = np.asanyarray(list);
+
+            result.Should().BeShaped(3).And.BeOfValues(true, false, true);
+            result.dtype.Should().Be(typeof(bool));
+        }
+
+        [Test]
+        public void List_Empty()
+        {
+            var list = new List<int>();
+            var result = np.asanyarray(list);
+
+            result.Should().BeShaped(0);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        [Test]
+        public void List_WithDtype()
+        {
+            var list = new List<int> { 1, 2, 3 };
+            var result = np.asanyarray(list, typeof(float));
+
+            result.dtype.Should().Be(typeof(float));
+            result.Should().BeShaped(3);
+        }
+
+        #endregion
+
+        #region IList<T> / ICollection<T> / IEnumerable<T>
+
+        [Test]
+        public void IList_Int()
+        {
+            IList<int> list = new List<int> { 1, 2, 3, 4, 5 };
+            var result = np.asanyarray(list);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        [Test]
+        public void ICollection_Int()
+        {
+            ICollection<int> collection = new List<int> { 1, 2, 3, 4, 5 };
+            var result = np.asanyarray(collection);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        [Test]
+        public void IEnumerable_Int()
+        {
+            IEnumerable<int> enumerable = new List<int> { 1, 2, 3, 4, 5 };
+            var result = np.asanyarray(enumerable);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        [Test]
+        public void IEnumerable_FromLinq()
+        {
+            var enumerable = Enumerable.Range(1, 5);
+            var result = np.asanyarray(enumerable);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        [Test]
+        public void IEnumerable_FromLinqSelect()
+        {
+            var enumerable = new[] { 1, 2, 3 }.Select(x => x * 2);
+            var result = np.asanyarray(enumerable);
+
+            result.Should().BeShaped(3).And.BeOfValues(2, 4, 6);
+        }
+
+        #endregion
+
+        #region IReadOnlyList<T> / IReadOnlyCollection<T>
+
+        [Test]
+        public void IReadOnlyList_Int()
+        {
+            IReadOnlyList<int> list = new List<int> { 1, 2, 3, 4, 5 };
+            var result = np.asanyarray(list);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        [Test]
+        public void IReadOnlyCollection_Int()
+        {
+            IReadOnlyCollection<int> collection = new List<int> { 1, 2, 3, 4, 5 };
+            var result = np.asanyarray(collection);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        #endregion
+
+        #region ReadOnlyCollection<T>
+
+        [Test]
+        public void ReadOnlyCollection_Int()
+        {
+            var collection = new ReadOnlyCollection<int>(new List<int> { 1, 2, 3, 4, 5 });
+            var result = np.asanyarray(collection);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        #endregion
+
+        #region LinkedList<T>
+
+        [Test]
+        public void LinkedList_Int()
+        {
+            var linkedList = new LinkedList<int>();
+            linkedList.AddLast(1);
+            linkedList.AddLast(2);
+            linkedList.AddLast(3);
+            var result = np.asanyarray(linkedList);
+
+            result.Should().BeShaped(3).And.BeOfValues(1, 2, 3);
+        }
+
+        #endregion
+
+        #region HashSet<T> / SortedSet<T>
+
+        [Test]
+        public void HashSet_Int()
+        {
+            var set = new HashSet<int> { 3, 1, 4, 1, 5, 9 }; // Duplicates removed
+            var result = np.asanyarray(set);
+
+            result.size.Should().Be(5); // 1, 3, 4, 5, 9 (no duplicates)
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        [Test]
+        public void SortedSet_Int()
+        {
+            var set = new SortedSet<int> { 3, 1, 4, 1, 5, 9 };
+            var result = np.asanyarray(set);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 3, 4, 5, 9); // Sorted, no duplicates
+        }
+
+        #endregion
+
+        #region Queue<T> / Stack<T>
+
+        [Test]
+        public void Queue_Int()
+        {
+            var queue = new Queue<int>();
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+            queue.Enqueue(3);
+            var result = np.asanyarray(queue);
+
+            result.Should().BeShaped(3).And.BeOfValues(1, 2, 3);
+        }
+
+        [Test]
+        public void Stack_Int()
+        {
+            var stack = new Stack<int>();
+            stack.Push(1);
+            stack.Push(2);
+            stack.Push(3);
+            var result = np.asanyarray(stack);
+
+            result.Should().BeShaped(3).And.BeOfValues(3, 2, 1); // LIFO order
+        }
+
+        #endregion
+
+        #region ArraySegment<T>
+
+        [Test]
+        public void ArraySegment_Int()
+        {
+            var array = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var segment = new ArraySegment<int>(array, 2, 5); // Elements 2,3,4,5,6
+            var result = np.asanyarray(segment);
+
+            result.Should().BeShaped(5).And.BeOfValues(2, 3, 4, 5, 6);
+        }
+
+        [Test]
+        public void ArraySegment_Empty()
+        {
+            var array = new int[] { 1, 2, 3 };
+            var segment = new ArraySegment<int>(array, 0, 0);
+            var result = np.asanyarray(segment);
+
+            result.Should().BeShaped(0);
+        }
+
+        [Test]
+        public void ArraySegment_Full()
+        {
+            var array = new int[] { 1, 2, 3, 4, 5 };
+            var segment = new ArraySegment<int>(array);
+            var result = np.asanyarray(segment);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        #endregion
+
+        #region Memory<T> / ReadOnlyMemory<T>
+
+        [Test]
+        public void Memory_Int()
+        {
+            var array = new int[] { 1, 2, 3, 4, 5 };
+            var memory = new Memory<int>(array, 1, 3); // Elements 2,3,4
+            var result = np.asanyarray(memory);
+
+            result.Should().BeShaped(3).And.BeOfValues(2, 3, 4);
+        }
+
+        [Test]
+        public void ReadOnlyMemory_Int()
+        {
+            var array = new int[] { 1, 2, 3, 4, 5 };
+            var memory = new ReadOnlyMemory<int>(array, 1, 3); // Elements 2,3,4
+            var result = np.asanyarray(memory);
+
+            result.Should().BeShaped(3).And.BeOfValues(2, 3, 4);
+        }
+
+        #endregion
+
+        #region ImmutableArray<T> / ImmutableList<T>
+
+        [Test]
+        public void ImmutableArray_Int()
+        {
+            var immutableArray = ImmutableArray.Create(1, 2, 3, 4, 5);
+            var result = np.asanyarray(immutableArray);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        [Test]
+        public void ImmutableList_Int()
+        {
+            var immutableList = ImmutableList.Create(1, 2, 3, 4, 5);
+            var result = np.asanyarray(immutableList);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+        }
+
+        [Test]
+        public void ImmutableHashSet_Int()
+        {
+            var immutableSet = ImmutableHashSet.Create(3, 1, 4, 1, 5);
+            var result = np.asanyarray(immutableSet);
+
+            result.size.Should().Be(4); // 1, 3, 4, 5 (no duplicates)
+        }
+
+        #endregion
+
+        #region All supported dtypes via List<T>
+
+        [Test]
+        public void List_Byte()
+        {
+            var list = new List<byte> { 1, 2, 3 };
+            var result = np.asanyarray(list);
+            result.dtype.Should().Be(typeof(byte));
+            result.Should().BeShaped(3);
+        }
+
+        // Note: sbyte is NOT supported by NumSharp (12 supported types: bool, byte, short, ushort, int, uint, long, ulong, char, float, double, decimal)
+
+        [Test]
+        public void List_Short()
+        {
+            var list = new List<short> { 1, 2, 3 };
+            var result = np.asanyarray(list);
+            result.dtype.Should().Be(typeof(short));
+            result.Should().BeShaped(3);
+        }
+
+        [Test]
+        public void List_UShort()
+        {
+            var list = new List<ushort> { 1, 2, 3 };
+            var result = np.asanyarray(list);
+            result.dtype.Should().Be(typeof(ushort));
+            result.Should().BeShaped(3);
+        }
+
+        [Test]
+        public void List_UInt()
+        {
+            var list = new List<uint> { 1, 2, 3 };
+            var result = np.asanyarray(list);
+            result.dtype.Should().Be(typeof(uint));
+            result.Should().BeShaped(3);
+        }
+
+        [Test]
+        public void List_Long()
+        {
+            var list = new List<long> { 1, 2, 3 };
+            var result = np.asanyarray(list);
+            result.dtype.Should().Be(typeof(long));
+            result.Should().BeShaped(3);
+        }
+
+        [Test]
+        public void List_ULong()
+        {
+            var list = new List<ulong> { 1, 2, 3 };
+            var result = np.asanyarray(list);
+            result.dtype.Should().Be(typeof(ulong));
+            result.Should().BeShaped(3);
+        }
+
+        [Test]
+        public void List_Float()
+        {
+            var list = new List<float> { 1.1f, 2.2f, 3.3f };
+            var result = np.asanyarray(list);
+            result.dtype.Should().Be(typeof(float));
+            result.Should().BeShaped(3);
+        }
+
+        [Test]
+        public void List_Char()
+        {
+            var list = new List<char> { 'a', 'b', 'c' };
+            var result = np.asanyarray(list);
+            result.dtype.Should().Be(typeof(char));
+            result.Should().BeShaped(3);
+        }
+
+        #endregion
+
+        #region Error cases
+
+        [Test]
+        public void Null_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => np.asanyarray(null));
+        }
+
+        [Test]
+        public void UnsupportedType_ThrowsNotSupportedException()
+        {
+            // String collections are not supported (string is not primitive/decimal)
+            var stringList = new List<string> { "a", "b", "c" };
+            Assert.ThrowsException<NotSupportedException>(() => np.asanyarray(stringList));
+        }
+
+        [Test]
+        public void CustomClass_ThrowsNotSupportedException()
+        {
+            var customObject = new object();
+            Assert.ThrowsException<NotSupportedException>(() => np.asanyarray(customObject));
+        }
+
+        #endregion
+
+        #region String special case
+
+        [Test]
+        public void String_CreatesCharArray()
+        {
+            var result = np.asanyarray("hello");
+
+            result.Should().BeShaped(5);
+            result.dtype.Should().Be(typeof(char));
+        }
+
+        #endregion
+    }
+}

--- a/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
+++ b/test/NumSharp.UnitTest/Creation/np.asanyarray.Tests.cs
@@ -529,5 +529,59 @@ namespace NumSharp.UnitTest.Creation
         }
 
         #endregion
+
+        #region Non-generic IEnumerable fallback
+
+        [Test]
+        public void ArrayList_Int()
+        {
+            var arrayList = new System.Collections.ArrayList { 1, 2, 3, 4, 5 };
+            var result = np.asanyarray(arrayList);
+
+            result.Should().BeShaped(5).And.BeOfValues(1, 2, 3, 4, 5);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        [Test]
+        public void ArrayList_Double()
+        {
+            var arrayList = new System.Collections.ArrayList { 1.1, 2.2, 3.3 };
+            var result = np.asanyarray(arrayList);
+
+            result.Should().BeShaped(3);
+            result.dtype.Should().Be(typeof(double));
+        }
+
+        [Test]
+        public void Hashtable_Keys()
+        {
+            var hashtable = new System.Collections.Hashtable { { 1, "a" }, { 2, "b" }, { 3, "c" } };
+            var result = np.asanyarray(hashtable.Keys);
+
+            result.size.Should().Be(3);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        #endregion
+
+        #region IEnumerator fallback
+
+        [Test]
+        public void IEnumerator_Int()
+        {
+            static System.Collections.IEnumerator GetEnumerator()
+            {
+                yield return 10;
+                yield return 20;
+                yield return 30;
+            }
+
+            var result = np.asanyarray(GetEnumerator());
+
+            result.Should().BeShaped(3).And.BeOfValues(10, 20, 30);
+            result.dtype.Should().Be(typeof(int));
+        }
+
+        #endregion
     }
 }

--- a/test/NumSharp.UnitTest/Logic/np.where.BattleTest.cs
+++ b/test/NumSharp.UnitTest/Logic/np.where.BattleTest.cs
@@ -8,6 +8,25 @@ namespace NumSharp.UnitTest.Logic
 {
     /// <summary>
     /// Battle tests for np.where - edge cases, strided arrays, views, etc.
+    ///
+    /// These tests verify NumSharp behavior against NumPy 2.4.2.
+    ///
+    /// KNOWN DIFFERENCES FROM NUMPY 2.x:
+    ///
+    /// 1. Scalar Type Promotion (NEP50):
+    ///    NumPy 2.x uses "weak scalar" semantics where Python scalars adopt array dtype.
+    ///    NumSharp uses C# semantics where literals have fixed types (int=int32, etc).
+    ///
+    ///    Example: np.where(cond, 1, uint8_array)
+    ///    - NumPy 2.x: returns uint8 (weak scalar rule)
+    ///    - NumSharp: returns int32 (C# int literal is int32)
+    ///
+    /// 2. Python int Scalar Default:
+    ///    - NumPy: Python int → int64 (platform default)
+    ///    - NumSharp: C# int literal → int32
+    ///
+    /// 3. Missing sbyte (int8) support:
+    ///    NumSharp does not support sbyte arrays (throws NotSupportedException).
     /// </summary>
     public class np_where_BattleTest
     {
@@ -16,15 +35,15 @@ namespace NumSharp.UnitTest.Logic
         [Test]
         public void Where_SlicedCondition()
         {
-            // Sliced condition array
+            // Sliced condition array (non-contiguous)
             var arr = np.arange(10);
-            var cond = (arr % 2 == 0)["::2"];  // Every other even check
+            var cond = (arr % 2 == 0)["::2"];  // Every other even check: [T,T,T,T,T]
             var x = np.ones(5, NPTypeCode.Int32);
             var y = np.zeros(5, NPTypeCode.Int32);
             var result = np.where(cond, x, y);
 
-            // Should work with sliced condition
             Assert.AreEqual(5, result.size);
+            result.Should().BeOfValues(1, 1, 1, 1, 1);
         }
 
         [Test]
@@ -62,6 +81,7 @@ namespace NumSharp.UnitTest.Logic
             var y = np.zeros(5, NPTypeCode.Int64);
             var result = np.where(cond, x, y);
 
+            // NumPy: [4, 0, 2, 0, 0]
             result.Should().BeOfValues(4L, 0L, 2L, 0L, 0L);
         }
 
@@ -102,6 +122,91 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(0, (int)result[0, 1]);
             Assert.AreEqual(2, (int)result[1, 0]);
             Assert.AreEqual(0, (int)result[1, 1]);
+        }
+
+        [Test]
+        public void Where_ScalarCondition_True()
+        {
+            // NumPy: np.where(True, [1,2,3], [4,5,6]) -> [1,2,3]
+            var result = np.where(np.array(true), np.array(new[] { 1, 2, 3 }), np.array(new[] { 4, 5, 6 }));
+            result.Should().BeOfValues(1, 2, 3);
+        }
+
+        [Test]
+        public void Where_ScalarCondition_False()
+        {
+            // NumPy: np.where(False, [1,2,3], [4,5,6]) -> [4,5,6]
+            var result = np.where(np.array(false), np.array(new[] { 1, 2, 3 }), np.array(new[] { 4, 5, 6 }));
+            result.Should().BeOfValues(4, 5, 6);
+        }
+
+        #endregion
+
+        #region Non-Boolean Conditions (Truthy/Falsy)
+
+        [Test]
+        public void Where_IntegerCondition_ZeroIsFalsy()
+        {
+            // NumPy: 0 is falsy, non-zero is truthy
+            var cond = np.array(new[] { 0, 1, 2, -1, 0 });
+            var x = np.ones(5);
+            var y = np.zeros(5);
+            var result = np.where(cond, x, y);
+
+            // NumPy: [0, 1, 1, 1, 0]
+            result.Should().BeOfValues(0.0, 1.0, 1.0, 1.0, 0.0);
+        }
+
+        [Test]
+        public void Where_FloatCondition_ZeroIsFalsy()
+        {
+            // NumPy: 0.0 is falsy
+            var cond = np.array(new[] { 0.0, 0.5, 1.0, -0.1, 0.0 });
+            var x = np.ones(5);
+            var y = np.zeros(5);
+            var result = np.where(cond, x, y);
+
+            // NumPy: [0, 1, 1, 1, 0]
+            result.Should().BeOfValues(0.0, 1.0, 1.0, 1.0, 0.0);
+        }
+
+        [Test]
+        public void Where_NaN_IsTruthy()
+        {
+            // NumPy: NaN is truthy (non-zero)
+            var cond = np.array(new[] { 0.0, double.NaN, 1.0 });
+            var x = np.array(new[] { 1, 2, 3 });
+            var y = np.array(new[] { 10, 20, 30 });
+            var result = np.where(cond, x, y);
+
+            // NumPy: [10, 2, 3] (NaN is truthy)
+            result.Should().BeOfValues(10, 2, 3);
+        }
+
+        [Test]
+        public void Where_Infinity_IsTruthy()
+        {
+            // NumPy: Inf and -Inf are truthy
+            var cond = np.array(new[] { 0.0, double.PositiveInfinity, double.NegativeInfinity });
+            var x = np.array(new[] { 1, 2, 3 });
+            var y = np.array(new[] { 10, 20, 30 });
+            var result = np.where(cond, x, y);
+
+            // NumPy: [10, 2, 3]
+            result.Should().BeOfValues(10, 2, 3);
+        }
+
+        [Test]
+        public void Where_NegativeZero_IsFalsy()
+        {
+            // NumPy: -0.0 == 0.0 in IEEE 754, so it's falsy
+            var cond = np.array(new[] { 0.0, -0.0, 1.0 });
+            var x = np.array(new[] { 1, 2, 3 });
+            var y = np.array(new[] { 10, 20, 30 });
+            var result = np.where(cond, x, y);
+
+            // NumPy: [10, 20, 3] (both 0.0 and -0.0 are falsy)
+            result.Should().BeOfValues(10, 20, 3);
         }
 
         #endregion
@@ -153,10 +258,11 @@ namespace NumSharp.UnitTest.Logic
         public void Where_SingleArg_Float_Truthy()
         {
             // 0.0 is falsy, anything else (including -0.0, NaN, Inf) is truthy
+            // Note: -0.0 == 0.0 in IEEE 754, so it's falsy
             var arr = np.array(new[] { 0.0, 1.0, -1.0, 0.5, -0.0 });
             var result = np.where(arr);
 
-            // Note: -0.0 == 0.0 in IEEE 754, so it's falsy
+            // NumPy: indices [1, 2, 3] (-0.0 is falsy)
             result[0].Should().BeOfValues(1L, 2L, 3L);
         }
 
@@ -171,6 +277,16 @@ namespace NumSharp.UnitTest.Logic
         }
 
         [Test]
+        public void Where_SingleArg_Infinity_IsTruthy()
+        {
+            // Inf values are truthy
+            var arr = np.array(new[] { 0.0, double.PositiveInfinity, double.NegativeInfinity, 0.0 });
+            var result = np.where(arr);
+
+            result[0].Should().BeOfValues(1L, 2L);
+        }
+
+        [Test]
         public void Where_SingleArg_4D()
         {
             var arr = np.zeros(new[] { 2, 2, 2, 2 }, NPTypeCode.Int32);
@@ -180,6 +296,120 @@ namespace NumSharp.UnitTest.Logic
 
             Assert.AreEqual(4, result.Length);  // 4 dimensions
             Assert.AreEqual(2, result[0].size); // 2 non-zero elements
+        }
+
+        [Test]
+        public void Where_SingleArg_ReturnsInt64Indices()
+        {
+            // NumPy returns int64 for indices
+            var arr = np.array(new[] { 0, 1, 0, 2 });
+            var result = np.where(arr);
+
+            Assert.AreEqual(typeof(long), result[0].dtype);
+        }
+
+        #endregion
+
+        #region 0D Scalar Arrays
+
+        [Test]
+        public void Where_0D_AllScalars_Returns0D()
+        {
+            // NumPy: when all inputs are 0D, result is 0D
+            var cond = np.array(true).reshape();  // 0D
+            var x = np.array(42).reshape();       // 0D
+            var y = np.array(99).reshape();       // 0D
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(0, result.ndim);
+            Assert.AreEqual(42, (int)result.GetValue(0));
+        }
+
+        [Test]
+        public void Where_0D_Cond_With_1D_Arrays()
+        {
+            // 0D condition broadcasts to match x/y shape
+            var cond = np.array(true).reshape();  // 0D
+            var x = np.array(new[] { 1, 2, 3 });
+            var y = np.array(new[] { 10, 20, 30 });
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(3);
+            result.Should().BeOfValues(1, 2, 3);
+        }
+
+        #endregion
+
+        #region Type Promotion (Array-to-Array)
+
+        [Test]
+        public void Where_TypePromotion_Bool_Int16()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new bool[] { true, false });
+            var y = np.array(new short[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            // NumPy: int16
+            Assert.AreEqual(typeof(short), result.dtype);
+        }
+
+        [Test]
+        public void Where_TwoScalars_Byte_StaysByte()
+        {
+            // C# byte (like np.uint8) stays byte, not widened to int64
+            var cond = np.array(new[] { true, false });
+            var result = np.where(cond, (byte)1, (byte)0);
+
+            Assert.AreEqual(typeof(byte), result.dtype);
+            Assert.AreEqual((byte)1, (byte)result[0]);
+            Assert.AreEqual((byte)0, (byte)result[1]);
+        }
+
+        [Test]
+        public void Where_TwoScalars_Short_StaysShort()
+        {
+            // C# short (like np.int16) stays short
+            var cond = np.array(new[] { true, false });
+            var result = np.where(cond, (short)100, (short)200);
+
+            Assert.AreEqual(typeof(short), result.dtype);
+        }
+
+        [Test]
+        public void Where_TypePromotion_Int32_UInt32()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new int[] { 1, 2 });
+            var y = np.array(new uint[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            // NumPy: int64 (to accommodate both signed and unsigned 32-bit range)
+            Assert.AreEqual(typeof(long), result.dtype);
+        }
+
+        [Test]
+        public void Where_TypePromotion_Int64_UInt64()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new long[] { 1, 2 });
+            var y = np.array(new ulong[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            // NumPy: float64 (no integer type can hold both int64 and uint64 full range)
+            Assert.AreEqual(typeof(double), result.dtype);
+        }
+
+        [Test]
+        public void Where_TypePromotion_UInt8_Float32()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new byte[] { 1, 2 });
+            var y = np.array(new float[] { 10.5f, 20.5f });
+            var result = np.where(cond, x, y);
+
+            // NumPy: float32
+            Assert.AreEqual(typeof(float), result.dtype);
         }
 
         #endregion
@@ -214,7 +444,49 @@ namespace NumSharp.UnitTest.Logic
             var result = np.where(cond, x, y);
 
             result.Should().BeShaped(2, 3, 2, 2, 2, 3);
-            Assert.AreEqual(1, (int)result[0, 0, 0, 0, 0, 0]);
+            Assert.AreEqual(144, result.size);
+            Assert.AreEqual(144, (long)np.sum(result));  // All 1s
+        }
+
+        [Test]
+        public void Where_AllTrue_LargeArray()
+        {
+            var size = 10000;
+            var cond = np.ones(size, NPTypeCode.Boolean);
+            var x = np.arange(size);
+            var y = np.zeros(size, NPTypeCode.Int64);
+            var result = np.where(cond, x, y);
+
+            // Sum of 0 to 9999 = 49995000
+            Assert.AreEqual(49995000L, (long)np.sum(result));
+        }
+
+        [Test]
+        public void Where_AllFalse_LargeArray()
+        {
+            var size = 10000;
+            var cond = np.zeros(size, NPTypeCode.Boolean);
+            var x = np.arange(size);
+            var y = np.zeros(size, NPTypeCode.Int64);
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(0L, (long)np.sum(result));
+        }
+
+        [Test]
+        public void Where_Alternating_LargeArray()
+        {
+            var size = 10000;
+            var cond = np.zeros(size, NPTypeCode.Boolean);
+            for (int i = 0; i < size; i += 2)
+                cond[i] = true;
+
+            var x = np.arange(size);
+            var y = np.zeros(size, NPTypeCode.Int64);
+            var result = np.where(cond, x, y);
+
+            // Sum of even indices: 0+2+4+...+9998 = 24995000
+            Assert.AreEqual(24995000L, (long)np.sum(result));
         }
 
         #endregion
@@ -339,6 +611,147 @@ namespace NumSharp.UnitTest.Logic
                 Assert.AreEqual(1, (int)result[2, j]);
                 Assert.AreEqual(0, (int)result[3, j]);
             }
+        }
+
+        #endregion
+
+        #region Empty Array Edge Cases
+
+        [Test]
+        public void Where_Empty2D()
+        {
+            // Empty (0,3) shape
+            var cond = np.zeros(new[] { 0, 3 }, NPTypeCode.Boolean);
+            var x = np.zeros(new[] { 0, 3 }, NPTypeCode.Double);
+            var y = np.zeros(new[] { 0, 3 }, NPTypeCode.Double);
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(0, 3);
+            Assert.AreEqual(typeof(double), result.dtype);
+        }
+
+        [Test]
+        public void Where_Empty3D()
+        {
+            // Empty (2,0,3) shape
+            var cond = np.zeros(new[] { 2, 0, 3 }, NPTypeCode.Boolean);
+            var x = np.zeros(new[] { 2, 0, 3 }, NPTypeCode.Int32);
+            var y = np.zeros(new[] { 2, 0, 3 }, NPTypeCode.Int32);
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(2, 0, 3);
+            Assert.AreEqual(typeof(int), result.dtype);
+        }
+
+        [Test]
+        public void Where_SingleArg_Empty2D()
+        {
+            var arr = np.zeros(new[] { 0, 3 }, NPTypeCode.Int32);
+            var result = np.where(arr);
+
+            Assert.AreEqual(2, result.Length);  // 2 dimensions
+            Assert.AreEqual(0, result[0].size);
+            Assert.AreEqual(0, result[1].size);
+        }
+
+        #endregion
+
+        #region Error Conditions
+
+        [Test]
+        public void Where_IncompatibleShapes_ThrowsException()
+        {
+            // Shapes (2,) and (3,) cannot be broadcast together
+            var cond = np.array(new[] { true, false });  // (2,)
+            var x = np.array(new[] { 1, 2, 3 });  // (3,)
+            var y = np.array(new[] { 4, 5, 6 });  // (3,)
+
+            Assert.ThrowsException<IncorrectShapeException>(() => np.where(cond, x, y));
+        }
+
+        #endregion
+
+        #region NEP50 Type Promotion (NumPy 2.x Parity)
+
+        /// <summary>
+        /// Verifies NEP50 weak scalar semantics: when a scalar is combined with an array,
+        /// the array's dtype wins for same-kind operations.
+        /// </summary>
+        [Test]
+        public void Where_ScalarTypePromotion_NEP50_WeakScalar()
+        {
+            // NumPy 2.x: np.where(cond, 1, uint8_array) -> uint8 (weak scalar)
+            var cond = np.array(new[] { true, false });
+            var yUint8 = np.array(new byte[] { 10, 20 });
+            var result = np.where(cond, 1, yUint8);
+
+            // Array dtype wins - matches NumPy 2.x NEP50
+            Assert.AreEqual(typeof(byte), result.dtype);
+            Assert.AreEqual((byte)1, (byte)result[0]);
+            Assert.AreEqual((byte)20, (byte)result[1]);
+        }
+
+        /// <summary>
+        /// Two same-type scalars preserve their type.
+        /// Note: NumPy would return int64 for Python int literals, but C# int32 scalars
+        /// cannot be distinguished from explicit np.array(1, dtype=int32), so we preserve.
+        /// </summary>
+        [Test]
+        public void Where_TwoScalars_SameType_Preserved()
+        {
+            var cond = np.array(new[] { true, false });
+
+            // int + int → int (preserved)
+            var result = np.where(cond, 1, 0);
+            Assert.AreEqual(typeof(int), result.dtype);
+            Assert.AreEqual(1, (int)result[0]);
+            Assert.AreEqual(0, (int)result[1]);
+
+            // long + long → long (preserved)
+            result = np.where(cond, 1L, 0L);
+            Assert.AreEqual(typeof(long), result.dtype);
+        }
+
+        /// <summary>
+        /// Verifies C# float scalars stay float32 (like np.float32, not Python float).
+        /// </summary>
+        [Test]
+        public void Where_TwoScalars_Float32_StaysFloat32()
+        {
+            // C# float (1.0f) is like np.float32, not Python's float (which is float64)
+            // np.where(cond, np.float32(1.0), np.float32(0.0)) -> float32
+            var cond = np.array(new[] { true, false });
+            var result = np.where(cond, 1.0f, 0.0f);
+
+            Assert.AreEqual(typeof(float), result.dtype);
+        }
+
+        /// <summary>
+        /// Verifies NEP50: int scalar + float32 array -> float32 (same-kind, array wins).
+        /// </summary>
+        [Test]
+        public void Where_IntScalar_Float32Array_ReturnsFloat32()
+        {
+            var cond = np.array(new[] { true, false });
+            var yFloat32 = np.array(new float[] { 10.5f, 20.5f });
+            var result = np.where(cond, 1, yFloat32);
+
+            // Array dtype wins for same-kind (int->float conversion)
+            Assert.AreEqual(typeof(float), result.dtype);
+        }
+
+        /// <summary>
+        /// Verifies NEP50: float scalar + int32 array -> float64 (cross-kind promotion).
+        /// </summary>
+        [Test]
+        public void Where_FloatScalar_Int32Array_ReturnsFloat64()
+        {
+            var cond = np.array(new[] { true, false });
+            var yInt32 = np.array(new int[] { 10, 20 });
+            var result = np.where(cond, 1.5, yInt32);
+
+            // Cross-kind: float scalar forces float64
+            Assert.AreEqual(typeof(double), result.dtype);
         }
 
         #endregion

--- a/test/NumSharp.UnitTest/Logic/np.where.BattleTest.cs
+++ b/test/NumSharp.UnitTest/Logic/np.where.BattleTest.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Linq;
+using TUnit.Core;
+using NumSharp.UnitTest.Utilities;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+namespace NumSharp.UnitTest.Logic
+{
+    /// <summary>
+    /// Battle tests for np.where - edge cases, strided arrays, views, etc.
+    /// </summary>
+    public class np_where_BattleTest
+    {
+        #region Strided/Sliced Arrays
+
+        [Test]
+        public void Where_SlicedCondition()
+        {
+            // Sliced condition array
+            var arr = np.arange(10);
+            var cond = (arr % 2 == 0)["::2"];  // Every other even check
+            var x = np.ones(5, NPTypeCode.Int32);
+            var y = np.zeros(5, NPTypeCode.Int32);
+            var result = np.where(cond, x, y);
+
+            // Should work with sliced condition
+            Assert.AreEqual(5, result.size);
+        }
+
+        [Test]
+        public void Where_SlicedXY()
+        {
+            var cond = np.array(new[] { true, false, true });
+            var x = np.arange(6)["::2"];  // [0, 2, 4]
+            var y = np.arange(6)["1::2"]; // [1, 3, 5]
+            var result = np.where(cond, x, y);
+
+            result.Should().BeOfValues(0L, 3L, 4L);
+        }
+
+        [Test]
+        public void Where_TransposedArrays()
+        {
+            var cond = np.array(new bool[,] { { true, false }, { false, true } }).T;
+            var x = np.array(new int[,] { { 1, 2 }, { 3, 4 } }).T;
+            var y = np.array(new int[,] { { 10, 20 }, { 30, 40 } }).T;
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(2, 2);
+            // After transpose: cond[0,0]=T, cond[0,1]=F, cond[1,0]=F, cond[1,1]=T
+            Assert.AreEqual(1, (int)result[0, 0]);
+            Assert.AreEqual(30, (int)result[0, 1]);
+            Assert.AreEqual(20, (int)result[1, 0]);
+            Assert.AreEqual(4, (int)result[1, 1]);
+        }
+
+        [Test]
+        public void Where_ReversedSlice()
+        {
+            var cond = np.array(new[] { true, false, true, false, true });
+            var x = np.arange(5)["::-1"];  // [4, 3, 2, 1, 0]
+            var y = np.zeros(5, NPTypeCode.Int64);
+            var result = np.where(cond, x, y);
+
+            result.Should().BeOfValues(4L, 0L, 2L, 0L, 0L);
+        }
+
+        #endregion
+
+        #region Complex Broadcasting
+
+        [Test]
+        public void Where_3Way_Broadcasting()
+        {
+            // cond: (2,1,1), x: (1,3,1), y: (1,1,4) -> result: (2,3,4)
+            var cond = np.array(new bool[,,] { { { true } }, { { false } } });
+            var x = np.arange(3).reshape(1, 3, 1);
+            var y = (np.arange(4) * 10).reshape(1, 1, 4);
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(2, 3, 4);
+            // First "page" (cond=True): values from x broadcast
+            Assert.AreEqual(0, (long)result[0, 0, 0]);
+            Assert.AreEqual(0, (long)result[0, 0, 3]);
+            Assert.AreEqual(2, (long)result[0, 2, 0]);
+            // Second "page" (cond=False): values from y broadcast
+            Assert.AreEqual(0, (long)result[1, 0, 0]);
+            Assert.AreEqual(30, (long)result[1, 0, 3]);
+            Assert.AreEqual(30, (long)result[1, 2, 3]);
+        }
+
+        [Test]
+        public void Where_RowVector_ColVector_Broadcast()
+        {
+            // cond: (1,4), x: (3,1), y: scalar -> result: (3,4)
+            var cond = np.array(new bool[,] { { true, false, true, false } });
+            var x = np.array(new int[,] { { 1 }, { 2 }, { 3 } });
+            var result = np.where(cond, x, 0);
+
+            result.Should().BeShaped(3, 4);
+            Assert.AreEqual(1, (int)result[0, 0]);
+            Assert.AreEqual(0, (int)result[0, 1]);
+            Assert.AreEqual(2, (int)result[1, 0]);
+            Assert.AreEqual(0, (int)result[1, 1]);
+        }
+
+        #endregion
+
+        #region Numeric Edge Cases
+
+        [Test]
+        public void Where_NaN_Values()
+        {
+            var cond = np.array(new[] { true, false, true });
+            var x = np.array(new[] { double.NaN, 1.0, double.NaN });
+            var y = np.array(new[] { 0.0, double.NaN, 0.0 });
+            var result = np.where(cond, x, y);
+
+            Assert.IsTrue(double.IsNaN((double)result[0]));  // from x
+            Assert.IsTrue(double.IsNaN((double)result[1]));  // from y
+            Assert.IsTrue(double.IsNaN((double)result[2]));  // from x
+        }
+
+        [Test]
+        public void Where_Infinity_Values()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new[] { double.PositiveInfinity, 1.0 });
+            var y = np.array(new[] { 0.0, double.NegativeInfinity });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(double.PositiveInfinity, (double)result[0]);
+            Assert.AreEqual(double.NegativeInfinity, (double)result[1]);
+        }
+
+        [Test]
+        public void Where_MaxMin_Values()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new[] { long.MaxValue, 0L });
+            var y = np.array(new[] { 0L, long.MinValue });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(long.MaxValue, (long)result[0]);
+            Assert.AreEqual(long.MinValue, (long)result[1]);
+        }
+
+        #endregion
+
+        #region Single Arg Edge Cases
+
+        [Test]
+        public void Where_SingleArg_Float_Truthy()
+        {
+            // 0.0 is falsy, anything else (including -0.0, NaN, Inf) is truthy
+            var arr = np.array(new[] { 0.0, 1.0, -1.0, 0.5, -0.0 });
+            var result = np.where(arr);
+
+            // Note: -0.0 == 0.0 in IEEE 754, so it's falsy
+            result[0].Should().BeOfValues(1L, 2L, 3L);
+        }
+
+        [Test]
+        public void Where_SingleArg_NaN_IsTruthy()
+        {
+            // NaN is non-zero, so it's truthy
+            var arr = np.array(new[] { 0.0, double.NaN, 0.0 });
+            var result = np.where(arr);
+
+            result[0].Should().BeOfValues(1L);
+        }
+
+        [Test]
+        public void Where_SingleArg_4D()
+        {
+            var arr = np.zeros(new[] { 2, 2, 2, 2 }, NPTypeCode.Int32);
+            arr[0, 1, 0, 1] = 1;
+            arr[1, 0, 1, 0] = 1;
+            var result = np.where(arr);
+
+            Assert.AreEqual(4, result.Length);  // 4 dimensions
+            Assert.AreEqual(2, result[0].size); // 2 non-zero elements
+        }
+
+        #endregion
+
+        #region Performance/Stress Tests
+
+        [Test]
+        public void Where_LargeArray_Performance()
+        {
+            var size = 1_000_000;
+            var cond = np.random.rand(size) > 0.5;
+            var x = np.ones(size, NPTypeCode.Double);
+            var y = np.zeros(size, NPTypeCode.Double);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var result = np.where(cond, x, y);
+            sw.Stop();
+
+            Assert.AreEqual(size, result.size);
+            // Should complete in reasonable time (< 1 second for 1M elements)
+            Assert.IsTrue(sw.ElapsedMilliseconds < 1000, $"Took {sw.ElapsedMilliseconds}ms");
+        }
+
+        [Test]
+        public void Where_ManyDimensions()
+        {
+            // 6D array
+            var shape = new[] { 2, 3, 2, 2, 2, 3 };
+            var cond = np.ones(shape, NPTypeCode.Boolean);
+            var x = np.ones(shape, NPTypeCode.Int32);
+            var y = np.zeros(shape, NPTypeCode.Int32);
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(2, 3, 2, 2, 2, 3);
+            Assert.AreEqual(1, (int)result[0, 0, 0, 0, 0, 0]);
+        }
+
+        #endregion
+
+        #region Type Conversion Edge Cases
+
+        [Test]
+        public void Where_UnsignedOverflow()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new byte[] { 255, 0 });
+            var y = np.array(new byte[] { 0, 255 });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(byte), result.dtype);
+            Assert.AreEqual((byte)255, (byte)result[0]);
+            Assert.AreEqual((byte)255, (byte)result[1]);
+        }
+
+        [Test]
+        public void Where_Decimal()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new decimal[] { 1.23456789m, 0m });
+            var y = np.array(new decimal[] { 0m, 9.87654321m });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(decimal), result.dtype);
+            Assert.AreEqual(1.23456789m, (decimal)result[0]);
+            Assert.AreEqual(9.87654321m, (decimal)result[1]);
+        }
+
+        [Test]
+        public void Where_Char()
+        {
+            var cond = np.array(new[] { true, false, true });
+            var x = np.array(new char[] { 'A', 'B', 'C' });
+            var y = np.array(new char[] { 'X', 'Y', 'Z' });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(char), result.dtype);
+            Assert.AreEqual('A', (char)result[0]);
+            Assert.AreEqual('Y', (char)result[1]);
+            Assert.AreEqual('C', (char)result[2]);
+        }
+
+        #endregion
+
+        #region View Behavior
+
+        [Test]
+        public void Where_ResultIsNewArray_NotView()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new[] { 1, 2 });
+            var y = np.array(new[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            // Modify original, result should not change
+            x[0] = 999;
+            Assert.AreEqual(1, (int)result[0], "Result should be independent of x");
+
+            y[1] = 999;
+            Assert.AreEqual(20, (int)result[1], "Result should be independent of y");
+        }
+
+        [Test]
+        public void Where_ModifyResult_DoesNotAffectInputs()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new[] { 1, 2 });
+            var y = np.array(new[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            result[0] = 999;
+            Assert.AreEqual(1, (int)x[0], "x should not be modified");
+            Assert.AreEqual(10, (int)y[0], "y should not be modified");
+        }
+
+        #endregion
+
+        #region Alternating Patterns
+
+        [Test]
+        public void Where_Checkerboard_Pattern()
+        {
+            // Create checkerboard condition
+            var cond = np.zeros(new[] { 4, 4 }, NPTypeCode.Boolean);
+            for (int i = 0; i < 4; i++)
+                for (int j = 0; j < 4; j++)
+                    cond[i, j] = (i + j) % 2 == 0;
+
+            var x = np.ones(new[] { 4, 4 }, NPTypeCode.Int32);
+            var y = np.zeros(new[] { 4, 4 }, NPTypeCode.Int32);
+            var result = np.where(cond, x, y);
+
+            // Verify checkerboard pattern
+            Assert.AreEqual(1, (int)result[0, 0]);
+            Assert.AreEqual(0, (int)result[0, 1]);
+            Assert.AreEqual(0, (int)result[1, 0]);
+            Assert.AreEqual(1, (int)result[1, 1]);
+        }
+
+        [Test]
+        public void Where_StripedPattern()
+        {
+            // Every row alternates between all True and all False
+            var cond = np.zeros(new[] { 4, 4 }, NPTypeCode.Boolean);
+            for (int i = 0; i < 4; i++)
+                for (int j = 0; j < 4; j++)
+                    cond[i, j] = i % 2 == 0;
+
+            var x = np.full(new[] { 4, 4 }, 1);
+            var y = np.full(new[] { 4, 4 }, 0);
+            var result = np.where(cond, x, y);
+
+            // Rows 0, 2 should be 1; rows 1, 3 should be 0
+            for (int j = 0; j < 4; j++)
+            {
+                Assert.AreEqual(1, (int)result[0, j]);
+                Assert.AreEqual(0, (int)result[1, j]);
+                Assert.AreEqual(1, (int)result[2, j]);
+                Assert.AreEqual(0, (int)result[3, j]);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/NumSharp.UnitTest/Logic/np.where.BattleTest.cs
+++ b/test/NumSharp.UnitTest/Logic/np.where.BattleTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using TUnit.Core;
 using NumSharp.UnitTest.Utilities;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
@@ -28,11 +27,12 @@ namespace NumSharp.UnitTest.Logic
     /// 3. Missing sbyte (int8) support:
     ///    NumSharp does not support sbyte arrays (throws NotSupportedException).
     /// </summary>
+    [TestClass]
     public class np_where_BattleTest
     {
         #region Strided/Sliced Arrays
 
-        [Test]
+        [TestMethod]
         public void Where_SlicedCondition()
         {
             // Sliced condition array (non-contiguous)
@@ -46,7 +46,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(1, 1, 1, 1, 1);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SlicedXY()
         {
             var cond = np.array(new[] { true, false, true });
@@ -57,7 +57,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(0L, 3L, 4L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_TransposedArrays()
         {
             var cond = np.array(new bool[,] { { true, false }, { false, true } }).T;
@@ -73,7 +73,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(4, (int)result[1, 1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ReversedSlice()
         {
             var cond = np.array(new[] { true, false, true, false, true });
@@ -89,7 +89,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Complex Broadcasting
 
-        [Test]
+        [TestMethod]
         public void Where_3Way_Broadcasting()
         {
             // cond: (2,1,1), x: (1,3,1), y: (1,1,4) -> result: (2,3,4)
@@ -109,7 +109,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(30, (long)result[1, 2, 3]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_RowVector_ColVector_Broadcast()
         {
             // cond: (1,4), x: (3,1), y: scalar -> result: (3,4)
@@ -124,7 +124,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(0, (int)result[1, 1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ScalarCondition_True()
         {
             // NumPy: np.where(True, [1,2,3], [4,5,6]) -> [1,2,3]
@@ -132,7 +132,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(1, 2, 3);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ScalarCondition_False()
         {
             // NumPy: np.where(False, [1,2,3], [4,5,6]) -> [4,5,6]
@@ -144,7 +144,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Non-Boolean Conditions (Truthy/Falsy)
 
-        [Test]
+        [TestMethod]
         public void Where_IntegerCondition_ZeroIsFalsy()
         {
             // NumPy: 0 is falsy, non-zero is truthy
@@ -157,7 +157,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(0.0, 1.0, 1.0, 1.0, 0.0);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_FloatCondition_ZeroIsFalsy()
         {
             // NumPy: 0.0 is falsy
@@ -170,7 +170,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(0.0, 1.0, 1.0, 1.0, 0.0);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_NaN_IsTruthy()
         {
             // NumPy: NaN is truthy (non-zero)
@@ -183,7 +183,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(10, 2, 3);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Infinity_IsTruthy()
         {
             // NumPy: Inf and -Inf are truthy
@@ -196,7 +196,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(10, 2, 3);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_NegativeZero_IsFalsy()
         {
             // NumPy: -0.0 == 0.0 in IEEE 754, so it's falsy
@@ -213,7 +213,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Numeric Edge Cases
 
-        [Test]
+        [TestMethod]
         public void Where_NaN_Values()
         {
             var cond = np.array(new[] { true, false, true });
@@ -226,7 +226,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.IsTrue(double.IsNaN((double)result[2]));  // from x
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Infinity_Values()
         {
             var cond = np.array(new[] { true, false });
@@ -238,7 +238,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(double.NegativeInfinity, (double)result[1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_MaxMin_Values()
         {
             var cond = np.array(new[] { true, false });
@@ -254,7 +254,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Single Arg Edge Cases
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_Float_Truthy()
         {
             // 0.0 is falsy, anything else (including -0.0, NaN, Inf) is truthy
@@ -266,7 +266,7 @@ namespace NumSharp.UnitTest.Logic
             result[0].Should().BeOfValues(1L, 2L, 3L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_NaN_IsTruthy()
         {
             // NaN is non-zero, so it's truthy
@@ -276,7 +276,7 @@ namespace NumSharp.UnitTest.Logic
             result[0].Should().BeOfValues(1L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_Infinity_IsTruthy()
         {
             // Inf values are truthy
@@ -286,7 +286,7 @@ namespace NumSharp.UnitTest.Logic
             result[0].Should().BeOfValues(1L, 2L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_4D()
         {
             var arr = np.zeros(new[] { 2, 2, 2, 2 }, NPTypeCode.Int32);
@@ -298,7 +298,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(2, result[0].size); // 2 non-zero elements
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_ReturnsInt64Indices()
         {
             // NumPy returns int64 for indices
@@ -312,7 +312,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region 0D Scalar Arrays
 
-        [Test]
+        [TestMethod]
         public void Where_0D_AllScalars_Returns0D()
         {
             // NumPy: when all inputs are 0D, result is 0D
@@ -325,7 +325,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(42, (int)result.GetValue(0));
         }
 
-        [Test]
+        [TestMethod]
         public void Where_0D_Cond_With_1D_Arrays()
         {
             // 0D condition broadcasts to match x/y shape
@@ -342,7 +342,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Type Promotion (Array-to-Array)
 
-        [Test]
+        [TestMethod]
         public void Where_TypePromotion_Bool_Int16()
         {
             var cond = np.array(new[] { true, false });
@@ -354,7 +354,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(typeof(short), result.dtype);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_TwoScalars_Byte_StaysByte()
         {
             // C# byte (like np.uint8) stays byte, not widened to int64
@@ -366,7 +366,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual((byte)0, (byte)result[1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_TwoScalars_Short_StaysShort()
         {
             // C# short (like np.int16) stays short
@@ -376,7 +376,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(typeof(short), result.dtype);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_TypePromotion_Int32_UInt32()
         {
             var cond = np.array(new[] { true, false });
@@ -388,7 +388,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(typeof(long), result.dtype);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_TypePromotion_Int64_UInt64()
         {
             var cond = np.array(new[] { true, false });
@@ -400,7 +400,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(typeof(double), result.dtype);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_TypePromotion_UInt8_Float32()
         {
             var cond = np.array(new[] { true, false });
@@ -416,7 +416,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Performance/Stress Tests
 
-        [Test]
+        [TestMethod]
         public void Where_LargeArray_Performance()
         {
             var size = 1_000_000;
@@ -433,7 +433,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.IsTrue(sw.ElapsedMilliseconds < 1000, $"Took {sw.ElapsedMilliseconds}ms");
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ManyDimensions()
         {
             // 6D array
@@ -448,7 +448,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(144, (long)np.sum(result));  // All 1s
         }
 
-        [Test]
+        [TestMethod]
         public void Where_AllTrue_LargeArray()
         {
             var size = 10000;
@@ -461,7 +461,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(49995000L, (long)np.sum(result));
         }
 
-        [Test]
+        [TestMethod]
         public void Where_AllFalse_LargeArray()
         {
             var size = 10000;
@@ -473,7 +473,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(0L, (long)np.sum(result));
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Alternating_LargeArray()
         {
             var size = 10000;
@@ -493,7 +493,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Type Conversion Edge Cases
 
-        [Test]
+        [TestMethod]
         public void Where_UnsignedOverflow()
         {
             var cond = np.array(new[] { true, false });
@@ -506,7 +506,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual((byte)255, (byte)result[1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Decimal()
         {
             var cond = np.array(new[] { true, false });
@@ -519,7 +519,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(9.87654321m, (decimal)result[1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Char()
         {
             var cond = np.array(new[] { true, false, true });
@@ -537,7 +537,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region View Behavior
 
-        [Test]
+        [TestMethod]
         public void Where_ResultIsNewArray_NotView()
         {
             var cond = np.array(new[] { true, false });
@@ -553,7 +553,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(20, (int)result[1], "Result should be independent of y");
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ModifyResult_DoesNotAffectInputs()
         {
             var cond = np.array(new[] { true, false });
@@ -570,7 +570,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Alternating Patterns
 
-        [Test]
+        [TestMethod]
         public void Where_Checkerboard_Pattern()
         {
             // Create checkerboard condition
@@ -590,7 +590,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(1, (int)result[1, 1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_StripedPattern()
         {
             // Every row alternates between all True and all False
@@ -617,7 +617,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Empty Array Edge Cases
 
-        [Test]
+        [TestMethod]
         public void Where_Empty2D()
         {
             // Empty (0,3) shape
@@ -630,7 +630,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(typeof(double), result.dtype);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Empty3D()
         {
             // Empty (2,0,3) shape
@@ -643,7 +643,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(typeof(int), result.dtype);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_Empty2D()
         {
             var arr = np.zeros(new[] { 0, 3 }, NPTypeCode.Int32);
@@ -658,7 +658,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Error Conditions
 
-        [Test]
+        [TestMethod]
         public void Where_IncompatibleShapes_ThrowsException()
         {
             // Shapes (2,) and (3,) cannot be broadcast together
@@ -677,7 +677,7 @@ namespace NumSharp.UnitTest.Logic
         /// Verifies NEP50 weak scalar semantics: when a scalar is combined with an array,
         /// the array's dtype wins for same-kind operations.
         /// </summary>
-        [Test]
+        [TestMethod]
         public void Where_ScalarTypePromotion_NEP50_WeakScalar()
         {
             // NumPy 2.x: np.where(cond, 1, uint8_array) -> uint8 (weak scalar)
@@ -696,7 +696,7 @@ namespace NumSharp.UnitTest.Logic
         /// Note: NumPy would return int64 for Python int literals, but C# int32 scalars
         /// cannot be distinguished from explicit np.array(1, dtype=int32), so we preserve.
         /// </summary>
-        [Test]
+        [TestMethod]
         public void Where_TwoScalars_SameType_Preserved()
         {
             var cond = np.array(new[] { true, false });
@@ -715,7 +715,7 @@ namespace NumSharp.UnitTest.Logic
         /// <summary>
         /// Verifies C# float scalars stay float32 (like np.float32, not Python float).
         /// </summary>
-        [Test]
+        [TestMethod]
         public void Where_TwoScalars_Float32_StaysFloat32()
         {
             // C# float (1.0f) is like np.float32, not Python's float (which is float64)
@@ -729,7 +729,7 @@ namespace NumSharp.UnitTest.Logic
         /// <summary>
         /// Verifies NEP50: int scalar + float32 array -> float32 (same-kind, array wins).
         /// </summary>
-        [Test]
+        [TestMethod]
         public void Where_IntScalar_Float32Array_ReturnsFloat32()
         {
             var cond = np.array(new[] { true, false });
@@ -743,7 +743,7 @@ namespace NumSharp.UnitTest.Logic
         /// <summary>
         /// Verifies NEP50: float scalar + int32 array -> float64 (cross-kind promotion).
         /// </summary>
-        [Test]
+        [TestMethod]
         public void Where_FloatScalar_Int32Array_ReturnsFloat64()
         {
             var cond = np.array(new[] { true, false });

--- a/test/NumSharp.UnitTest/Logic/np.where.Test.cs
+++ b/test/NumSharp.UnitTest/Logic/np.where.Test.cs
@@ -308,6 +308,7 @@ namespace NumSharp.UnitTest.Logic
             var result = np.where(cond, 42, 0);
 
             Assert.AreEqual(1, result.size);
+            Assert.AreEqual(typeof(int), result.dtype);  // same-type scalars preserve type
             Assert.AreEqual(42, (int)result[0]);
         }
 

--- a/test/NumSharp.UnitTest/Logic/np.where.Test.cs
+++ b/test/NumSharp.UnitTest/Logic/np.where.Test.cs
@@ -1,0 +1,496 @@
+using System;
+using System.Linq;
+using TUnit.Core;
+using NumSharp.UnitTest.Utilities;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+namespace NumSharp.UnitTest.Logic
+{
+    /// <summary>
+    /// Comprehensive tests for np.where matching NumPy 2.x behavior.
+    ///
+    /// NumPy signature: where(condition, x=None, y=None, /)
+    /// - Single arg: returns np.nonzero(condition)
+    /// - Three args: element-wise selection with broadcasting
+    /// </summary>
+    public class np_where_Test
+    {
+        #region Single Argument (nonzero equivalent)
+
+        [Test]
+        public void Where_SingleArg_1D_ReturnsIndices()
+        {
+            // np.where([0, 1, 0, 2, 0, 3]) -> (array([1, 3, 5]),)
+            var arr = np.array(new[] { 0, 1, 0, 2, 0, 3 });
+            var result = np.where(arr);
+
+            Assert.AreEqual(1, result.Length);
+            result[0].Should().BeOfValues(1L, 3L, 5L);
+        }
+
+        [Test]
+        public void Where_SingleArg_2D_ReturnsTupleOfIndices()
+        {
+            // np.where([[0, 1, 0], [2, 0, 3]]) -> (array([0, 1, 1]), array([1, 0, 2]))
+            var arr = np.array(new int[,] { { 0, 1, 0 }, { 2, 0, 3 } });
+            var result = np.where(arr);
+
+            Assert.AreEqual(2, result.Length);
+            result[0].Should().BeOfValues(0L, 1L, 1L);  // row indices
+            result[1].Should().BeOfValues(1L, 0L, 2L);  // col indices
+        }
+
+        [Test]
+        public void Where_SingleArg_Boolean_ReturnsNonzero()
+        {
+            var arr = np.array(new[] { true, false, true, false, true });
+            var result = np.where(arr);
+
+            Assert.AreEqual(1, result.Length);
+            result[0].Should().BeOfValues(0L, 2L, 4L);
+        }
+
+        [Test]
+        public void Where_SingleArg_Empty_ReturnsEmptyIndices()
+        {
+            var arr = np.array(new int[0]);
+            var result = np.where(arr);
+
+            Assert.AreEqual(1, result.Length);
+            Assert.AreEqual(0, result[0].size);
+        }
+
+        [Test]
+        public void Where_SingleArg_AllFalse_ReturnsEmptyIndices()
+        {
+            var arr = np.array(new[] { false, false, false });
+            var result = np.where(arr);
+
+            Assert.AreEqual(1, result.Length);
+            Assert.AreEqual(0, result[0].size);
+        }
+
+        [Test]
+        public void Where_SingleArg_AllTrue_ReturnsAllIndices()
+        {
+            var arr = np.array(new[] { true, true, true });
+            var result = np.where(arr);
+
+            result[0].Should().BeOfValues(0L, 1L, 2L);
+        }
+
+        [Test]
+        public void Where_SingleArg_3D_ReturnsTupleOfThreeArrays()
+        {
+            // 2x2x2 array with some non-zero elements
+            var arr = np.zeros(new[] { 2, 2, 2 }, NPTypeCode.Int32);
+            arr[0, 0, 1] = 1;
+            arr[1, 1, 0] = 1;
+            var result = np.where(arr);
+
+            Assert.AreEqual(3, result.Length);
+            result[0].Should().BeOfValues(0L, 1L);  // dim 0
+            result[1].Should().BeOfValues(0L, 1L);  // dim 1
+            result[2].Should().BeOfValues(1L, 0L);  // dim 2
+        }
+
+        #endregion
+
+        #region Three Arguments (element-wise selection)
+
+        [Test]
+        public void Where_ThreeArgs_Basic_SelectsCorrectly()
+        {
+            // np.where(a < 5, a, 10*a) for a = arange(10)
+            var a = np.arange(10);
+            var result = np.where(a < 5, a, 10 * a);
+
+            result.Should().BeOfValues(0L, 1L, 2L, 3L, 4L, 50L, 60L, 70L, 80L, 90L);
+        }
+
+        [Test]
+        public void Where_ThreeArgs_BooleanCondition()
+        {
+            var cond = np.array(new[] { true, false, true, false });
+            var x = np.array(new[] { 1, 2, 3, 4 });
+            var y = np.array(new[] { 10, 20, 30, 40 });
+            var result = np.where(cond, x, y);
+
+            result.Should().BeOfValues(1, 20, 3, 40);
+        }
+
+        [Test]
+        public void Where_ThreeArgs_2D()
+        {
+            // np.where([[True, False], [True, True]], [[1, 2], [3, 4]], [[9, 8], [7, 6]])
+            var cond = np.array(new bool[,] { { true, false }, { true, true } });
+            var x = np.array(new int[,] { { 1, 2 }, { 3, 4 } });
+            var y = np.array(new int[,] { { 9, 8 }, { 7, 6 } });
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(2, 2);
+            Assert.AreEqual(1, (int)result[0, 0]);
+            Assert.AreEqual(8, (int)result[0, 1]);
+            Assert.AreEqual(3, (int)result[1, 0]);
+            Assert.AreEqual(4, (int)result[1, 1]);
+        }
+
+        [Test]
+        public void Where_ThreeArgs_NonBoolCondition_TreatsAsTruthy()
+        {
+            // np.where([0, 1, 2, 0], 100, -100) -> [-100, 100, 100, -100]
+            var cond = np.array(new[] { 0, 1, 2, 0 });
+            var result = np.where(cond, 100, -100);
+
+            result.Should().BeOfValues(-100, 100, 100, -100);
+        }
+
+        #endregion
+
+        #region Scalar Arguments
+
+        [Test]
+        public void Where_ScalarX()
+        {
+            var cond = np.array(new[] { true, false, true, false });
+            var y = np.array(new[] { 10, 20, 30, 40 });
+            var result = np.where(cond, 99, y);
+
+            result.Should().BeOfValues(99, 20, 99, 40);
+        }
+
+        [Test]
+        public void Where_ScalarY()
+        {
+            var cond = np.array(new[] { true, false, true, false });
+            var x = np.array(new[] { 1, 2, 3, 4 });
+            var result = np.where(cond, x, -1);
+
+            result.Should().BeOfValues(1, -1, 3, -1);
+        }
+
+        [Test]
+        public void Where_BothScalars()
+        {
+            var cond = np.array(new[] { true, false, true, false });
+            var result = np.where(cond, 1, 0);
+
+            result.Should().BeOfValues(1, 0, 1, 0);
+        }
+
+        [Test]
+        public void Where_ScalarFloat()
+        {
+            var cond = np.array(new[] { true, false });
+            var result = np.where(cond, 1.5, 2.5);
+
+            Assert.AreEqual(typeof(double), result.dtype);
+            Assert.AreEqual(1.5, (double)result[0], 1e-10);
+            Assert.AreEqual(2.5, (double)result[1], 1e-10);
+        }
+
+        #endregion
+
+        #region Broadcasting
+
+        [Test]
+        public void Where_Broadcasting_ScalarY()
+        {
+            // np.where(a < 4, a, -1) for 3x3 array
+            var arr = np.array(new int[,] { { 0, 1, 2 }, { 0, 2, 4 }, { 0, 3, 6 } });
+            var result = np.where(arr < 4, arr, -1);
+
+            result.Should().BeShaped(3, 3);
+            Assert.AreEqual(0, (int)result[0, 0]);
+            Assert.AreEqual(1, (int)result[0, 1]);
+            Assert.AreEqual(2, (int)result[0, 2]);
+            Assert.AreEqual(-1, (int)result[1, 2]);
+            Assert.AreEqual(-1, (int)result[2, 2]);
+        }
+
+        [Test]
+        public void Where_Broadcasting_DifferentShapes()
+        {
+            // cond: (2,1), x: (3,), y: (1,3) -> result: (2,3)
+            var cond = np.array(new bool[,] { { true }, { false } });
+            var x = np.array(new[] { 1, 2, 3 });
+            var y = np.array(new int[,] { { 10, 20, 30 } });
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(2, 3);
+            // Row 0: cond=True, so x values
+            Assert.AreEqual(1, (int)result[0, 0]);
+            Assert.AreEqual(2, (int)result[0, 1]);
+            Assert.AreEqual(3, (int)result[0, 2]);
+            // Row 1: cond=False, so y values
+            Assert.AreEqual(10, (int)result[1, 0]);
+            Assert.AreEqual(20, (int)result[1, 1]);
+            Assert.AreEqual(30, (int)result[1, 2]);
+        }
+
+        [Test]
+        public void Where_Broadcasting_ColumnVector()
+        {
+            // cond: (3,1), x: scalar, y: (1,4) -> result: (3,4)
+            var cond = np.array(new bool[,] { { true }, { false }, { true } });
+            var x = 1;
+            var y = np.array(new int[,] { { 10, 20, 30, 40 } });
+            var result = np.where(cond, x, y);
+
+            result.Should().BeShaped(3, 4);
+            // Row 0: all 1s
+            for (int j = 0; j < 4; j++)
+                Assert.AreEqual(1, (int)result[0, j]);
+            // Row 1: y values
+            Assert.AreEqual(10, (int)result[1, 0]);
+            Assert.AreEqual(40, (int)result[1, 3]);
+            // Row 2: all 1s
+            for (int j = 0; j < 4; j++)
+                Assert.AreEqual(1, (int)result[2, j]);
+        }
+
+        #endregion
+
+        #region Type Promotion
+
+        [Test]
+        public void Where_TypePromotion_IntFloat_ReturnsFloat64()
+        {
+            var cond = np.array(new[] { true, false });
+            var result = np.where(cond, 1, 2.5);
+
+            Assert.AreEqual(typeof(double), result.dtype);
+            Assert.AreEqual(1.0, (double)result[0], 1e-10);
+            Assert.AreEqual(2.5, (double)result[1], 1e-10);
+        }
+
+        [Test]
+        public void Where_TypePromotion_Int32Int64_ReturnsInt64()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new int[] { 1 });
+            var y = np.array(new long[] { 2 });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(long), result.dtype);
+        }
+
+        [Test]
+        public void Where_TypePromotion_FloatDouble_ReturnsDouble()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new float[] { 1.5f });
+            var y = np.array(new double[] { 2.5 });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(double), result.dtype);
+        }
+
+        #endregion
+
+        #region Edge Cases
+
+        [Test]
+        public void Where_EmptyArrays_ThreeArgs()
+        {
+            var cond = np.array(new bool[0]);
+            var x = np.array(new int[0]);
+            var y = np.array(new int[0]);
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(0, result.size);
+        }
+
+        [Test]
+        public void Where_SingleElement()
+        {
+            var cond = np.array(new[] { true });
+            var result = np.where(cond, 42, 0);
+
+            Assert.AreEqual(1, result.size);
+            Assert.AreEqual(42, (int)result[0]);
+        }
+
+        [Test]
+        public void Where_AllTrue_ReturnsAllX()
+        {
+            var cond = np.array(new[] { true, true, true });
+            var x = np.array(new[] { 1, 2, 3 });
+            var y = np.array(new[] { 10, 20, 30 });
+            var result = np.where(cond, x, y);
+
+            result.Should().BeOfValues(1, 2, 3);
+        }
+
+        [Test]
+        public void Where_AllFalse_ReturnsAllY()
+        {
+            var cond = np.array(new[] { false, false, false });
+            var x = np.array(new[] { 1, 2, 3 });
+            var y = np.array(new[] { 10, 20, 30 });
+            var result = np.where(cond, x, y);
+
+            result.Should().BeOfValues(10, 20, 30);
+        }
+
+        [Test]
+        public void Where_LargeArray()
+        {
+            var size = 100000;
+            var cond = np.arange(size) % 2 == 0;  // alternating True/False
+            var x = np.ones(size, NPTypeCode.Int32);
+            var y = np.zeros(size, NPTypeCode.Int32);
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(size, result.size);
+            // Even indices should be 1, odd should be 0
+            Assert.AreEqual(1, (int)result[0]);
+            Assert.AreEqual(0, (int)result[1]);
+            Assert.AreEqual(1, (int)result[2]);
+        }
+
+        #endregion
+
+        #region NumPy Output Verification
+
+        [Test]
+        public void Where_NumPyExample1()
+        {
+            // From NumPy docs: np.where([[True, False], [True, True]],
+            //                          [[1, 2], [3, 4]], [[9, 8], [7, 6]])
+            // Expected: array([[1, 8], [3, 4]])
+            var cond = np.array(new bool[,] { { true, false }, { true, true } });
+            var x = np.array(new int[,] { { 1, 2 }, { 3, 4 } });
+            var y = np.array(new int[,] { { 9, 8 }, { 7, 6 } });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(1, (int)result[0, 0]);
+            Assert.AreEqual(8, (int)result[0, 1]);
+            Assert.AreEqual(3, (int)result[1, 0]);
+            Assert.AreEqual(4, (int)result[1, 1]);
+        }
+
+        [Test]
+        public void Where_NumPyExample2()
+        {
+            // From NumPy docs: np.where(a < 5, a, 10*a) for a = arange(10)
+            // Expected: array([ 0,  1,  2,  3,  4, 50, 60, 70, 80, 90])
+            var a = np.arange(10);
+            var result = np.where(a < 5, a, 10 * a);
+
+            result.Should().BeOfValues(0L, 1L, 2L, 3L, 4L, 50L, 60L, 70L, 80L, 90L);
+        }
+
+        [Test]
+        public void Where_NumPyExample3()
+        {
+            // From NumPy docs: np.where(a < 4, a, -1) for specific array
+            // Expected: array([[ 0,  1,  2], [ 0,  2, -1], [ 0,  3, -1]])
+            var a = np.array(new int[,] { { 0, 1, 2 }, { 0, 2, 4 }, { 0, 3, 6 } });
+            var result = np.where(a < 4, a, -1);
+
+            Assert.AreEqual(0, (int)result[0, 0]);
+            Assert.AreEqual(1, (int)result[0, 1]);
+            Assert.AreEqual(2, (int)result[0, 2]);
+            Assert.AreEqual(0, (int)result[1, 0]);
+            Assert.AreEqual(2, (int)result[1, 1]);
+            Assert.AreEqual(-1, (int)result[1, 2]);
+            Assert.AreEqual(0, (int)result[2, 0]);
+            Assert.AreEqual(3, (int)result[2, 1]);
+            Assert.AreEqual(-1, (int)result[2, 2]);
+        }
+
+        #endregion
+
+        #region Dtype Coverage
+
+        [Test]
+        public void Where_Dtype_Byte()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new byte[] { 1, 2 });
+            var y = np.array(new byte[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(byte), result.dtype);
+            result.Should().BeOfValues((byte)1, (byte)20);
+        }
+
+        [Test]
+        public void Where_Dtype_Int16()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new short[] { 1, 2 });
+            var y = np.array(new short[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(short), result.dtype);
+            result.Should().BeOfValues((short)1, (short)20);
+        }
+
+        [Test]
+        public void Where_Dtype_Int32()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new int[] { 1, 2 });
+            var y = np.array(new int[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(int), result.dtype);
+            result.Should().BeOfValues(1, 20);
+        }
+
+        [Test]
+        public void Where_Dtype_Int64()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new long[] { 1, 2 });
+            var y = np.array(new long[] { 10, 20 });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(long), result.dtype);
+            result.Should().BeOfValues(1L, 20L);
+        }
+
+        [Test]
+        public void Where_Dtype_Single()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new float[] { 1.5f, 2.5f });
+            var y = np.array(new float[] { 10.5f, 20.5f });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(float), result.dtype);
+            Assert.AreEqual(1.5f, (float)result[0], 1e-6f);
+            Assert.AreEqual(20.5f, (float)result[1], 1e-6f);
+        }
+
+        [Test]
+        public void Where_Dtype_Double()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new double[] { 1.5, 2.5 });
+            var y = np.array(new double[] { 10.5, 20.5 });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(double), result.dtype);
+            Assert.AreEqual(1.5, (double)result[0], 1e-10);
+            Assert.AreEqual(20.5, (double)result[1], 1e-10);
+        }
+
+        [Test]
+        public void Where_Dtype_Boolean()
+        {
+            var cond = np.array(new[] { true, false });
+            var x = np.array(new bool[] { true, true });
+            var y = np.array(new bool[] { false, false });
+            var result = np.where(cond, x, y);
+
+            Assert.AreEqual(typeof(bool), result.dtype);
+            Assert.IsTrue((bool)result[0]);
+            Assert.IsFalse((bool)result[1]);
+        }
+
+        #endregion
+    }
+}

--- a/test/NumSharp.UnitTest/Logic/np.where.Test.cs
+++ b/test/NumSharp.UnitTest/Logic/np.where.Test.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using TUnit.Core;
 using NumSharp.UnitTest.Utilities;
 using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
@@ -13,11 +12,12 @@ namespace NumSharp.UnitTest.Logic
     /// - Single arg: returns np.nonzero(condition)
     /// - Three args: element-wise selection with broadcasting
     /// </summary>
+    [TestClass]
     public class np_where_Test
     {
         #region Single Argument (nonzero equivalent)
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_1D_ReturnsIndices()
         {
             // np.where([0, 1, 0, 2, 0, 3]) -> (array([1, 3, 5]),)
@@ -28,7 +28,7 @@ namespace NumSharp.UnitTest.Logic
             result[0].Should().BeOfValues(1L, 3L, 5L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_2D_ReturnsTupleOfIndices()
         {
             // np.where([[0, 1, 0], [2, 0, 3]]) -> (array([0, 1, 1]), array([1, 0, 2]))
@@ -40,7 +40,7 @@ namespace NumSharp.UnitTest.Logic
             result[1].Should().BeOfValues(1L, 0L, 2L);  // col indices
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_Boolean_ReturnsNonzero()
         {
             var arr = np.array(new[] { true, false, true, false, true });
@@ -50,7 +50,7 @@ namespace NumSharp.UnitTest.Logic
             result[0].Should().BeOfValues(0L, 2L, 4L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_Empty_ReturnsEmptyIndices()
         {
             var arr = np.array(new int[0]);
@@ -60,7 +60,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(0, result[0].size);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_AllFalse_ReturnsEmptyIndices()
         {
             var arr = np.array(new[] { false, false, false });
@@ -70,7 +70,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(0, result[0].size);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_AllTrue_ReturnsAllIndices()
         {
             var arr = np.array(new[] { true, true, true });
@@ -79,7 +79,7 @@ namespace NumSharp.UnitTest.Logic
             result[0].Should().BeOfValues(0L, 1L, 2L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleArg_3D_ReturnsTupleOfThreeArrays()
         {
             // 2x2x2 array with some non-zero elements
@@ -98,7 +98,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Three Arguments (element-wise selection)
 
-        [Test]
+        [TestMethod]
         public void Where_ThreeArgs_Basic_SelectsCorrectly()
         {
             // np.where(a < 5, a, 10*a) for a = arange(10)
@@ -108,7 +108,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(0L, 1L, 2L, 3L, 4L, 50L, 60L, 70L, 80L, 90L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ThreeArgs_BooleanCondition()
         {
             var cond = np.array(new[] { true, false, true, false });
@@ -119,7 +119,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(1, 20, 3, 40);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ThreeArgs_2D()
         {
             // np.where([[True, False], [True, True]], [[1, 2], [3, 4]], [[9, 8], [7, 6]])
@@ -135,7 +135,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(4, (int)result[1, 1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ThreeArgs_NonBoolCondition_TreatsAsTruthy()
         {
             // np.where([0, 1, 2, 0], 100, -100) -> [-100, 100, 100, -100]
@@ -149,7 +149,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Scalar Arguments
 
-        [Test]
+        [TestMethod]
         public void Where_ScalarX()
         {
             var cond = np.array(new[] { true, false, true, false });
@@ -159,7 +159,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(99, 20, 99, 40);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ScalarY()
         {
             var cond = np.array(new[] { true, false, true, false });
@@ -169,7 +169,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(1, -1, 3, -1);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_BothScalars()
         {
             var cond = np.array(new[] { true, false, true, false });
@@ -178,7 +178,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(1, 0, 1, 0);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_ScalarFloat()
         {
             var cond = np.array(new[] { true, false });
@@ -193,7 +193,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Broadcasting
 
-        [Test]
+        [TestMethod]
         public void Where_Broadcasting_ScalarY()
         {
             // np.where(a < 4, a, -1) for 3x3 array
@@ -208,7 +208,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(-1, (int)result[2, 2]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Broadcasting_DifferentShapes()
         {
             // cond: (2,1), x: (3,), y: (1,3) -> result: (2,3)
@@ -228,7 +228,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(30, (int)result[1, 2]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Broadcasting_ColumnVector()
         {
             // cond: (3,1), x: scalar, y: (1,4) -> result: (3,4)
@@ -253,7 +253,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Type Promotion
 
-        [Test]
+        [TestMethod]
         public void Where_TypePromotion_IntFloat_ReturnsFloat64()
         {
             var cond = np.array(new[] { true, false });
@@ -264,7 +264,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(2.5, (double)result[1], 1e-10);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_TypePromotion_Int32Int64_ReturnsInt64()
         {
             var cond = np.array(new[] { true, false });
@@ -275,7 +275,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(typeof(long), result.dtype);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_TypePromotion_FloatDouble_ReturnsDouble()
         {
             var cond = np.array(new[] { true, false });
@@ -290,7 +290,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Edge Cases
 
-        [Test]
+        [TestMethod]
         public void Where_EmptyArrays_ThreeArgs()
         {
             var cond = np.array(new bool[0]);
@@ -301,7 +301,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(0, result.size);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_SingleElement()
         {
             var cond = np.array(new[] { true });
@@ -312,7 +312,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(42, (int)result[0]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_AllTrue_ReturnsAllX()
         {
             var cond = np.array(new[] { true, true, true });
@@ -323,7 +323,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(1, 2, 3);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_AllFalse_ReturnsAllY()
         {
             var cond = np.array(new[] { false, false, false });
@@ -334,7 +334,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(10, 20, 30);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_LargeArray()
         {
             var size = 100000;
@@ -354,7 +354,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region NumPy Output Verification
 
-        [Test]
+        [TestMethod]
         public void Where_NumPyExample1()
         {
             // From NumPy docs: np.where([[True, False], [True, True]],
@@ -371,7 +371,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(4, (int)result[1, 1]);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_NumPyExample2()
         {
             // From NumPy docs: np.where(a < 5, a, 10*a) for a = arange(10)
@@ -382,7 +382,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(0L, 1L, 2L, 3L, 4L, 50L, 60L, 70L, 80L, 90L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_NumPyExample3()
         {
             // From NumPy docs: np.where(a < 4, a, -1) for specific array
@@ -405,7 +405,7 @@ namespace NumSharp.UnitTest.Logic
 
         #region Dtype Coverage
 
-        [Test]
+        [TestMethod]
         public void Where_Dtype_Byte()
         {
             var cond = np.array(new[] { true, false });
@@ -417,7 +417,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues((byte)1, (byte)20);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Dtype_Int16()
         {
             var cond = np.array(new[] { true, false });
@@ -429,7 +429,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues((short)1, (short)20);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Dtype_Int32()
         {
             var cond = np.array(new[] { true, false });
@@ -441,7 +441,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(1, 20);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Dtype_Int64()
         {
             var cond = np.array(new[] { true, false });
@@ -453,7 +453,7 @@ namespace NumSharp.UnitTest.Logic
             result.Should().BeOfValues(1L, 20L);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Dtype_Single()
         {
             var cond = np.array(new[] { true, false });
@@ -466,7 +466,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(20.5f, (float)result[1], 1e-6f);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Dtype_Double()
         {
             var cond = np.array(new[] { true, false });
@@ -479,7 +479,7 @@ namespace NumSharp.UnitTest.Logic
             Assert.AreEqual(20.5, (double)result[1], 1e-10);
         }
 
-        [Test]
+        [TestMethod]
         public void Where_Dtype_Boolean()
         {
             var cond = np.array(new[] { true, false });


### PR DESCRIPTION
## Summary

- Add IL-generated SIMD optimization for `np.where(condition, x, y)`
- Uses `DynamicMethod` to generate type-specific kernels at runtime
- Vector256/Vector128.ConditionalSelect for SIMD element selection
- 4x loop unrolling for instruction-level parallelism
- Native long indexing for large arrays
- Supports all 12 dtypes (11 via SIMD, Decimal via scalar fallback)

## Implementation

| Component | Description |
|-----------|-------------|
| `WhereKernel<T>` | Delegate type for IL-generated kernels |
| `GetWhereKernel<T>()` | Get/generate cached kernel |
| `WhereExecute<T>()` | Main entry with automatic fallback |
| Mask creation | Grouped by element size (1/2/4/8 bytes) |

## Eligibility for SIMD Path

```csharp
bool canUseKernel = ILKernelGenerator.Enabled &&
                    cond.typecode == NPTypeCode.Boolean &&
                    cond.Shape.IsContiguous &&
                    xArr.Shape.IsContiguous &&
                    yArr.Shape.IsContiguous;
```

Falls back to iterator path for:
- Non-contiguous/broadcasted arrays
- Non-bool conditions (need truthiness conversion)

## Test Plan

- [x] 26 new WhereSimdTests for SIMD correctness
- [x] 36 existing np_where_Test pass
- [x] 21 battle tests pass
- [x] All 12 dtypes covered

Closes #604